### PR TITLE
Latest schema v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ All the instance methods below are bound to the instance, so they can be used wi
 
 Generate validating function and cache the compiled schema for future use.
 
-Validating function returns boolean and has properties `errors` with the errors from the last validation (`null` if there were no errors) and `schema` with the reference to the original schema. 
+Validating function returns boolean and has properties `errors` with the errors from the last validation (`null` if there were no errors) and `schema` with the reference to the original schema.
 
 Unless the option `validateSchema` is false, the schema will be validated against meta-schema and if schema is invalid the error will be thrown. See [options](#options).
 
@@ -169,7 +169,7 @@ By default the schema is validated against meta-schema before it is added, and i
 
 Adds meta schema that can be used to validate other schemas. That function should be used instead of `addSchema` because there may be instance options that would compile a meta schema incorrectly (at the moment it is `removeAdditional` option).
 
-There is no need to explicitely add draft 4 meta schema (http://json-schema.org/draft-04/schema) - it is added by default, unless option `meta` is set to `false`. You only need to use it if you have a changed meta-schema that you want to use to validate your schemas. See `validateSchema`.
+There is no need to explicitly add draft 4 meta schema (http://json-schema.org/draft-04/schema) - it is added by default, unless option `meta` is set to `false`. You only need to use it if you have a changed meta-schema that you want to use to validate your schemas. See `validateSchema`.
 
 
 ##### .validateSchema(Object schema) -&gt; Boolean
@@ -229,7 +229,7 @@ Options can have properties `separator` (string used to separate errors, ", " by
 - _uniqueItems_: validate `uniqueItems` keyword (true by default).
 - _unicode_: calculate correct length of strings with unicode pairs (true by default). Pass `false` to use `.length` of strings that is faster, but gives "incorrect" lengths of strings with unicode pairs - each unicode pair is counted as two characters.
 - _beautify_: format the generated function with [js-beautify](https://github.com/beautify-web/js-beautify) (the validating function is generated without line-breaks). `npm install js-beautify` to use this option. `true` or js-beautify options can be passed.
-- _cache_: an optional instance of cache to store compiled schemas using stable-stringified schema as a key. For example, set-associative cache [sacjs](https://github.com/epoberezkin/sacjs) can be used. If not passed then a simple hash is used which is good enough for the common use case (a limited number of statically defined schemas). Cache should have methods `put(key, value)`, `get(key)` and `del(key)`. 
+- _cache_: an optional instance of cache to store compiled schemas using stable-stringified schema as a key. For example, set-associative cache [sacjs](https://github.com/epoberezkin/sacjs) can be used. If not passed then a simple hash is used which is good enough for the common use case (a limited number of statically defined schemas). Cache should have methods `put(key, value)`, `get(key)` and `del(key)`.
 
 
 ## Tests

--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -259,8 +259,17 @@ function Ajv(opts) {
 
 
     function addInitialSchemas() {
-        if (self.opts.meta !== false)
-            addMetaSchema(require('./refs/json-schema-draft-04.json'), META_SCHEMA_ID, true);
+        if (self.opts.meta !== false) {
+            var metaSchema = require('./refs/json-schema-draft-04.json');
+
+            addMetaSchema(metaSchema, META_SCHEMA_ID, true);
+
+            // Add other schemas according to JSON specification:
+            // http://json-schema.org/latest/json-schema-core.html
+            addMetaSchema(metaSchema, 'http://json-schema.org/schema', true);
+            addMetaSchema(metaSchema, 'http://json-schema.org/hyper-schema', true);
+            addMetaSchema(metaSchema, 'http://json-schema.org/draft-04/hyper-schema', true);
+        }
 
         var optsSchemas = self.opts.schemas;
         if (!optsSchemas) return;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test-spec": "mocha spec/*.spec.js -R spec",
     "test-cov": "istanbul cover -x '**/spec/**' node_modules/mocha/bin/_mocha -- spec/*.spec.js -R spec",
-    "test": "npm run test-cov"
+    "build": "node bin/compile-dots.js",
+    "test": "npm run build && npm run test-cov",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/spec/tests/issues/33_json_schema_latest.json
+++ b/spec/tests/issues/33_json_schema_latest.json
@@ -1,0 +1,21 @@
+[
+  {
+    "description": "use latest json schema as v4 (#33)",
+    "schema": {
+      "$schema": "http://json-schema.org/schema",
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "empty object",
+        "data": {},
+        "valid": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Some unrelated things in the PR, but all separate commits so you can cherry pick if needed.

Summary: The specification lists four different URLs that should be validated against the latest v4 specification, as of today. I've added the other three for compatibility with current JSON schemas out there.
