### PR TITLE
Add a files array to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.1.0",
   "description": "Another JSON Schema Validator",
   "main": "lib/ajv.js",
+  "files": [
+    "lib/",
+    "LICENSE"
+  ],
   "scripts": {
     "test-spec": "mocha spec/*.spec.js -R spec",
     "test-cov": "istanbul cover -x '**/spec/**' node_modules/mocha/bin/_mocha -- spec/*.spec.js -R spec",


### PR DESCRIPTION
Ensures that only and all of the `lib/` directory will be in the release.

Edit: This also makes sure NPM installs are small, as no tests or scripts will be bundled either. Just `lib/`, `LICENSE`, `README.md` and `package.json`.
