### PR TITLE
Add run time lookup of schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ Although `addSchema` does not compile schemas, explicit compilation is not requi
 
 By default the schema is validated against meta-schema before it is added, and if the schema does not pass validation the exception is thrown. This behaviour is controlled by `validateSchema` option.
 
+##### .registerSchemaLookup(Function lookup)
+
+Register a synchronous `lookup` function that takes the desired reference (id) and returns the matching schema at runtime. This is useful when one has a large number of schemas and loading them at once results in too large of an overhead.
+
+The `lookup` function should return either:
+
+- the schema in a format accepted by .addSchema()
+- a falsey value indicating the schema was not found
+
+If more than one `lookup` function is registered, each will called in the order they where registered until one returns a schema.
+
 
 ##### .addMetaSchema(Object schema [, String key])
 

--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -30,12 +30,14 @@ function Ajv(opts) {
     this._refs = {};
     this._formats = formats(this.opts.format);
     this._cache = this.opts.cache || new Cache;
+    this._lookups = [];
 
     // this is done on purpose, so that methods are bound to the instance
     // (without using bind) so that they can be used without the instance
     this.validate = validate;
     this.compile = compile;
     this.addSchema = addSchema;
+    this.registerSchemaLookup = registerSchemaLookup;
     this.addMetaSchema = addMetaSchema;
     this.validateSchema = validateSchema;
     this.getSchema = getSchema;
@@ -100,6 +102,15 @@ function Ajv(opts) {
         schemaObj.meta = _meta;
     }
 
+    /**
+     * Registers a function that can be used to add a schema on demand
+     * @param {Function} lookup A function that translates a `key` to a schema on demand
+     */
+    function registerSchemaLookup(lookup) {
+        if (typeof lookup !== 'function') throw new Error('lookup should be a function');
+
+        self._lookups.push(lookup);
+    }
 
     /**
      * Add schema that will be used to validate other schemas
@@ -137,6 +148,16 @@ function Ajv(opts) {
     function getSchema(keyRef) {
         var schemaObj = _getSchemaObj(keyRef);
         switch (typeof schemaObj) {
+            case 'undefined':
+                for(var i = 0; i < self._lookups.length; i++) {
+                    var schema = self._lookups[i](keyRef);
+
+                    if(schema) {
+                        addSchema(schema);
+                        return getSchema(keyRef);
+                    }
+                }
+            break;
             case 'object': return schemaObj.validate || _compile(schemaObj);
             case 'string': return getSchema(schemaObj);
         }

--- a/lib/dotjs/ref.js
+++ b/lib/dotjs/ref.js
@@ -1,5 +1,7 @@
 'use strict';
-module.exports = function anonymous(it) {
+module.exports = function anonymous(it
+  /**/
+) {
   var out = ' ';
   var $lvl = it.level,
     $dataLvl = it.dataLevel,

--- a/lib/dotjs/validate.js
+++ b/lib/dotjs/validate.js
@@ -1,5 +1,7 @@
 'use strict';
-module.exports = function anonymous(it) {
+module.exports = function anonymous(it
+  /**/
+) {
   var out = '';
   if (it.isTop) {
     var $top = it.isTop,


### PR DESCRIPTION
Adds the ability to register functions that resolve a schema, on-the-fly, when a reference is not found.

In my particular use case, there are a large number of available schemas but only a small subset is needed for any one instantiation of the application.

It certainly makes sense to allow asynchronous lookups depending on the outcome of #40. One obvious use case is downloading a remote schema definition.
