### PR TITLE
Equal fail when order of keys is different

### DIFF
--- a/lib/compile/equal.js
+++ b/lib/compile/equal.js
@@ -17,8 +17,17 @@ module.exports = function equal(a, b) {
   if (arrA != arrB) return false;
 
   if (a && b && typeof a === 'object' && typeof b === 'object') {
+    var keysSet = {};
     var keys = Object.keys(a);
-    if (!equal(keys, Object.keys(b))) return false;
+    var keys2 = Object.keys(b);
+    if (keys.length !== keys2.length) return false;
+    for (i = 0; i < keys.length; i++) {
+      keysSet[keys[i]] = 1;
+    }
+    for (i = 0; i < keys2.length; i++) {
+      keysSet[keys2[i]] = 1;
+    }
+    keys = Object.keys(keysSet);
     for (i = 0; i < keys.length; i++)
       if (!equal(a[keys[i]], b[keys[i]])) return false;
     return true;

--- a/lib/compile/equal.js
+++ b/lib/compile/equal.js
@@ -17,17 +17,18 @@ module.exports = function equal(a, b) {
   if (arrA != arrB) return false;
 
   if (a && b && typeof a === 'object' && typeof b === 'object') {
-    var keysSet = {};
     var keys = Object.keys(a);
-    var keys2 = Object.keys(b);
-    if (keys.length !== keys2.length) return false;
+
+    if (keys.length !== Object.keys(b).length) {
+      return false;
+    }
+
     for (i = 0; i < keys.length; i++) {
-      keysSet[keys[i]] = 1;
+      if (!Object.prototype.hasOwnProperty.call(b, keys[i])) {
+        return false;
+      }
     }
-    for (i = 0; i < keys2.length; i++) {
-      keysSet[keys2[i]] = 1;
-    }
-    keys = Object.keys(keysSet);
+
     for (i = 0; i < keys.length; i++)
       if (!equal(a[keys[i]], b[keys[i]])) return false;
     return true;

--- a/spec/equal.spec.js
+++ b/spec/equal.spec.js
@@ -24,9 +24,11 @@ describe('equal', function() {
 
 
   it('should compare objects', function() {
-    equal({a: 1, b: '2'}, {b: '2', a: 1}) .should.equal(true)
-    equal({a: 1, b: '2'}, {b: '2', a: 1, c: []}) .should.equal(false)
-    equal({a: 1, b: '2'}, {a: 1, b: '2'}) .should.equal(true)
+    equal({a: 1, b: '2'}, {b: '2', a: 1}) .should.equal(true);
+    equal({a: 1, b: '2'}, {b: '2', a: 1, c: []}) .should.equal(false);
+    equal({a: 1, b: '2', c: 3}, {b: '2', a: 1, d: 3}) .should.equal(false);
+    equal({b: '2', a: 1, d: 3}, {a: 1, b: '2', c: 3}) .should.equal(false);
+    equal({a: 1, b: '2'}, {a: 1, b: '2'}) .should.equal(true);
     equal({ a: [ { b: 'c' } ] }, { a: [ { b: 'c' } ] }) .should.equal(true);
     equal({ a: [ { b: 'c' } ] }, { a: [ { b: 'd' } ] }) .should.equal(false);
     equal({ a: [ { b: 'c' } ] }, { a: [ { c: 'c' } ] }) .should.equal(false);

--- a/spec/equal.spec.js
+++ b/spec/equal.spec.js
@@ -24,6 +24,9 @@ describe('equal', function() {
 
 
   it('should compare objects', function() {
+    equal({a: 1, b: '2'}, {b: '2', a: 1}) .should.equal(true)
+    equal({a: 1, b: '2'}, {b: '2', a: 1, c: []}) .should.equal(false)
+    equal({a: 1, b: '2'}, {a: 1, b: '2'}) .should.equal(true)
     equal({ a: [ { b: 'c' } ] }, { a: [ { b: 'c' } ] }) .should.equal(true);
     equal({ a: [ { b: 'c' } ] }, { a: [ { b: 'd' } ] }) .should.equal(false);
     equal({ a: [ { b: 'c' } ] }, { a: [ { c: 'c' } ] }) .should.equal(false);


### PR DESCRIPTION
In section [3.6](http://json-schema.org/latest/json-schema-core.html#anchor9) equality of objects are defined as they are have the same set of property names, but not same order.
The equal function and it's test will fail if order of keys are different, but javascript [does not](http://stackoverflow.com/a/5525820) guarantee order of keys in object.

So i fixed this.
