### PR TITLE
remove redundant property in required error message

### DIFF
--- a/lib/dot/definitions.def
+++ b/lib/dot/definitions.def
@@ -150,7 +150,7 @@
   not:             "'should NOT be valid'",
   oneOf:           "'should match exactly one schema in oneOf'",
   pattern:         "'should match pattern \"{{=it.util.escapeQuotes($schema)}}\"'",
-  required:        "'should have required property {{=$missingProperty}}'",
+  required:        "'is a required property'",
   type:            "'should be {{? $isArray }}{{= $typeSchema.join(\",\") }}{{??}}{{=$typeSchema}}{{?}}'",
   uniqueItems:     "'should NOT have duplicate items (items ## ' + j + ' and ' + i + ' are identical)'"
 } #}}

--- a/lib/dot/required.jst
+++ b/lib/dot/required.jst
@@ -31,7 +31,7 @@
           , $missingProperty = '\' + ' + $propertyPath + ' + \'';
         it.errorPath = it.opts.jsonPointers
                         ? it.util.getPathExpr($currentErrorPath,  $propertyPath, true)
-                        : $currentErrorPath;
+                        : $currentErrorPath + ' + ' + $propertyPath;
       }}
       {{# def.error:'required' }}
     } else {

--- a/lib/dot/required.jst
+++ b/lib/dot/required.jst
@@ -31,7 +31,7 @@
           , $missingProperty = '\' + ' + $propertyPath + ' + \'';
         it.errorPath = it.opts.jsonPointers
                         ? it.util.getPathExpr($currentErrorPath,  $propertyPath, true)
-                        : $currentErrorPath + ' + ' + $propertyPath;
+                        : $currentErrorPath;
       }}
       {{# def.error:'required' }}
     } else {

--- a/spec/errors.spec.js
+++ b/spec/errors.spec.js
@@ -83,24 +83,24 @@ describe('Validation errors', function () {
     var validate = ajv.compile(schema);
     shouldBeValid(validate, data);
     shouldBeInvalid(validate, invalidData1);
-    shouldBeError(validate.errors[0], 'required', '.bar', 'should have required property .bar');
+    shouldBeError(validate.errors[0], 'required', '.bar', 'is a required property');
     shouldBeInvalid(validate, invalidData2);
-    shouldBeError(validate.errors[0], 'required', '.foo', 'should have required property .foo');
+    shouldBeError(validate.errors[0], 'required', '.foo', 'is a required property');
 
     var validateJP = ajvJP.compile(schema);
     shouldBeValid(validateJP, data);
     shouldBeInvalid(validateJP, invalidData1);
-    shouldBeError(validateJP.errors[0], 'required', '/bar', 'should have required property bar');
+    shouldBeError(validateJP.errors[0], 'required', '/bar', 'is a required property');
     shouldBeInvalid(validateJP, invalidData2);
-    shouldBeError(validateJP.errors[0], 'required', '/foo', 'should have required property foo');
+    shouldBeError(validateJP.errors[0], 'required', '/foo', 'is a required property');
 
     var fullValidate = fullAjv.compile(schema);
     shouldBeValid(fullValidate, data);
     shouldBeInvalid(fullValidate, invalidData1);
-    shouldBeError(fullValidate.errors[0], 'required', '/bar', 'should have required property .bar');
+    shouldBeError(fullValidate.errors[0], 'required', '/bar', 'is a required property');
     shouldBeInvalid(fullValidate, invalidData2, 2);
-    shouldBeError(fullValidate.errors[0], 'required', '/foo', 'should have required property .foo');
-    shouldBeError(fullValidate.errors[1], 'required', '/baz', 'should have required property .baz');
+    shouldBeError(fullValidate.errors[0], 'required', '/foo', 'is a required property');
+    shouldBeError(fullValidate.errors[1], 'required', '/baz', 'is a required property');
   });
 
 
@@ -121,24 +121,24 @@ describe('Validation errors', function () {
     var validate = ajv.compile(schema);
     shouldBeValid(validate, data);
     shouldBeInvalid(validate, invalidData1);
-    shouldBeError(validate.errors[0], 'required', "['1']", "should have required property '1'");
+    shouldBeError(validate.errors[0], 'required', "['1']", "is a required property");
     shouldBeInvalid(validate, invalidData2);
-    shouldBeError(validate.errors[0], 'required', "['2']", "should have required property '2'");
+    shouldBeError(validate.errors[0], 'required', "['2']", "is a required property");
 
     var validateJP = ajvJP.compile(schema);
     shouldBeValid(validateJP, data);
     shouldBeInvalid(validateJP, invalidData1);
-    shouldBeError(validateJP.errors[0], 'required', "/1", "should have required property '1'");
+    shouldBeError(validateJP.errors[0], 'required', "/1", "is a required property");
     shouldBeInvalid(validateJP, invalidData2);
-    shouldBeError(validateJP.errors[0], 'required', "/2", "should have required property '2'");
+    shouldBeError(validateJP.errors[0], 'required', "/2", "is a required property");
 
     var fullValidate = fullAjv.compile(schema);
     shouldBeValid(fullValidate, data);
     shouldBeInvalid(fullValidate, invalidData1);
-    shouldBeError(fullValidate.errors[0], 'required', '/1', "should have required property '1'");
+    shouldBeError(fullValidate.errors[0], 'required', '/1', "is a required property");
     shouldBeInvalid(fullValidate, invalidData2, 2);
-    shouldBeError(fullValidate.errors[0], 'required', '/2', "should have required property '2'");
-    shouldBeError(fullValidate.errors[1], 'required', '/98', "should have required property '98'");
+    shouldBeError(fullValidate.errors[0], 'required', '/2', "is a required property");
+    shouldBeError(fullValidate.errors[1], 'required', '/98', "is a required property");
   });
 
 


### PR DESCRIPTION
For required properties, the error message is currently:

"data.name should have required property .name"

This works for other validations, where the property is present, but required is a special case that indicates the property is not there. The above message is somewhat confusing. I've simply updated the required errors to read:

"data should have required property .name"
