### PR TITLE
Fix reference to external schemas

### DIFF
--- a/lib/compile/resolve.js
+++ b/lib/compile/resolve.js
@@ -85,7 +85,7 @@ function getJsonPointer(parsedRef, baseId, root) {
       part = unescapeFragment(part);
       schema = schema[part];
       if (!schema) break;
-      if (schema.id) baseId = resolveUrl(baseId, schema.id);
+      if (schema.id) baseId = resolveUrl(baseId, part);
       if (schema.$ref) {
         var $ref = resolveUrl(baseId, schema.$ref);
         var res = _resolve.call(this, root, $ref);


### PR DESCRIPTION
### Note

All tests have passed but I did not perform any manual testing and I am a bit confused I did not break anything. I guess the test suite is lacking a test case for this particular scenario but I'm not sure if I should implement a test and if so where/how. 

If a test is required please give me inputs. 

BTW I like what you do here :)  
### Use case

``` js
var Ajv = require('ajv');
var ajv = Ajv();

var schema = {
  type: "object",
  properties: {
    whatever: { type: "string" },
    title: {
      "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
    },
  }
}
var validate = ajv.compile(schema);
```
### Error trace

```
/home/cyp/node_modules/ajv/lib/compile/resolve.js:189
    return id ? id.replace(TRAILING_SLASH_HASH, '') : '';
                   ^

TypeError: id.replace is not a function
    at normalizeId (/home/cyp/node_modules/ajv/lib/compile/resolve.js:189:17)
    at resolveUrl (/home/cyp/node_modules/ajv/lib/compile/resolve.js:194:7)
    at Ajv.getJsonPointer (/home/cyp/node_modules/ajv/lib/compile/resolve.js:89:28)
    at Ajv._resolve (/home/cyp/node_modules/ajv/lib/compile/resolve.js:71:24)
    at Ajv.resolve (/home/cyp/node_modules/ajv/lib/compile/resolve.js:30:21)
    at Object.resolveRef (/home/cyp/node_modules/ajv/lib/compile/index.js:97:21)
    at Object.generate_ref [as code] (/home/cyp/node_modules/ajv/lib/dotjs/ref.js:41:22)
    at Object.generate_validate [as validate] (/home/cyp/node_modules/ajv/lib/dotjs/validate.js:44:35)
    at Object.generate_properties [as code] (/home/cyp/node_modules/ajv/lib/dotjs/properties.js:145:26)
    at generate_validate (/home/cyp/node_modules/ajv/lib/dotjs/validate.js:44:35)
```

I've added a console.log at line 88 of resolve.js to output information about the reference that fails: 

The added line: 

``` js
if (!(schema.id instanceof String)) console.log('baseId', baseId, 'id', schema.id, schema.title);
```

The output:

```
baseId http://json-schema.org/draft-04/schema# id { type: 'string', format: 'uri' } { type: 'string' }
```
### Analysis

The loop reads the parts of the URL and I expect it to append the parts to the base id and remove the additional `#` characters. So I replaced schema.id by part in the method `resolveUrl`. 
