### PR TITLE
Minimal typescript definition file for ajv.js

### DIFF
--- a/ajv.d.ts
+++ b/ajv.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for ajv
+// Project: https://github.com/epoberezkin/ajv
+// Definitions by: mrchief <https://github.com/mrchief>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'ajv' {
+  function Ajv(opts?: any): any;
+  export default Ajv;
+}


### PR DESCRIPTION
This would allow `ajv.js` to be used in TypeScript projects without errors/warnings.

Of course, it provides no type checking but that can be rolled in gradually.
