### PR TITLE
Rename exclusiveFormat to formatExclusive (v5 draft)

### DIFF
--- a/KEYWORDS.md
+++ b/KEYWORDS.md
@@ -16,7 +16,7 @@ The keywords and their values define what rules the data should satisfy to be va
     - [maxLength/minLength](#maxlength--minlength)
     - [pattern](#pattern)
     - [format](#format)
-    - [formatMaximum / formatMinimum and exclusiveFormatMaximum / exclusiveFormatMinimum](#formatmaximum--formatminimum-and-exclusiveformatmaximum--exclusiveformatminimum-v5-proposal) (v5)
+    - [formatMaximum / formatMinimum and formatExclusiveMaximum / formatExclusiveMinimum](#formatmaximum--formatminimum-and-exclusiveformatmaximum--exclusiveformatminimum-v5-proposal) (v5)
 - [Keywords for arrays](#keywords-for-arrays)
     - [maxItems/minItems](#maxitems--minitems)
     - [uniqueItems](#uniqueitems)
@@ -193,13 +193,13 @@ _invalid_: `"abc"`
 
 
 
-### `formatMaximum` / `formatMinimum` and `exclusiveFormatMaximum` / `exclusiveFormatMinimum` (v5 proposal)
+### `formatMaximum` / `formatMinimum` and `formatExclusiveMaximum` / `formatExclusiveMinimum` (v5 proposal)
 
 The value of keyword `formatMaximum` (`formatMinimum`) should be a string. This value is the maximum (minimum) allowed value for the data to be valid as determined by `format` keyword.
 
 Ajv defines comparison rules for formats `"date"`, `"time"` and `"date-time".
 
-The value of keyword `exclusiveFormatMaximum` (`exclusiveFormatMinimum`) should be a boolean value. These keyword cannot be used without `formatMaximum` (`formatMinimum`). If this keyword value is equal to `true`, the data to be valid should not be equal to the value in `formatMaximum` (`formatMinimum`) keyword.
+The value of keyword `formatExclusiveMaximum` (`formatExclusiveMinimum`) should be a boolean value. These keyword cannot be used without `formatMaximum` (`formatMinimum`). If this keyword value is equal to `true`, the data to be valid should not be equal to the value in `formatMaximum` (`formatMinimum`) keyword.
 
 
 __Example__
@@ -210,7 +210,7 @@ _schema_:
 {
     "format": "date",
     "formatMaximum": "2016-02-06",
-    "exclusiveFormatMaximum": true
+    "formatExclusiveMaximum": true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ It uses [doT templates](https://github.com/olado/doT) to generate super-fast val
 - [assigning defaults](#assigning-defaults) to missing properties and items
 - NEW: [coercing data](#coercing-data-types) to the types specified in `type` keywords
 - [custom keywords](#defining-custom-keywords)
-- keywords `switch`, `constant`, `contains`, `patternGroups`, `patternRequired`, `formatMaximum` / `formatMinimum` and `exclusiveFormatMaximum` / `exclusiveFormatMinimum` from [JSON-schema v5 proposals](https://github.com/json-schema/json-schema/wiki/v5-Proposals) with [option v5](#options)
+- keywords `switch`, `constant`, `contains`, `patternGroups`, `patternRequired`, `formatMaximum` / `formatMinimum` and `formatExclusiveMaximum` / `formatExclusiveMinimum` from [JSON-schema v5 proposals](https://github.com/json-schema/json-schema/wiki/v5-Proposals) with [option v5](#options)
 - [v5 meta-schema](https://raw.githubusercontent.com/epoberezkin/ajv/master/lib/refs/json-schema-v5.json#) for schemas using v5 keywords
 - NEW: [v5 $data reference](#data-reference) to use values from the validated data as values for the schema keywords
 - NEW: [asynchronous validation](#asynchronous-validation) of custom formats and keywords
@@ -176,7 +176,7 @@ With option `v5: true` Ajv also supports all validation keywords and [$data refe
 - [constant](https://github.com/epoberezkin/ajv/blob/master/KEYWORDS.md#constant-v5-proposal) - check that data is equal to some value
 - [patternGroups](https://github.com/epoberezkin/ajv/blob/master/KEYWORDS.md#patterngroups-v5-proposal) - a more powerful alternative to patternProperties
 - [patternRequired](https://github.com/epoberezkin/ajv/blob/master/KEYWORDS.md#patternrequired-v5-proposal) - like `required` but with patterns that some property should match.
-- [formatMaximum, formatMinimum, exclusiveFormatMaximum, exclusiveFormatMinimum](https://github.com/epoberezkin/ajv/blob/master/KEYWORDS.md#formatmaximum--formatminimum-and-exclusiveformatmaximum--exclusiveformatminimum-v5-proposal) - setting limits for date, time, etc.
+- [formatMaximum, formatMinimum, formatExclusiveMaximum, formatExclusiveMinimum](https://github.com/epoberezkin/ajv/blob/master/KEYWORDS.md#formatmaximum--formatminimum-and-exclusiveformatmaximum--exclusiveformatminimum-v5-proposal) - setting limits for date, time, etc.
 
 See [JSON-Schema validation keywords](https://github.com/epoberezkin/ajv/blob/master/KEYWORDS.md) for more details.
 
@@ -209,7 +209,7 @@ You can find patterns used for format validation and the sources that were used 
 
 With `v5` option you can use values from the validated data as the values for the schema keywords. See [v5 proposal](https://github.com/json-schema/json-schema/wiki/$data-(v5-proposal)) for more information about how it works.
 
-`$data` reference is supported in the keywords: constant, enum, format, maximum/minimum, exclusiveMaximum / exclusiveMinimum, maxLength / minLength, maxItems / minItems, maxProperties / minProperties, formatMaximum / formatMinimum, exclusiveFormatMaximum / exclusiveFormatMinimum, multipleOf, pattern, required, uniqueItems.
+`$data` reference is supported in the keywords: constant, enum, format, maximum/minimum, exclusiveMaximum / exclusiveMinimum, maxLength / minLength, maxItems / minItems, maxProperties / minProperties, formatMaximum / formatMinimum, formatExclusiveMaximum / formatExclusiveMinimum, multipleOf, pattern, required, uniqueItems.
 
 The value of "$data" should be a [relative JSON-pointer](http://tools.ietf.org/html/draft-luff-relative-json-pointer-00).
 
@@ -864,7 +864,7 @@ Defaults:
 
 ##### Validation and reporting options
 
-- _v5_: add keywords `switch`, `constant`, `contains`, `patternGroups`, `patternRequired`, `formatMaximum` / `formatMinimum` and `exclusiveFormatMaximum` / `exclusiveFormatMinimum` from [JSON-schema v5 proposals](https://github.com/json-schema/json-schema/wiki/v5-Proposals). With this option added schemas without `$schema` property are validated against [v5 meta-schema](https://raw.githubusercontent.com/epoberezkin/ajv/master/lib/refs/json-schema-v5.json#). `false` by default.
+- _v5_: add keywords `switch`, `constant`, `contains`, `patternGroups`, `patternRequired`, `formatMaximum` / `formatMinimum` and `formatExclusiveMaximum` / `formatExclusiveMinimum` from [JSON-schema v5 proposals](https://github.com/json-schema/json-schema/wiki/v5-Proposals). With this option added schemas without `$schema` property are validated against [v5 meta-schema](https://raw.githubusercontent.com/epoberezkin/ajv/master/lib/refs/json-schema-v5.json#). `false` by default.
 - _allErrors_: check all rules collecting all errors. Default is to return after the first error.
 - _verbose_: include the reference to the part of the schema (`schema` and `parentSchema`) and validated data in errors (false by default).
 - _jsonPointers_: set `dataPath` propery of errors using [JSON Pointers](https://tools.ietf.org/html/rfc6901) instead of JavaScript property access notation.

--- a/lib/dot/errors.def
+++ b/lib/dot/errors.def
@@ -116,7 +116,7 @@
   switch:          "'should pass \"switch\" keyword validation'",
   constant:        "'should be equal to constant'",
   _formatLimit:    "'should be {{=$opStr}} \"{{#def.concatSchemaEQ}}\"'",
-  _exclusiveFormatLimit: "'{{=$exclusiveKeyword}} should be boolean'"
+  _formatExclusiveLimit: "'{{=$exclusiveKeyword}} should be boolean'"
 } #}}
 
 
@@ -149,7 +149,7 @@
   switch:          "validate.schema{{=$schemaPath}}",
   constant:        "validate.schema{{=$schemaPath}}",
   _formatLimit:    "{{#def.schemaRefOrQS}}",
-  _exclusiveFormatLimit: "validate.schema{{=$schemaPath}}"
+  _formatExclusiveLimit: "validate.schema{{=$schemaPath}}"
 } #}}
 
 
@@ -181,5 +181,5 @@
   switch:          "{ caseIndex: {{=$caseIndex}} }",
   constant:        "{}",
   _formatLimit:    "{ limit: {{#def.schemaValueQS}} }",
-  _exclusiveFormatLimit: "{}"
+  _formatExclusiveLimit: "{}"
 } #}}

--- a/lib/dot/v5/_formatLimit.jst
+++ b/lib/dot/v5/_formatLimit.jst
@@ -56,7 +56,7 @@ var {{=$valid}} = undefined;
 
 {{
   var $isMax = $keyword == 'formatMaximum'
-    , $exclusiveKeyword = 'exclusiveFormat' + ($isMax ? 'Maximum' : 'Minimum')
+    , $exclusiveKeyword = 'formatExclusive' + ($isMax ? 'Maximum' : 'Minimum')
     , $schemaExcl = it.schema[$exclusiveKeyword]
     , $isDataExcl = it.opts.v5 && $schemaExcl && $schemaExcl.$data
     , $op = $isMax ? '<' : '>'
@@ -79,7 +79,7 @@ var {{=$valid}} = undefined;
   if (typeof {{=$schemaValueExcl}} != 'boolean' && {{=$schemaValueExcl}} !== undefined) {
     {{=$valid}} = false;
     {{ var $errorKeyword = $exclusiveKeyword; }}
-    {{# def.error:'_exclusiveFormatLimit' }}
+    {{# def.error:'_formatExclusiveLimit' }}
   }
 
   {{# def.elseIfValid }}

--- a/lib/refs/json-schema-v5.json
+++ b/lib/refs/json-schema-v5.json
@@ -243,7 +243,7 @@
                 { "$ref": "#/definitions/$data" }
             ]
         },
-        "exclusiveFormatMaximum": {
+        "formatExclusiveMaximum": {
             "anyOf": [
                 {
                     "type": "boolean",
@@ -252,7 +252,7 @@
                 { "$ref": "#/definitions/$data" }
             ]
         },
-        "exclusiveFormatMinimum": {
+        "formatExclusiveMinimum": {
             "anyOf": [
                 {
                     "type": "boolean",
@@ -318,8 +318,8 @@
         "exclusiveMinimum": [ "minimum" ],
         "formatMaximum": [ "format" ],
         "formatMinimum": [ "format" ],
-        "exclusiveFormatMaximum": [ "formatMaximum" ],
-        "exclusiveFormatMinimum": [ "formatMinimum" ]
+        "formatExclusiveMaximum": [ "formatMaximum" ],
+        "formatExclusiveMinimum": [ "formatMinimum" ]
     },
     "default": {}
 }

--- a/lib/v5.js
+++ b/lib/v5.js
@@ -25,8 +25,8 @@ function enableV5(ajv) {
 
   _addKeyword('formatMaximum', 'string', inlineFunctions._formatLimit);
   _addKeyword('formatMinimum', 'string', inlineFunctions._formatLimit);
-  ajv.addKeyword('exclusiveFormatMaximum');
-  ajv.addKeyword('exclusiveFormatMinimum');
+  ajv.addKeyword('formatExclusiveMaximum');
+  ajv.addKeyword('formatExclusiveMinimum');
 
   ajv.addKeyword('patternGroups'); // implemented in properties.jst
   _addKeyword('patternRequired', 'object');

--- a/spec/v5/$data/formatMaximum.json
+++ b/spec/v5/$data/formatMaximum.json
@@ -61,13 +61,13 @@
     ]
   },
   {
-    "description": "formatMaximum in the property with exclusiveFormatMaximum",
+    "description": "formatMaximum in the property with formatExclusiveMaximum",
     "schema": {
       "properties": {
         "finalDate": {
           "format": "date",
           "formatMaximum": { "$data": "1/beforeThan" },
-          "exclusiveFormatMaximum": true
+          "formatExclusiveMaximum": true
         },
         "beforeThan": {}
       }
@@ -147,13 +147,13 @@
     ]
   },
   {
-    "description": "formatMaximum with format in the property and with exclusiveFormatMaximum",
+    "description": "formatMaximum with format in the property and with formatExclusiveMaximum",
     "schema": {
       "properties": {
         "when": {
           "format": { "$data": "1/whenFormat" },
           "formatMaximum": "2015-08-17",
-          "exclusiveFormatMaximum": true
+          "formatExclusiveMaximum": true
         },
         "whenFormat": {}
       }
@@ -229,13 +229,13 @@
     ]
   },
   {
-    "description": "formatMaximum and format in the properties with exclusiveFormatMaximum",
+    "description": "formatMaximum and format in the properties with formatExclusiveMaximum",
     "schema": {
       "properties": {
         "when": {
           "format": { "$data": "1/whenFormat" },
           "formatMaximum": { "$data": "1/beforeThan" },
-          "exclusiveFormatMaximum": true
+          "formatExclusiveMaximum": true
         },
         "whenFormat": {},
         "beforeThan": {}
@@ -273,13 +273,13 @@
   },
 
   {
-    "description": "exclusiveFormatMaximum in the property",
+    "description": "formatExclusiveMaximum in the property",
     "schema": {
       "properties": {
         "finalDate": {
           "format": "date",
           "formatMaximum": "2015-08-17",
-          "exclusiveFormatMaximum": { "$data": "1/maxIsExclusive" }
+          "formatExclusiveMaximum": { "$data": "1/maxIsExclusive" }
         },
         "maxIsExclusive": {}
       }
@@ -332,7 +332,7 @@
         "valid": true
       },
       {
-        "description": "fails if value of exclusiveFormatMaximum is not boolean",
+        "description": "fails if value of formatExclusiveMaximum is not boolean",
         "data": {
           "finalDate": "2014-12-03",
           "maxIsExclusive": "false"
@@ -343,13 +343,13 @@
   },
 
   {
-    "description": "formatMaximum and exclusiveFormatMaximum in the properties",
+    "description": "formatMaximum and formatExclusiveMaximum in the properties",
     "schema": {
       "properties": {
         "finalDate": {
           "format": "date",
           "formatMaximum": { "$data": "1/beforeThan" },
-          "exclusiveFormatMaximum": { "$data": "1/maxIsExclusive" }
+          "formatExclusiveMaximum": { "$data": "1/maxIsExclusive" }
         },
         "beforeThan": {},
         "maxIsExclusive": {}
@@ -409,7 +409,7 @@
         "valid": true
       },
       {
-        "description": "fails if value of exclusiveFormatMaximum is not boolean",
+        "description": "fails if value of formatExclusiveMaximum is not boolean",
         "data": {
           "finalDate": "2014-12-03",
           "beforeThan": "2015-08-17",
@@ -430,13 +430,13 @@
   },
 
   {
-    "description": "formatMaximum with format and exclusiveFormatMaximum in the properties",
+    "description": "formatMaximum with format and formatExclusiveMaximum in the properties",
     "schema": {
       "properties": {
         "when": {
           "format": { "$data": "1/whenFormat" },
           "formatMaximum": "2015-08-17",
-          "exclusiveFormatMaximum": { "$data": "1/maxIsExclusive" }
+          "formatExclusiveMaximum": { "$data": "1/maxIsExclusive" }
         },
         "whenFormat": {},
         "maxIsExclusive": {}
@@ -496,7 +496,7 @@
         "valid": true
       },
       {
-        "description": "fails if value of exclusiveFormatMaximum is not boolean",
+        "description": "fails if value of formatExclusiveMaximum is not boolean",
         "data": {
           "when": "2014-12-03",
           "whenFormat": "date",
@@ -508,13 +508,13 @@
   },
 
   {
-    "description": "formatMaximum, format and exclusiveFormatMaximum in the properties",
+    "description": "formatMaximum, format and formatExclusiveMaximum in the properties",
     "schema": {
       "properties": {
         "when": {
           "format": { "$data": "1/whenFormat" },
           "formatMaximum": { "$data": "1/beforeThan" },
-          "exclusiveFormatMaximum": { "$data": "1/maxIsExclusive" }
+          "formatExclusiveMaximum": { "$data": "1/maxIsExclusive" }
         },
         "beforeThan": {},
         "whenFormat": {},
@@ -581,7 +581,7 @@
         "valid": true
       },
       {
-        "description": "fails if value of exclusiveFormatMaximum is not boolean",
+        "description": "fails if value of formatExclusiveMaximum is not boolean",
         "data": {
           "when": "2014-12-03",
           "whenFormat": "date",

--- a/spec/v5/$data/formatMinimum.json
+++ b/spec/v5/$data/formatMinimum.json
@@ -54,13 +54,13 @@
     ]
   },
   {
-    "description": "formatMinimum in the property with exclusiveFormatMinimum",
+    "description": "formatMinimum in the property with formatExclusiveMinimum",
     "schema": {
       "properties": {
         "finalDate": {
           "format": "date",
           "formatMinimum": { "$data": "1/laterThan" },
-          "exclusiveFormatMinimum": true
+          "formatExclusiveMinimum": true
         },
         "laterThan": {}
       }
@@ -140,13 +140,13 @@
     ]
   },
   {
-    "description": "formatMinimum with format in the property and with exclusiveFormatMinimum",
+    "description": "formatMinimum with format in the property and with formatExclusiveMinimum",
     "schema": {
       "properties": {
         "when": {
           "format": { "$data": "1/whenFormat" },
           "formatMinimum": "2015-08-17",
-          "exclusiveFormatMinimum": true
+          "formatExclusiveMinimum": true
         },
         "whenFormat": {}
       }
@@ -222,13 +222,13 @@
     ]
   },
   {
-    "description": "formatMinimum and format in the properties with exclusiveFormatMinimum",
+    "description": "formatMinimum and format in the properties with formatExclusiveMinimum",
     "schema": {
       "properties": {
         "when": {
           "format": { "$data": "1/whenFormat" },
           "formatMinimum": { "$data": "1/laterThan" },
-          "exclusiveFormatMinimum": true
+          "formatExclusiveMinimum": true
         },
         "whenFormat": {},
         "laterThan": {}
@@ -266,13 +266,13 @@
   },
 
   {
-    "description": "exclusiveFormatMinimum in the property",
+    "description": "formatExclusiveMinimum in the property",
     "schema": {
       "properties": {
         "finalDate": {
           "format": "date",
           "formatMinimum": "2015-08-17",
-          "exclusiveFormatMinimum": { "$data": "1/minIsExclusive" }
+          "formatExclusiveMinimum": { "$data": "1/minIsExclusive" }
         },
         "minIsExclusive": {}
       }
@@ -325,7 +325,7 @@
         "valid": true
       },
       {
-        "description": "fails if value of exclusiveFormatMinimum is not boolean",
+        "description": "fails if value of formatExclusiveMinimum is not boolean",
         "data": {
           "finalDate": "2015-11-09",
           "minIsExclusive": "false"
@@ -336,13 +336,13 @@
   },
 
   {
-    "description": "formatMinimum and exclusiveFormatMinimum in the properties",
+    "description": "formatMinimum and formatExclusiveMinimum in the properties",
     "schema": {
       "properties": {
         "finalDate": {
           "format": "date",
           "formatMinimum": { "$data": "1/laterThan" },
-          "exclusiveFormatMinimum": { "$data": "1/minIsExclusive" }
+          "formatExclusiveMinimum": { "$data": "1/minIsExclusive" }
         },
         "laterThan": {},
         "minIsExclusive": {}
@@ -402,7 +402,7 @@
         "valid": true
       },
       {
-        "description": "fails if value of exclusiveFormatMinimum is not boolean",
+        "description": "fails if value of formatExclusiveMinimum is not boolean",
         "data": {
           "finalDate": "2015-11-09",
           "laterThan": "2015-08-17",
@@ -423,13 +423,13 @@
   },
 
   {
-    "description": "formatMinimum with format and exclusiveFormatMinimum in the properties",
+    "description": "formatMinimum with format and formatExclusiveMinimum in the properties",
     "schema": {
       "properties": {
         "when": {
           "format": { "$data": "1/whenFormat" },
           "formatMinimum": "2015-08-17",
-          "exclusiveFormatMinimum": { "$data": "1/minIsExclusive" }
+          "formatExclusiveMinimum": { "$data": "1/minIsExclusive" }
         },
         "whenFormat": {},
         "minIsExclusive": {}
@@ -489,7 +489,7 @@
         "valid": true
       },
       {
-        "description": "fails if value of exclusiveFormatMinimum is not boolean",
+        "description": "fails if value of formatExclusiveMinimum is not boolean",
         "data": {
           "when": "2015-11-09",
           "whenFormat": "date",
@@ -501,13 +501,13 @@
   },
 
   {
-    "description": "formatMinimum, format and exclusiveFormatMinimum in the properties",
+    "description": "formatMinimum, format and formatExclusiveMinimum in the properties",
     "schema": {
       "properties": {
         "when": {
           "format": { "$data": "1/whenFormat" },
           "formatMinimum": { "$data": "1/laterThan" },
-          "exclusiveFormatMinimum": { "$data": "1/minIsExclusive" }
+          "formatExclusiveMinimum": { "$data": "1/minIsExclusive" }
         },
         "laterThan": {},
         "whenFormat": {},
@@ -574,7 +574,7 @@
         "valid": true
       },
       {
-        "description": "fails if value of exclusiveFormatMinimum is not boolean",
+        "description": "fails if value of formatExclusiveMinimum is not boolean",
         "data": {
           "when": "2015-11-09",
           "whenFormat": "date",

--- a/spec/v5/formatMaximum.json
+++ b/spec/v5/formatMaximum.json
@@ -29,11 +29,11 @@
     ]
   },
   {
-    "description": "exclusiveFormatMaximum validation with date format",
+    "description": "formatExclusiveMaximum validation with date format",
     "schema": {
       "format": "date",
       "formatMaximum": "2015-08-17",
-      "exclusiveFormatMaximum": true
+      "formatExclusiveMaximum": true
     },
     "tests": [
       {
@@ -94,11 +94,11 @@
     ]
   },
   {
-    "description": "exclusiveFormatMaximum validation with time format",
+    "description": "formatExclusiveMaximum validation with time format",
     "schema": {
       "format": "time",
       "formatMaximum": "13:15:17.000Z",
-      "exclusiveFormatMaximum": true
+      "formatExclusiveMaximum": true
     },
     "tests": [
       {
@@ -169,11 +169,11 @@
     ]
   },
   {
-    "description": "exclusiveFormatMaximum validation with date-time format",
+    "description": "formatExclusiveMaximum validation with date-time format",
     "schema": {
       "format": "date-time",
       "formatMaximum": "2015-08-17T13:15:17.000Z",
-      "exclusiveFormatMaximum": true
+      "formatExclusiveMaximum": true
     },
     "tests": [
       {

--- a/spec/v5/formatMinimum.json
+++ b/spec/v5/formatMinimum.json
@@ -29,11 +29,11 @@
     ]
   },
   {
-    "description": "exclusiveFormatMinimum validation with date format",
+    "description": "formatExclusiveMinimum validation with date format",
     "schema": {
       "format": "date",
       "formatMinimum": "2015-08-17",
-      "exclusiveFormatMinimum": true
+      "formatExclusiveMinimum": true
     },
     "tests": [
       {
@@ -94,11 +94,11 @@
     ]
   },
   {
-    "description": "exclusiveFormatMinimum validation with time format",
+    "description": "formatExclusiveMinimum validation with time format",
     "schema": {
       "format": "time",
       "formatMinimum": "13:15:17.000Z",
-      "exclusiveFormatMinimum": true
+      "formatExclusiveMinimum": true
     },
     "tests": [
       {
@@ -169,11 +169,11 @@
     ]
   },
   {
-    "description": "exclusiveFormatMinimum validation with date-time format",
+    "description": "formatExclusiveMinimum validation with date-time format",
     "schema": {
       "format": "date-time",
       "formatMinimum": "2015-08-17T13:15:17.000Z",
-      "exclusiveFormatMinimum": true
+      "formatExclusiveMinimum": true
     },
     "tests": [
       {


### PR DESCRIPTION
Unless there exists a more recent v5 proposal for these keywords, the names should be:
- formatExclusiveMinimum
- formatExclusiveMaximum

https://github.com/json-schema/json-schema/wiki/formatMinimum-(v5-proposal)
