### PR TITLE
V4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ __Please note__: all asynchronous subschemas that are referenced from the curren
 
 Validation function for an asynchronous custom format/keyword should return a promise that resolves to `true` or `false` (or rejects with `new Ajv.ValidationError(errors)` if you want to return custom errors from the keyword function). Ajv compiles asynchronous schemas to either [generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) (default) that can be optionally transpiled with [regenerator](https://github.com/facebook/regenerator) or to [es7 async function](http://tc39.github.io/ecmascript-asyncawait/) that can be transpiled with [nodent](https://github.com/MatAtBread/nodent) or with regenerator as well. You can also supply any other transpiler as a function. See [Options](#options).
 
-The compiled validation function has `async: true` property (if the schema is asynchronous), so you can differentiate these functions if you are using both syncronous and asynchronous schemas.
+The compiled validation function has `$async: true` property (if the schema is asynchronous), so you can differentiate these functions if you are using both syncronous and asynchronous schemas.
 
 If you are using generators, the compiled validation function can be either wrapped with [co](https://github.com/tj/co) (default) or returned as generator function, that can be used directly, e.g. in [koa](http://koajs.com/) 1.0. `co` is a small library, it is included in Ajv (both as npm dependency and in the browser bundle).
 

--- a/README.md
+++ b/README.md
@@ -561,9 +561,11 @@ With [option `useDefaults`](#options) Ajv will assign values from `default` keyw
 
 This option modifies original data.
 
-__Please note__: if the default value is an object or an array it will be inserted in the data by reference unless the option `useDefaults: "clone"` is passed.
+__Please note__: by default the default value is inserted in the generated validation code as a literal (starting from v4.0), so the value inserted in the data will be the deep clone of the default in the schema.
 
-The default behaviour is faster and it allows to have dynamic values in defaults, e.g. timestamp, without recompiling the schema. The side effect is that modifying the default value in any validated data instance will change the default in the schema and in other validated data instances. See example 3 below.
+If you need to insert the default value in the data by reference pass the option `useDefaults: "shared"`.
+
+Inserting defaults by reference can be faster (in case you have an object in `default`) and it allows to have dynamic values in defaults, e.g. timestamp, without recompiling the schema. The side effect is that modifying the default value in any validated data instance will change the default in the schema and in other validated data instances. See example 3 below.
 
 
 Example 1 (`default` in `properties`):
@@ -606,9 +608,11 @@ console.log(validate(data)); // true
 console.log(data); // [ 1, "foo" ]
 ```
 
-Example 3 (leaking "defaults"):
+Example 3 (inserting "defaults" by reference):
 
 ```javascript
+var ajv = Ajv({ useDefaults: 'shared' });
+
 var schema = {
   properties: {
     foo: {

--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -89,7 +89,7 @@ function Ajv(opts) {
     }
 
     var valid = v(data);
-    if (v.async) return self._opts.async == '*' ? co(valid) : valid;
+    if (v.$async) return self._opts.async == '*' ? co(valid) : valid;
     self.errors = v.errors;
     return valid;
   }
@@ -279,7 +279,7 @@ function Ajv(opts) {
       callValidate.errors = null;
       callValidate.root = root ? root : callValidate;
       if (schemaObj.schema.$async === true)
-        callValidate.async = true;
+        callValidate.$async = true;
       return callValidate;
     }
     schemaObj.compiling = true;

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -100,7 +100,7 @@ function compile(schema, root, localRefs, baseId) {
     validate.refs = refs;
     validate.refVal = refVal;
     validate.root = isRoot ? validate : _root;
-    if ($async) validate.async = true;
+    if ($async) validate.$async = true;
     validate.sourceCode = sourceCode;
 
     return validate;
@@ -156,7 +156,7 @@ function compile(schema, root, localRefs, baseId) {
   function resolvedRef(refVal, code) {
     return typeof refVal == 'object'
             ? { code: code, schema: refVal, inline: true }
-            : { code: code, async: refVal && refVal.async };
+            : { code: code, $async: refVal && refVal.$async };
   }
 
   function usePattern(regexStr) {

--- a/lib/dot/defaults.def
+++ b/lib/dot/defaults.def
@@ -1,9 +1,9 @@
 {{## def.assignDefault:
   if ({{=$passData}} === undefined)
-    {{=$passData}} = {{? it.opts.useDefaults == 'clone' }}
-                       {{= JSON.stringify($sch.default) }}
-                     {{??}}
+    {{=$passData}} = {{? it.opts.useDefaults == 'shared' }}
                        {{= it.useDefault($sch.default) }}
+                     {{??}}
+                       {{= JSON.stringify($sch.default) }}
                      {{?}};
 #}}
 

--- a/lib/dot/dependencies.jst
+++ b/lib/dot/dependencies.jst
@@ -24,9 +24,15 @@ var missing{{=$lvl}};
 {{ for (var $property in $propertyDeps) { }}
   {{ $deps = $propertyDeps[$property]; }}
   if ({{=$data}}{{= it.util.getProperty($property) }} !== undefined
-    && ({{# def.checkMissingProperty:$deps }})) {
-    {{# def.errorMissingProperty }}
-    {{# def.error:'dependencies' }}
+    {{? $breakOnError }}
+        && ({{# def.checkMissingProperty:$deps }})) {
+        {{# def.errorMissingProperty:'dependencies' }}
+    {{??}}
+      ) {
+        {{~ $deps:$reqProperty }}
+          {{# def.allErrorsMissingProperty:'dependencies' }}
+        {{~}}
+    {{?}}
   } {{# def.elseIfValid }}
 {{ } }}
 

--- a/lib/dot/errors.def
+++ b/lib/dot/errors.def
@@ -180,6 +180,6 @@
   patternRequired: "{ missingPattern: '{{=$missingPattern}}' }",
   switch:          "{ caseIndex: {{=$caseIndex}} }",
   constant:        "{}",
-  _formatLimit:    "{ limit: {{#def.schemaValueQS}} }",
+  _formatLimit:    "{ comparison: {{=$opExpr}}, limit: {{#def.schemaValueQS}}, exclusive: {{=$exclusive}} }",
   _exclusiveFormatLimit: "{}"
 } #}}

--- a/lib/dot/missing.def
+++ b/lib/dot/missing.def
@@ -7,7 +7,7 @@
 #}}
 
 
-{{## def.errorMissingProperty:
+{{## def.errorMissingProperty:_error:
   {{
     var $propertyPath = 'missing' + $lvl
       , $missingProperty = '\' + ' + $propertyPath + ' + \'';
@@ -16,5 +16,19 @@
                       ? it.util.getPathExpr($currentErrorPath,  $propertyPath, true)
                       : $currentErrorPath + ' + ' + $propertyPath;
     }
-  }}  
+  }}
+  {{# def.error:_error }}
+#}}
+
+{{## def.allErrorsMissingProperty:_error:
+  {{
+    var $prop = it.util.getProperty($reqProperty)
+      , $missingProperty = it.util.escapeQuotes($reqProperty);
+    if (it.opts._errorDataPathProperty) {
+      it.errorPath = it.util.getPath($currentErrorPath, $reqProperty, it.opts.jsonPointers);
+    }
+  }}
+  if ({{=$data}}{{=$prop}} === undefined) {
+    {{# def.addError:_error }}
+  }
 #}}

--- a/lib/dot/ref.jst
+++ b/lib/dot/ref.jst
@@ -55,7 +55,7 @@
     {{?}}
   {{??}}
     {{
-      $async = $refVal.async === true;
+      $async = $refVal.$async === true;
       $refCode = $refVal.code;
     }}
   {{?}}

--- a/lib/dot/required.jst
+++ b/lib/dot/required.jst
@@ -62,8 +62,7 @@
       else {
     {{??}}
       if ({{# def.checkMissingProperty:$required }}) {
-        {{# def.errorMissingProperty }}
-        {{# def.error:'required' }}
+        {{# def.errorMissingProperty:'required' }}
       } else {
     {{?}}
   {{??}}
@@ -83,17 +82,8 @@
 
       {{? $isData }}  }  {{?}}
     {{??}}
-      {{~ $required:$property:$i }}
-        {{
-          var $prop = it.util.getProperty($property)
-            , $missingProperty = it.util.escapeQuotes($property);
-          if (it.opts._errorDataPathProperty) {
-            it.errorPath = it.util.getPath($currentErrorPath, $property, it.opts.jsonPointers);
-          }
-        }}
-        if ({{=$data}}{{=$prop}} === undefined) {
-          {{# def.addError:'required' }}
-        }
+      {{~ $required:$reqProperty }}
+        {{# def.allErrorsMissingProperty:'required' }}
       {{~}}
     {{?}}
   {{?}}

--- a/lib/dot/v5/_formatLimit.jst
+++ b/lib/dot/v5/_formatLimit.jst
@@ -85,15 +85,15 @@ var {{=$valid}} = undefined;
   {{# def.elseIfValid }}
 
   {{# def.compareFormat }}
-  var exclusive{{=$lvl}} = {{=$schemaValueExcl}} === true;
+  var {{=$exclusive}} = {{=$schemaValueExcl}} === true;
 
   if ({{=$valid}} === undefined) {
-    {{=$valid}} = exclusive{{=$lvl}}
+    {{=$valid}} = {{=$exclusive}}
                   ? {{=$result}} {{=$op}} 0
                   : {{=$result}} {{=$op}}= 0;
   }
 
-  if (!{{=$valid}}) var op{{=$lvl}} = exclusive{{=$lvl}} ? '{{=$op}}' : '{{=$op}}=';
+  if (!{{=$valid}}) var op{{=$lvl}} = {{=$exclusive}} ? '{{=$op}}' : '{{=$op}}=';
 {{??}}
   {{
     var $exclusive = $schemaExcl === true

--- a/spec/errors.spec.js
+++ b/spec/errors.spec.js
@@ -343,9 +343,9 @@ describe('Validation errors', function () {
       shouldBeValid(fullValidate, data);
       shouldBeInvalid(fullValidate, invalidData1);
       shouldBeError(fullValidate.errors[0], 'dependencies', '#/dependencies', path('/bar'), msg, params('bar'));
-      shouldBeInvalid(fullValidate, invalidData2/*, 2*/);
+      shouldBeInvalid(fullValidate, invalidData2, 2);
       shouldBeError(fullValidate.errors[0], 'dependencies', '#/dependencies', path('/foo'), msg, params('foo'));
-      // shouldBeError(fullValidate.errors[1], 'dependencies', path('/baz'), msg, params('baz'));
+      shouldBeError(fullValidate.errors[1], 'dependencies', '#/dependencies', path('/baz'), msg, params('baz'));
 
       function params(missing) {
         var p = {

--- a/spec/options.spec.js
+++ b/spec/options.spec.js
@@ -421,35 +421,51 @@ describe('Ajv Options', function () {
       }
     });
 
-    describe('useDefaults: clone', function() {
-      it('should not modify underlying defaults when modifying validated data', function() {
-        test(Ajv({ useDefaults: 'clone' }));
-        test(Ajv({ useDefaults: 'clone', allErrors: true }));
 
-        function test(ajv) {
-          var schema = {
-            properties: {
-              items: {
-                type: 'array',
-                default: ['a-default']
-              }
-            }
-          };
-
-          var validate = ajv.compile(schema);
-
-          var data = {};
-          validate(data) .should.equal(true);
-          data.items .should.eql([ 'a-default' ]);
-
-          data.items.push('another-value');
-          data.items .should.eql([ 'a-default', 'another-value' ]);
-
-          var data2 = {};
-          validate(data2) .should.equal(true);
-          data2.items .should.eql([ 'a-default' ]);
-        }
+    describe('useDefaults: by value / by reference', function() {
+      describe('using by value', function() {
+        it('should NOT modify underlying defaults when modifying validated data', function() {
+          test('value', Ajv({ useDefaults: true }));
+          test('value', Ajv({ useDefaults: true, allErrors: true }));
+        });
       });
+
+      describe('using by reference', function() {
+        it('should modify underlying defaults when modifying validated data', function() {
+          test('reference', Ajv({ useDefaults: 'shared' }));
+          test('reference', Ajv({ useDefaults: 'shared', allErrors: true }));
+        });
+      });
+
+      function test(useDefaultsMode, ajv) {
+        var schema = {
+          properties: {
+            items: {
+              type: 'array',
+              default: ['a-default']
+            }
+          }
+        };
+
+        var validate = ajv.compile(schema);
+
+        var data = {};
+        validate(data) .should.equal(true);
+        data.items .should.eql([ 'a-default' ]);
+
+        data.items.push('another-value');
+        data.items .should.eql([ 'a-default', 'another-value' ]);
+
+        var data2 = {};
+        validate(data2) .should.equal(true);
+
+        if (useDefaultsMode == 'reference')
+          data2.items .should.eql([ 'a-default', 'another-value' ]);
+        else if (useDefaultsMode == 'value')
+          data2.items .should.eql([ 'a-default' ]);
+        else
+          throw new Error('unknown useDefaults mode');
+      }
     });
   });
 

--- a/spec/resolve.spec.js
+++ b/spec/resolve.spec.js
@@ -96,6 +96,8 @@ describe('resolve', function () {
 
 
   describe('missing schema error', function() {
+    this.timeout(4000);
+
     it('should contain missingRef and missingSchema', function() {
       testMissingSchemaError({
         baseId: 'http://example.com/1.json',


### PR DESCRIPTION
 useDeafults: 'clone' should be the default
 dependencies in allErrors mode (#73)
 error parameters in v5 errors (to add messages to ajv-i18n)
 rename async property of validation function to $async to avoid name clash with meteor
