### PR TITLE
Handle overlap between props and patternProps

### DIFF
--- a/lib/dot/properties.jst
+++ b/lib/dot/properties.jst
@@ -133,6 +133,7 @@ var valid{{=$it.level}} = true;
 {{?}}
 
 {{ var $useDefaults = it.opts.useDefaults && !it.compositeRule; }}
+var matchedProps = {};
 
 {{? $schemaKeys.length }}
   {{~ $schemaKeys:$propertyKey }}
@@ -197,6 +198,10 @@ var valid{{=$it.level}} = true;
     {{?}} {{ /* def.nonEmptySchema */ }}
 
     {{# def.ifResultValid }}
+
+    if (valid{{=$it.level}}) {
+      matchedProps["{{=$propertyKey}}"] = true;
+    }
   {{~}}
 {{?}}
 
@@ -212,6 +217,11 @@ var valid{{=$it.level}} = true;
     }}
 
     for (var key{{=$lvl}} in {{=$data}}) {
+      if (matchedProps[key{{=$lvl}}]) {
+        valid{{=$it.level}} = true;
+        continue;
+      }
+
       if ({{= it.usePattern($pProperty) }}.test(key{{=$lvl}})) {
         {{
           $it.errorPath = it.util.getPathExpr(it.errorPath, 'key' + $lvl, it.opts.jsonPointers);


### PR DESCRIPTION
When a particular attribute matches both an explicit "properties" entry and a
"patternProperties" pattern, we should not fail validation if the attribute's
value is appropriate for the "properties" schema but not for
"patternProperties".
