### PR TITLE
feat(own-properties): support optionally checking own properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,6 +842,7 @@ Defaults:
   format:           'fast',
   formats:          {},
   schemas:          {},
+  ownProperties:    false,
   // referenced schema options:
   missingRefs:      true,
   loadSchema:       undefined, // function(uri, cb) { /* ... */ cb(err, schema); },
@@ -878,7 +879,7 @@ Defaults:
 - _format_: formats validation mode ('fast' by default). Pass 'full' for more correct and slow validation or `false` not to validate formats at all. E.g., 25:00:00 and 2015/14/33 will be invalid time and date in 'full' mode but it will be valid in 'fast' mode.
 - _formats_: an object with custom formats. Keys and values will be passed to `addFormat` method.
 - _schemas_: an array or object of schemas that will be added to the instance. If the order is important, pass array. In this case schemas must have IDs in them. Otherwise the object can be passed - `addSchema(value, key)` will be called for each schema in this object.
-
+- _ownProperties_: indicates that when iterating properties of data to be validated, only properties found directly upon the object are used (rather than all enumerable properties)
 
 ##### Referenced schema options
 

--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -104,6 +104,7 @@ declare namespace ajv {
     format?: string;
     formats?: Object;
     schemas?: Array<Object> | Object;
+    ownProperties?: boolean;
     missingRefs?: boolean | string;
     loadSchema?: (uri: string, cb: (err: Error, schema: Object) => any) => any;
     removeAdditional?: boolean | string;

--- a/lib/dot/properties.jst
+++ b/lib/dot/properties.jst
@@ -34,6 +34,7 @@
                               && Object.keys($aProperties).length
     , $removeAdditional = it.opts.removeAdditional
     , $checkAdditional = $noAdditional || $additionalIsSchema || $removeAdditional
+    , $ownProperties = it.opts.ownProperties
     , $currentBaseId = it.baseId;
 
   var $required = it.schema.required;
@@ -52,6 +53,10 @@ var valid{{=$it.level}} = true;
 
 {{? $checkAdditional }}
   for (var key{{=$lvl}} in {{=$data}}) {
+    {{? $ownProperties }}
+    if (!{{=$data}}.hasOwnProperty(key{{=$lvl}})) continue;
+    {{?}}
+
     {{? $someProperties }}
       var isAdditional{{=$lvl}} = !(false
         {{? $schemaKeys.length }}
@@ -212,6 +217,10 @@ var valid{{=$it.level}} = true;
     }}
 
     for (var key{{=$lvl}} in {{=$data}}) {
+      {{? $ownProperties }}
+      if (!{{=$data}}.hasOwnProperty(key{{=$lvl}})) continue;
+      {{?}}
+
       if ({{= it.usePattern($pProperty) }}.test(key{{=$lvl}})) {
         {{
           $it.errorPath = it.util.getPathExpr(it.errorPath, 'key' + $lvl, it.opts.jsonPointers);
@@ -251,6 +260,10 @@ var valid{{=$it.level}} = true;
       var pgPropCount{{=$lvl}} = 0;
 
       for (var key{{=$lvl}} in {{=$data}}) {
+        {{? $ownProperties }}
+        if (!{{=$data}}.hasOwnProperty(key{{=$lvl}})) continue;
+        {{?}}
+
         if ({{= it.usePattern($pgProperty) }}.test(key{{=$lvl}})) {
           pgPropCount{{=$lvl}}++;
 

--- a/lib/dot/v5/patternRequired.jst
+++ b/lib/dot/v5/patternRequired.jst
@@ -5,13 +5,17 @@
 {{
   var $key = 'key' + $lvl
     , $matched = 'patternMatched' + $lvl
-    , $closingBraces = '';
+    , $closingBraces = ''
+    , $ownProperties = it.opts.ownProperties;
 }}
 
 var {{=$valid}} = true;
 {{~ $schema:$pProperty }}
   var {{=$matched}} = false;
   for (var {{=$key}} in {{=$data}}) {
+    {{? $ownProperties }}
+    if (!{{=$data}}.hasOwnProperty({{=$key}})) continue;
+    {{?}}
     {{=$matched}} = {{= it.usePattern($pProperty) }}.test({{=$key}});
     if ({{=$matched}}) break;
   }


### PR DESCRIPTION
Traditionally ajv validates additionalProperties by checking all
enumerable properties of an object. This patch allows the user to
specify that they only want own properties of an object to be
considered in this validation
