### PR TITLE
Add `schema` to interface returned by `getSchema`

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -92,6 +92,7 @@ declare namespace ajv {
       parentDataProperty?: string | number
     ): boolean | Thenable<boolean>;
     errors?: Array<ErrorObject>;
+    schema?: Object;
   }
 
   interface Options {


### PR DESCRIPTION
`getSchema` returns "schema validating function (with property `schema`).", but property `schema` is not included in interface `ValidateFunction`.

This fix seems to work for me, since VS Code no longer complains when I do something like `let mySchema = ajv.getSchema(id).schema;`, but there may be a better way to annotate this. 
