### PR TITLE
[typescript] Use Class in type's definition to allow use 'new' operator

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -1,7 +1,9 @@
-declare function ajv (options?: ajv.Options): ajv.Ajv;
-
-declare namespace ajv {
-  interface Ajv {
+  export default class Ajv {
+    /**
+     * Constructor
+     * @param  {Object} Options
+     */
+    constructor(options?)
     /**
     * Validate data using schema
     * Schema will be compiled and cached (using serialized JSON as key. [json-stable-stringify](https://github.com/substack/json-stable-stringify) is used to serialize.
@@ -77,7 +79,7 @@ declare namespace ajv {
     * @return {String} human readable string with all errors descriptions
     */
     errorsText(errors?: Array<ErrorObject>, options?: ErrorsTextOptions): string;
-    errors?: Array<ErrorObject>;
+    errors: Array<ErrorObject>;
   }
 
   interface Thenable <R> {
@@ -95,7 +97,7 @@ declare namespace ajv {
     schema?: Object;
   }
 
-  interface Options {
+  export interface Options {
     v5?: boolean;
     allErrors?: boolean;
     verbose?: boolean;
@@ -253,6 +255,4 @@ declare namespace ajv {
   }
 
   interface NoParams {}
-}
-
-export = ajv;
+  


### PR DESCRIPTION
After struggle a lot with the message `[ts] Only a void function can be called with the 'new' keyword`, every time that I try to use the code above, I got to resolve the issue  by using export class insted a namespace.

```
import Ajv from 'ajv';
...
const ajv = new Ajv(ajvOptions);
```

This change allows to type cheking the options, outside of the parameter like this:

```
import Ajv, {Options} from 'ajv';
const ajvOptions: Options = {...}
const ajv = new Ajv(ajvOptions);
```
