### PR TITLE
fix: date-time string validation to fail validating for date-only string

### DIFF
--- a/lib/compile/formats.js
+++ b/lib/compile/formats.js
@@ -90,6 +90,8 @@ function date(str) {
 
 
 function time(str, full) {
+  if (str === undefined) return false;
+
   var matches = str.match(TIME);
   if (!matches) return false;
 

--- a/lib/compile/formats.js
+++ b/lib/compile/formats.js
@@ -90,8 +90,6 @@ function date(str) {
 
 
 function time(str, full) {
-  if (str === undefined) return false;
-
   var matches = str.match(TIME);
   if (!matches) return false;
 
@@ -107,6 +105,9 @@ var DATE_TIME_SEPARATOR = /t|\s/i;
 function date_time(str) {
   // http://tools.ietf.org/html/rfc3339#section-5.6
   var dateTime = str.split(DATE_TIME_SEPARATOR);
+
+  if (dateTime.length < 2) return false;
+
   return date(dateTime[0]) && time(dateTime[1], true);
 }
 

--- a/spec/tests/rules/format.json
+++ b/spec/tests/rules/format.json
@@ -101,6 +101,22 @@
     ]
   },
   {
+    "description": "validation of date-time strings",
+    "schema": {"format": "date-time"},
+    "tests": [
+      {
+        "description": "a valid date-time string",
+        "data": "1963-06-19T12:13:14Z",
+        "valid": true
+      },
+      {
+        "description": "an invalid date-time string",
+        "data": "1963-06-19",
+        "valid": false
+      }
+    ]
+  },
+  {
     "description": "validation of uuid strings",
     "schema": {"format": "uuid"},
     "tests": [


### PR DESCRIPTION
This should resolve issue #261. Added specs for the failing use-case specifically. Let me know if you see any issues.
