### PR TITLE
Assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,15 @@ __Please note__: every time this method is called the errors are overwritten so 
 If the schema is asynchronous (has `$async` keyword on the top level) this method returns a Promise. See [Asynchronous validation](#asynchronous-validation).
 
 
+##### .assert(Object schema|String key|String ref, data)
+
+Just like `validate`, but throws a [`ValidationError`](#validation-errors) if the validation fails.
+
+The error object has the `errors` property and the `errorsText` method.
+
+This method does not support async validation.
+
+
 ##### .addSchema(Array&lt;Object&gt;|Object schema [, String key])
 
 Add schema(s) to validator instance. From version 1.0.0 this method does not compile schemas (but it still validates them). Because of that change, dependencies can be added in any order and circular dependencies are supported. It also prevents unnecessary compilation of schemas that are containers for other schemas but not used as a whole.

--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -1,6 +1,7 @@
-declare var ajv: { 
+declare var ajv: {
   (options?: ajv.Options): ajv.Ajv;
   new (options?: ajv.Options): ajv.Ajv;
+  ValidationError: ajv.ValidationErrorConstructor;
 }
 
 declare namespace ajv {
@@ -257,6 +258,25 @@ declare namespace ajv {
   }
 
   interface NoParams {}
+
+  interface ValidationErrorConstructor {
+    prototype: ValidationError;
+    new (errors: ErrorObject[]): ValidationError;
+  }
+
+  interface ValidationError extends Error {
+
+    /** "validation failed" */
+    message: string;
+
+    /** true */
+    avj: boolean;
+
+    /** true */
+    validation: boolean;
+
+    errors: ErrorObject[];
+  }
 }
 
 export = ajv;

--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -79,7 +79,8 @@ declare namespace ajv {
     * @param  {Object} options optional options with properties `separator` and `dataVar`.
     * @return {String} human readable string with all errors descriptions
     */
-    errorsText(errors?: Array<ErrorObject>, options?: ErrorsTextOptions): string;
+    errorsText(errors: Array<ErrorObject>, options?: ErrorsTextOptions): string;
+    errorsText(options?: ErrorsTextOptions): string;
     errors?: Array<ErrorObject>;
   }
 

--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -15,6 +15,14 @@ declare namespace ajv {
     */
     validate(schemaKeyRef: Object | string, data: any): boolean;
     /**
+    * Validate data using schema and throw a ValidationError if the data is not valid
+    * Schema will be compiled and cached (using serialized JSON as key. [json-stable-stringify](https://github.com/substack/json-stable-stringify) is used to serialize.
+    * @param  {String|Object} schemaKeyRef key, ref or schema object
+    * @param  {Any} data to be validated
+    * @throws ValidationError Has the `errors` property and the `errorsText` method
+    */
+    assert(schemaKeyRef: Object | string, data: any): void;
+    /**
     * Create validating function for passed schema.
     * @param  {Object} schema schema object
     * @return {Function} validating function
@@ -276,6 +284,20 @@ declare namespace ajv {
     validation: boolean;
 
     errors: ErrorObject[];
+
+    /**
+     * the data that was validated. Available if `assert()` was used
+     */
+    actual?: any;
+
+    /**
+    * Available if `assert()` was used.
+    * Convert array of error message objects to string
+    * @param  {Array<Object>} errors optional array of validation errors, if not passed errors from the instance are used.
+    * @param  {Object} options optional options with properties `separator` and `dataVar`.
+    * @return {String} human readable string with all errors descriptions
+    */
+    errorsText?: (options?: ErrorsTextOptions) => string;
   }
 }
 

--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -12,11 +12,12 @@ var compileSchema = require('./compile')
   , async = require('./async')
   , co = require('co');
 
+var ValidationError = require('./compile/validation_error');
 module.exports = Ajv;
 
 Ajv.prototype.compileAsync = async.compile;
 Ajv.prototype.addKeyword = require('./keyword');
-Ajv.ValidationError = require('./compile/validation_error');
+Ajv.ValidationError = ValidationError;
 
 var META_SCHEMA_ID = 'http://json-schema.org/draft-04/schema';
 var SCHEMA_URI_FORMAT = /^(?:(?:[a-z][a-z0-9+-.]*:)?\/\/)?[^\s]*$/i;
@@ -48,6 +49,7 @@ function Ajv(opts) {
   // this is done on purpose, so that methods are bound to the instance
   // (without using bind) so that they can be used without the instance
   this.validate = validate;
+  this.assert = assert;
   this.compile = compile;
   this.addSchema = addSchema;
   this.addMetaSchema = addMetaSchema;
@@ -96,6 +98,25 @@ function Ajv(opts) {
       return self._opts.async == '*' ? co(valid) : valid;
     self.errors = v.errors;
     return valid;
+  }
+
+
+  /**
+   * Validate data using schema and throw a ValidationError if the data is not valid
+   * Schema will be compiled and cached (using serialized JSON as key. [json-stable-stringify](https://github.com/substack/json-stable-stringify) is used to serialize.
+   * @param  {String|Object} schemaKeyRef key, ref or schema object
+   * @param  {Any} data to be validated
+   * @throws ValidationError Has the `errors` property and the `errorsText` method
+   */
+  function assert(schemaKeyRef, data) {
+    var valid = validate(schemaKeyRef, data);
+    if (typeof valid === 'object') throw new Error('assert does not support async validation');
+    if (!valid) {
+      var error = new ValidationError(self.errors);
+      error.errorsText = errorsText;
+      error.actual = data;
+      throw error;
+    }
   }
 
 

--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -329,6 +329,7 @@ function Ajv(opts) {
    * @return {String} human readable string with all errors descriptions
    */
   function errorsText(errors, options) {
+    if (errors && !(errors instanceof Array)) options = errors;
     errors = errors || self.errors;
     if (!errors) return 'No errors';
     options = options || {};

--- a/spec/ajv.spec.js
+++ b/spec/ajv.spec.js
@@ -91,6 +91,45 @@ describe('Ajv', function () {
   });
 
 
+  describe('assert method', function () {
+
+    it('should compile schema and validate data against it', function() {
+      should.not.throw(function () { ajv.assert({ type: 'integer' }, 1); });
+      should.throw(function () { ajv.assert({ type: 'integer' }, '1'); });
+      should.not.throw(function () { ajv.assert({ type: 'string' }, 'a'); });
+      should.throw(function () { ajv.assert({ type: 'string' }, 1); });
+    });
+
+    it('should validate against previously compiled schema by id (also see addSchema)', function() {
+      should.not.throw(function () { ajv.assert({ id: '//e.com/int.json', type: 'integer' }, 1); });
+      should.not.throw(function () { ajv.assert('//e.com/int.json', 1); });
+      should.throw(function () { ajv.assert('//e.com/int.json', '1'); });
+
+      ajv.compile({ id: '//e.com/str.json', type: 'string' }).should.be.a('function');
+      should.not.throw(function () { ajv.assert('//e.com/str.json', 'a'); });
+      should.throw(function () { ajv.assert('//e.com/str.json', 1); });
+    });
+
+    it('should throw exception if no schema with ref', function() {
+      should.not.throw(function () { ajv.assert({ id: 'integer', type: 'integer' }, 1); });
+      should.not.throw(function () { ajv.assert('integer', 1); });
+      should.throw(function() { ajv.assert('string', 'foo'); });
+    });
+
+    it('should throw a ValidationError with the failure reason', function () {
+      try {
+        ajv.assert({ type: 'integer' }, '1');
+      } catch (error) {
+        error.should.be.instanceof(Ajv.ValidationError);
+        error.should.have.property('errors');
+        error.should.have.property('errorsText');
+        error.should.have.property('actual');
+        return;
+      }
+      throw new Error('no error thrown');
+    });
+  });
+
   describe('addSchema method', function() {
     it('should add and compile schema with key', function() {
       var res = ajv.addSchema({ type: 'integer' }, 'int');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
#274

**What changes did you make?**
I added an `assert` method that works like `validate` but throws a `ValidationError` if the validation failed. The error also has `actual` and `errorsText` set. To make it easier to use `errorsText`, I added support for omitting `errors` argument but providing `options`. I also added the `ValidationError` because it was missing.

**Is there anything that requires more attention while reviewing?**
I wasn't sure how to handle async validation. A method should better not return sometimes a promise, sometimes throw an error. If we want to cover async validation, it would be better to add another method `assertAsync()`. But I think it's fine as-is because people expect an `assert` function to throw sync.
