### PR TITLE
add browsers field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.5.0",
   "description": "Another JSON Schema Validator",
   "main": "lib/ajv.js",
-  "browser": "dist/ajv.bundle.js",
+  "webpack": "dist/ajv.bundle.js",
   "typings": "lib/ajv.d.ts",
   "files": [
     "lib/",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.5.0",
   "description": "Another JSON Schema Validator",
   "main": "lib/ajv.js",
+  "browser": "dist/ajv.bundle.js",
   "typings": "lib/ajv.d.ts",
   "files": [
     "lib/",


### PR DESCRIPTION
This is a real fix for #117 to prevent webpack build warnings. Webpack will automatically use the browser build (see https://webpack.github.io/docs/configuration.html#resolve-packagemains).
