### PR TITLE
Add option to not retain validator source code

### DIFF
--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -32,7 +32,8 @@ function compile(schema, root, localRefs, baseId) {
     , patternsHash = {}
     , defaults = []
     , defaultsHash = {}
-    , customRules = [];
+    , customRules = []
+    , retainSourceCode = this._opts.retainSourceCode !== false;
 
   root = root || { schema: schema, refVal: refVal, refs: refs };
 
@@ -54,7 +55,7 @@ function compile(schema, root, localRefs, baseId) {
       cv.refVal = v.refVal;
       cv.root = v.root;
       cv.$async = v.$async;
-      cv.sourceCode = v.sourceCode;
+      if (retainSourceCode) cv.sourceCode = v.sourceCode;
     }
     return v;
   } finally {
@@ -100,7 +101,7 @@ function compile(schema, root, localRefs, baseId) {
 
     sourceCode = vars(refVal, refValCode) + vars(patterns, patternCode)
                    + vars(defaults, defaultCode) + vars(customRules, customRuleCode)
-                   + sourceCode;
+                   + sourceCode + 'return validate;';
 
     if (opts.beautify) {
       /* istanbul ignore else */
@@ -114,7 +115,37 @@ function compile(schema, root, localRefs, baseId) {
       validateCode = $async && transpile
                       ? transpile(sourceCode)
                       : sourceCode;
-      eval(validateCode);
+
+      var makeValidate = new Function(
+        'refVal',
+        'co',
+        'equal',
+        'ucs2length',
+        'root',
+        'formats',
+        'customRules',
+        'ValidationError',
+        'RULES',
+        'defaults',
+        'self',
+        'validate',
+        validateCode
+      );
+
+      validate = makeValidate(
+        refVal,
+        co,
+        equal,
+        ucs2length,
+        root,
+        formats,
+        customRules,
+        ValidationError,
+        RULES,
+        defaults,
+        self
+      );
+
       refVal[0] = validate;
     } catch(e) {
       console.error('Error compiling schema, function code:', validateCode);
@@ -127,7 +158,7 @@ function compile(schema, root, localRefs, baseId) {
     validate.refVal = refVal;
     validate.root = isRoot ? validate : _root;
     if ($async) validate.$async = true;
-    validate.sourceCode = sourceCode;
+    if (retainSourceCode) validate.sourceCode = sourceCode;
 
     return validate;
   }

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -9,6 +9,17 @@ var beautify = (function() { try { return require('' + 'js-beautify').js_beautif
 
 var validateGenerator = require('../dotjs/validate');
 
+/**
+ * Functions below are used inside compiled validations function
+ */
+
+var co = require('co');
+var ucs2length = util.ucs2length;
+var equal = require('./equal');
+
+// this error is thrown by async schemas to return validation errors via exception
+var ValidationError = require('./validation_error');
+
 module.exports = compile;
 
 
@@ -363,19 +374,3 @@ function vars(arr, statement) {
     code += statement(i, arr);
   return code;
 }
-
-
-/*eslint-disable no-unused-vars */
-
-/**
- * Functions below are used inside compiled validations function
- */
-
-var co = require('co');
-var ucs2length = util.ucs2length;
-var equal = require('./equal');
-
-// this error is thrown by async schemas to return validation errors via exception
-var ValidationError = require('./validation_error');
-
-/*eslint-enable no-unused-vars */


### PR DESCRIPTION
**What issue does this pull request resolve?**
Programs with many schemas eat a lot of memory in the form of validator source strings.

**What changes did you make?**
Added an option to retain the `sourceCode` property and changed the `eval` to a `new Function` which is indirect and therefore does not retain references to the current context. This required explicitly passing in all variables that the compiled functions depend on. The option is called `retainSourceCode` and it defaults to true.

This has the added benefit of explicitly showing what variables are being used by the validator functions.

@MadanThangavelu @Matt-Esch
