### PR TITLE
Add missing rootData parameter from ValidateFunction typescript interface

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -92,7 +92,8 @@ declare namespace ajv {
       data: any,
       dataPath?: string,
       parentData?: Object | Array<any>,
-      parentDataProperty?: string | number
+      parentDataProperty?: string | number,
+      rootData?: any
     ): boolean | Thenable<boolean>;
     errors?: Array<ErrorObject>;
     schema?: Object;

--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -93,7 +93,7 @@ declare namespace ajv {
       dataPath?: string,
       parentData?: Object | Array<any>,
       parentDataProperty?: string | number,
-      rootData?: any
+      rootData?: Object | Array<any>
     ): boolean | Thenable<boolean>;
     errors?: Array<ErrorObject>;
     schema?: Object;


### PR DESCRIPTION
**What issue does this pull request resolve?**

This resolves a typescript validation error of `ajv.compile(someJSONSchemaObject).toString();`

I did some minor refactoring of the function like this (adding the function's interface):

``` typescript
import * as ajv from 'ajv';
export var validate: ajv.ValidateFunction = function validate (data, dataPath, parentData, parentDataProperty, rootData) {
  //...the body of compiled function
}
```

And I get this typescript error:

```
 Type '(data: any, dataPath: string, parentData: Object | any[], parentDataProperty: string | number, ro...' is not assignable to type 'ValidateFunction'.
```

> The problem is that `rootData` argument is not listed in the interface type definition.

**What changes did you make?**

I added the missing argument in the typescript interface type definition.

**Is there anything that requires more attention while reviewing?**
