### PR TITLE
Store require paths for optional dependencies in variables

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -27,6 +27,8 @@ var MODES = [
 
 
 var regenerator, nodent;
+var regeneratorRequirePath = 'regenerator';
+var nodentRequirePath = 'nodent';
 
 
 function setupAsync(opts, required) {
@@ -92,7 +94,7 @@ function checkAsyncFunction(opts, required) {
 function getRegenerator(opts, required) {
   try {
     if (!regenerator) {
-      regenerator = require('' + 'regenerator');
+      regenerator = require(regeneratorRequirePath);
       regenerator.runtime();
     }
     if (!opts.async || opts.async === true)
@@ -113,7 +115,7 @@ function regeneratorTranspile(code) {
 function getNodent(opts, required) {
   /* jshint evil: true */
   try {
-    if (!nodent) nodent = require('' + 'nodent')({ log: false, dontInstallRequireHook: true });
+    if (!nodent) nodent = require(nodentRequirePath)({ log: false, dontInstallRequireHook: true });
     if (opts.async != 'es7') {
       if (opts.async && opts.async !== true) console.warn('nodent transpiles only es7 async functions');
       opts.async = 'es7';

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -6,10 +6,11 @@ var resolve = require('./resolve')
   , async = require('../async');
 
 var beautify;
+var beautifyRequirePath = 'js-beautify';
 
 function loadBeautify(){
   if (beautify === undefined) {
-    try { beautify = require('' + 'js-beautify').js_beautify; }
+    try { beautify = require(beautifyRequirePath).js_beautify; }
     catch(e) { beautify = false; }
   }
 }


### PR DESCRIPTION
Fixes #325 and, probably, #117 
remove warnings about missing dpendencies for webpack.

For use case with `angular 2` and `angular-cli` I have not warnings in browser console anymore.
And I have no warnings
Still, there some warnings while testing angular application. But it is much better.
```
WARNING in ./~/ajv/lib/compile/index.js
13:21 Critical dependency: the request of a dependency is an expression
```