### PR TITLE
fix: display prop for additionalProperties error

### DIFF
--- a/lib/dot/errors.def
+++ b/lib/dot/errors.def
@@ -94,7 +94,7 @@
   'false schema':  "'boolean schema is false'",
   $ref:            "'can\\\'t resolve reference {{=it.util.escapeQuotes($schema)}}'",
   additionalItems: "'should NOT have more than {{=$schema.length}} items'",
-  additionalProperties: "'should NOT have additional properties'",
+  additionalProperties: "'should NOT have additional property \"{{=$additionalProperty}}\"'",
   anyOf:           "'should match some schema in anyOf'",
   const:           "'should be equal to constant'",
   contains:        "'should contain a valid item'",


### PR DESCRIPTION
_This is trivial, but since it was not pre-approved I'll have no objection whatsoever if it's shot down_

It's adding a single variable interpolation to an error template, so a proposal seemed overkill as I'd already solved it.  But I can go through the steps if desired, and fully intend to for anything less trivial.

<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

With "additionalProperties": false, the existing errror message was always:

```CONSOLE
~/schemas$ ajv compile -m draft-04/hyper-schema -s foo
schema foo is invalid
error: schema is invalid: some.path should NOT have additional properties
~/schemas$ 
```

which can be hard to track down in very large objects.

**What changes did you make?**

This changes it to include the name of the property that triggered the error, which was already available in the error object:

```CONSOLE
~/schemas$ ajv compile -m draft-04/hyper-schema -s foo
schema foo is invalid
error: schema is invalid: some.path should NOT have additional property "thisIsWrong"
~/schemas$ 
```

**Is there anything that requires more attention while reviewing?**

I could not find any tests that verified error message wording.  I looked by grepping the submodule for NOT since it appears in several messages including ones with interpolated variables.

(but the test suite and coverage are super-impressive)