### PR TITLE
docs: FAQ for additionalProperties error messages

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -25,6 +25,13 @@ No. There is no concurrency in JavaScript - it is single-threaded. While a valid
 No. In many cases there is a module responsible for the validation in the application, usually to load schemas and to process errors. This module is the right place to introduce any custom API. Convenience is a subjective thing, changing or extending API purely because of convenience would either break backward compatibility (even if it's done in a new major version it still complicates migration) or bloat API (making it more difficult to maintain).
 
 
+##### Why don't `"additionalProperties": false` errors display the property name?
+
+Doing this would create a precedent where validated data is used in error messages, creating a vulnerability (e.g., when ajv is used to validate API data/parameters and error messages are logged).
+
+Since the property name is already in the params object, in an application you can modify messages in any way you need. ajv-errors package will allow to modify messages as well - templating is [not there yet](https://github.com/epoberezkin/ajv-errors/issues/4), though.
+
+
 ## Additional properties inside compound keywords anyOf, oneOf, etc.
 
 See [#127](https://github.com/epoberezkin/ajv/issues/127), [#129](https://github.com/epoberezkin/ajv/issues/129), [#134](https://github.com/epoberezkin/ajv/issues/134), [#140](https://github.com/epoberezkin/ajv/issues/140), [#193](https://github.com/epoberezkin/ajv/issues/193), [#205](https://github.com/epoberezkin/ajv/issues/205), [#238](https://github.com/epoberezkin/ajv/issues/238), [#264](https://github.com/epoberezkin/ajv/issues/264).

--- a/README.md
+++ b/README.md
@@ -1175,6 +1175,7 @@ Properties of `params` object in errors depend on the keyword that failed valida
 - [ajv-i18n](https://github.com/epoberezkin/ajv-i18n) - internationalised error messages
 - [ajv-merge-patch](https://github.com/epoberezkin/ajv-merge-patch) - keywords $merge and $patch.
 - [ajv-keywords](https://github.com/epoberezkin/ajv-keywords) - several custom keywords that can be used with Ajv (typeof, instanceof, range, propertyNames)
+- [ajv-errors](https://github.com/epoberezkin/ajv-errors) - custom error messages for Ajv
 
 
 ## Some packages using Ajv


### PR DESCRIPTION
Also add ajv-errors to the list of related packages.

<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

Apparently putting the property name in the additionalProperties error message has been requested multiple times.  Perhaps it should be a FAQ?

**What changes did you make?**

Added your words from the PR with very minor tweaks to the FAQ.  That seemed to be the best place, unless error messages should get their own section instead of going in the error API section.

Also linked ajv-errors in the README as I had not realized it existed (although maybe it's omitted for being too new?  Happy to remove this if it's not wanted but the FAQ is)

**Is there anything that requires more attention while reviewing?**

Nope.