### PR TITLE
fix: use uri-js to resovle uri's

### DIFF
--- a/lib/compile/resolve.js
+++ b/lib/compile/resolve.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var url = require('url')
+var URI = require('uri-js')
   , equal = require('fast-deep-equal')
   , util = require('./util')
   , SchemaObject = require('./schema_obj')
@@ -67,7 +67,7 @@ function resolve(compile, root, ref) {
  */
 function resolveSchema(root, ref) {
   /* jshint validthis: true */
-  var p = url.parse(ref, false, true)
+  var p = URI.parse(ref)
     , refPath = _getFullPath(p)
     , baseId = getFullPath(this._getId(root.schema));
   if (refPath !== baseId) {
@@ -115,9 +115,9 @@ var PREVENT_SCOPE_CHANGE = util.toHash(['properties', 'patternProperties', 'enum
 /* @this Ajv */
 function getJsonPointer(parsedRef, baseId, schema, root) {
   /* jshint validthis: true */
-  parsedRef.hash = parsedRef.hash || '';
-  if (parsedRef.hash.slice(0,2) != '#/') return;
-  var parts = parsedRef.hash.split('/');
+  parsedRef.fragment = parsedRef.fragment || '';
+  if (parsedRef.fragment.slice(0,1) != '/') return;
+  var parts = parsedRef.fragment.split('/');
 
   for (var i = 1; i < parts.length; i++) {
     var part = parts[i];
@@ -206,14 +206,13 @@ function countKeys(schema) {
 
 function getFullPath(id, normalize) {
   if (normalize !== false) id = normalizeId(id);
-  var p = url.parse(id, false, true);
+  var p = URI.parse(id);
   return _getFullPath(p);
 }
 
 
 function _getFullPath(p) {
-  var protocolSeparator = p.protocol || p.href.slice(0,2) == '//' ? '//' : '';
-  return (p.protocol||'') + protocolSeparator + (p.host||'') + (p.path||'')  + '#';
+  return URI.serialize(p).split('#')[0] + '#';
 }
 
 
@@ -225,7 +224,7 @@ function normalizeId(id) {
 
 function resolveUrl(baseId, id) {
   id = normalizeId(id);
-  return url.resolve(baseId, id);
+  return URI.resolve(baseId, id);
 }
 
 
@@ -246,7 +245,7 @@ function resolveIds(schema) {
       fullPath += '/' + (typeof keyIndex == 'number' ? keyIndex : util.escapeFragment(keyIndex));
 
     if (typeof id == 'string') {
-      id = baseId = normalizeId(baseId ? url.resolve(baseId, id) : id);
+      id = baseId = normalizeId(baseId ? URI.resolve(baseId, id) : id);
 
       var refVal = self._refs[id];
       if (typeof refVal == 'string') refVal = self._refs[refVal];

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "co": "^4.6.0",
     "fast-deep-equal": "^1.0.0",
     "json-schema-traverse": "^0.3.0",
-    "json-stable-stringify": "^1.0.1"
+    "json-stable-stringify": "^1.0.1",
+    "uri-js": "^3.0.2"
   },
   "devDependencies": {
     "ajv-async": "^0.1.0",

--- a/spec/resolve.spec.js
+++ b/spec/resolve.spec.js
@@ -91,6 +91,35 @@ describe('resolve', function () {
         });
       });
     });
+
+    it('should resolve ids defined as urn\'s (issue #423)', function() {
+      var schema = {
+        "type": "object",
+        "properties": {
+          "ip1": {
+            "id": "urn:some:ip:prop",
+            "type": "string",
+            "format": "ipv4"
+          },
+          "ip2": {
+            "$ref": "urn:some:ip:prop"
+          }
+        },
+        "required": [
+          "ip1",
+          "ip2"
+        ]
+      };
+
+      var data = {
+        "ip1": "0.0.0.0",
+        "ip2": "0.0.0.0"
+      };
+      instances.forEach(function (ajv) {
+        var validate = ajv.compile(schema);
+        validate(data) .should.equal(true);
+      });
+    });
   });
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
KIf the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
This is a PR to resolve #423 

In the issue you mentioned that it should maybe be part of the JSON-schema-test-suite, but juding from the last comment on the issue, it might not be necessary.

**What changes did you make?**
Replaced usage of the node `url` package with `uri-js` for resolving url's and schema id's.

**Is there anything that requires more attention while reviewing?**
This changes a pretty central part of url resolving, but it seems like it should be covered by the tests.

Let me know if you'd like to do some other changes, if it need more tests, or implement it some other way.