### PR TITLE
Fix type definitions

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -110,8 +110,13 @@ declare namespace ajv {
       parentDataProperty?: string | number,
       rootData?: Object | Array<any>
     ): boolean | Thenable<any>;
-    errors?: Array<ErrorObject>;
-    schema?: Object | boolean;
+    schema: Object | boolean;
+    errors?: null | Array<ErrorObject>;
+    refs: Object;
+    refVal: Array<any>;
+    root: ValidateFunction | Object;
+    $async?: true;
+    source?: Object;
   }
 
   interface Options {

--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -149,7 +149,7 @@ declare namespace ajv {
     cache?: Object;
   }
 
-  type FormatValidator = string | RegExp | ((data: string) => boolean);
+  type FormatValidator = string | RegExp | ((data: string) => boolean | Thenable<any>);
 
   interface FormatDefinition {
     validate: FormatValidator;

--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -1,6 +1,9 @@
 declare var ajv: { 
   (options?: ajv.Options): ajv.Ajv;
   new (options?: ajv.Options): ajv.Ajv;
+  ValidationError: ValidationError;
+  MissingRefError: MissingRefError;
+  $dataMetaSchema: Object;
 }
 
 declare namespace ajv {
@@ -296,6 +299,24 @@ declare namespace ajv {
   interface EnumParams {
     allowedValues: Array<any>;
   }
+}
+
+declare class ValidationError extends Error {
+  constructor(errors: Array<ajv.ErrorObject>);
+
+  message: string;
+  errors: Array<ajv.ErrorObject>;
+  ajv: true;
+  validation: true;
+}
+
+declare class MissingRefError extends Error {
+  constructor(baseId: string, ref: string, message?: string);
+  static message: (baseId: string, ref: string) => string;
+
+  message: string;
+  missingRef: string;
+  missingSchema: string;
 }
 
 export = ajv;


### PR DESCRIPTION
@blakeembrey can you have a look please, particularly at https://github.com/epoberezkin/ajv/pull/592/commits/28386786fd9f6229652829a673745a1563e097c7 ?

If that's ok, then is it maybe ok to replace `declare var ajv` with `declare class Ajv` (and drop function form without new) in the next major version?