### PR TITLE
Update draft-06 meta-schema

### DIFF
--- a/lib/refs/json-schema-draft-06.json
+++ b/lib/refs/json-schema-draft-06.json
@@ -57,6 +57,10 @@
             "type": "string"
         },
         "default": {},
+        "examples": {
+            "type": "array",
+            "items": {}
+        },
         "multipleOf": {
             "type": "number",
             "exclusiveMinimum": 0


### PR DESCRIPTION
See json-schema-org/json-schema-spec#481 - the previously-published meta-schema was missing a definition for the "examples" array.
