### PR TITLE
Add method chaining to all add* and remove* methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,17 @@ if (!valid) console.log(ajv.errorsText());
 // ...
 ```
 
+or with method chaining
+
+```javascript
+// ...
+var validate = new Ajv()
+    .addSchema(cardSchema)
+    .getSchema('/card#/definitions/organisation');
+var valid = validate(data);
+// ...
+```
+
 See [API](#api) and [Options](#options) for more details.
 
 Ajv compiles schemas to functions and caches them in all cases (using schema serialized with [fast-json-stable-stringify](https://github.com/epoberezkin/fast-json-stable-stringify) or a custom function as a key), so that the next time the same schema is used (not necessarily the same object instance) it won't be compiled again.

--- a/README.md
+++ b/README.md
@@ -914,7 +914,7 @@ __Please note__: every time this method is called the errors are overwritten so 
 If the schema is asynchronous (has `$async` keyword on the top level) this method returns a Promise. See [Asynchronous validation](#asynchronous-validation).
 
 
-##### .addSchema(Array&lt;Object&gt;|Object schema [, String key])
+##### .addSchema(Array&lt;Object&gt;|Object schema [, String key]) -&gt; Ajv
 
 Add schema(s) to validator instance. This method does not compile schemas (but it still validates them). Because of that dependencies can be added in any order and circular dependencies are supported. It also prevents unnecessary compilation of schemas that are containers for other schemas but not used as a whole.
 
@@ -929,8 +929,14 @@ Although `addSchema` does not compile schemas, explicit compilation is not requi
 
 By default the schema is validated against meta-schema before it is added, and if the schema does not pass validation the exception is thrown. This behaviour is controlled by `validateSchema` option.
 
+__Please note__: Ajv uses the [method chaining syntax](https://en.wikipedia.org/wiki/Method_chaining) for all methods with the prefix `add*` and `remove*`.
+This allows you to do nice things like the following.
 
-##### .addMetaSchema(Array&lt;Object&gt;|Object schema [, String key])
+```javascript
+var validate = new Ajv().addSchema(schema).addFormat(name, regex).getSchema(uri);
+```  
+
+##### .addMetaSchema(Array&lt;Object&gt;|Object schema [, String key]) -&gt; Ajv
 
 Adds meta schema(s) that can be used to validate other schemas. That function should be used instead of `addSchema` because there may be instance options that would compile a meta schema incorrectly (at the moment it is `removeAdditional` option).
 
@@ -955,7 +961,7 @@ Errors will be available at `ajv.errors`.
 Retrieve compiled schema previously added with `addSchema` by the key passed to `addSchema` or by its full reference (id). The returned validating function has `schema` property with the reference to the original schema.
 
 
-##### .removeSchema([Object schema|String key|String ref|RegExp pattern])
+##### .removeSchema([Object schema|String key|String ref|RegExp pattern]) -&gt; Ajv
 
 Remove added/cached schema. Even if schema is referenced by other schemas it can be safely removed as dependent schemas have local references.
 
@@ -968,7 +974,7 @@ Schema can be removed using:
 If no parameter is passed all schemas but meta-schemas will be removed and the cache will be cleared.
 
 
-##### <a name="api-addformat"></a>.addFormat(String name, String|RegExp|Function|Object format)
+##### <a name="api-addformat"></a>.addFormat(String name, String|RegExp|Function|Object format) -&gt; Ajv
 
 Add custom format to validate strings or numbers. It can also be used to replace pre-defined formats for Ajv instance.
 
@@ -986,7 +992,7 @@ If object is passed it should have properties `validate`, `compare` and `async`:
 Custom formats can be also added via `formats` option.
 
 
-##### <a name="api-addkeyword"></a>.addKeyword(String keyword, Object definition)
+##### <a name="api-addkeyword"></a>.addKeyword(String keyword, Object definition) -&gt; Ajv
 
 Add custom validation keyword to Ajv instance.
 
@@ -1027,7 +1033,7 @@ See [Defining custom keywords](#defining-custom-keywords) for more details.
 Returns custom keyword definition, `true` for pre-defined keywords and `false` if the keyword is unknown.
 
 
-##### .removeKeyword(String keyword)
+##### .removeKeyword(String keyword) -&gt; Ajv
 
 Removes custom or pre-defined keyword so you can redefine them.
 

--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -36,15 +36,17 @@ declare namespace ajv {
     * Adds schema to the instance.
     * @param {Object|Array} schema schema or array of schemas. If array is passed, `key` and other parameters will be ignored.
     * @param {String} key Optional schema key. Can be passed to `validate` method instead of schema object or id/ref. One schema per instance can have empty `id` and `key`.
+    * @return {Ajv} this for method chaining
     */
-    addSchema(schema: Array<Object> | Object, key?: string): void;
+    addSchema(schema: Array<Object> | Object, key?: string): Ajv;
     /**
     * Add schema that will be used to validate other schemas
     * options in META_IGNORE_OPTIONS are alway set to false
     * @param {Object} schema schema object
     * @param {String} key optional schema key
+    * @return {Ajv} this for method chaining
     */
-    addMetaSchema(schema: Object, key?: string): void;
+    addMetaSchema(schema: Object, key?: string): Ajv;
     /**
     * Validate schema
     * @param {Object|Boolean} schema schema to validate
@@ -63,21 +65,24 @@ declare namespace ajv {
     * If RegExp is passed all schemas with key/id matching pattern but meta-schemas are removed.
     * Even if schema is referenced by other schemas it still can be removed as other schemas have local references.
     * @param  {String|Object|RegExp|Boolean} schemaKeyRef key, ref, pattern to match key/ref or schema object
+    * @return {Ajv} this for method chaining
     */
-    removeSchema(schemaKeyRef?: Object | string | RegExp | boolean): void;
+    removeSchema(schemaKeyRef?: Object | string | RegExp | boolean): Ajv;
     /**
     * Add custom format
     * @param {String} name format name
     * @param {String|RegExp|Function} format string is converted to RegExp; function should return boolean (true when valid)
+    * @return {Ajv} this for method chaining
     */
-    addFormat(name: string, format: FormatValidator | FormatDefinition): void;
+    addFormat(name: string, format: FormatValidator | FormatDefinition): Ajv;
     /**
     * Define custom keyword
     * @this  Ajv
     * @param {String} keyword custom keyword, should be a valid identifier, should be different from all standard, custom and macro keywords.
     * @param {Object} definition keyword definition object with properties `type` (type(s) which the keyword applies to), `validate` or `compile`.
+    * @return {Ajv} this for method chaining
     */
-    addKeyword(keyword: string, definition: KeywordDefinition): void;
+    addKeyword(keyword: string, definition: KeywordDefinition): Ajv;
     /**
     * Get keyword definition
     * @this  Ajv
@@ -89,8 +94,9 @@ declare namespace ajv {
     * Remove keyword
     * @this  Ajv
     * @param {String} keyword pre-defined or custom keyword.
+    * @return {Ajv} this for method chaining
     */
-    removeKeyword(keyword: string): void;
+    removeKeyword(keyword: string): Ajv;
     /**
     * Convert array of error message objects to string
     * @param  {Array<Object>} errors optional array of validation errors, if not passed errors from the instance are used.

--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -126,6 +126,7 @@ function compile(schema, _meta) {
  * @param {String} key Optional schema key. Can be passed to `validate` method instead of schema object or id/ref. One schema per instance can have empty `id` and `key`.
  * @param {Boolean} _skipValidation true to skip schema validation. Used internally, option validateSchema should be used instead.
  * @param {Boolean} _meta true if schema is a meta-schema. Used internally, addMetaSchema should be used instead.
+ * @return {Ajv} this for method chaining
  */
 function addSchema(schema, key, _skipValidation, _meta) {
   if (Array.isArray(schema)){
@@ -138,6 +139,7 @@ function addSchema(schema, key, _skipValidation, _meta) {
   key = resolve.normalizeId(key || id);
   checkUnique(this, key);
   this._schemas[key] = this._addSchema(schema, _skipValidation, _meta, true);
+  return this;
 }
 
 
@@ -148,9 +150,11 @@ function addSchema(schema, key, _skipValidation, _meta) {
  * @param {Object} schema schema object
  * @param {String} key optional schema key
  * @param {Boolean} skipValidation true to skip schema validation, can be used to override validateSchema option for meta-schema
+ * @return {Ajv} this for method chaining
  */
 function addMetaSchema(schema, key, skipValidation) {
   this.addSchema(schema, key, skipValidation, true);
+  return this;
 }
 
 
@@ -247,25 +251,26 @@ function _getSchemaObj(self, keyRef) {
  * Even if schema is referenced by other schemas it still can be removed as other schemas have local references.
  * @this   Ajv
  * @param  {String|Object|RegExp} schemaKeyRef key, ref, pattern to match key/ref or schema object
+ * @return {Ajv} this for method chaining
  */
 function removeSchema(schemaKeyRef) {
   if (schemaKeyRef instanceof RegExp) {
     _removeAllSchemas(this, this._schemas, schemaKeyRef);
     _removeAllSchemas(this, this._refs, schemaKeyRef);
-    return;
+    return this;
   }
   switch (typeof schemaKeyRef) {
     case 'undefined':
       _removeAllSchemas(this, this._schemas);
       _removeAllSchemas(this, this._refs);
       this._cache.clear();
-      return;
+      return this;
     case 'string':
       var schemaObj = _getSchemaObj(this, schemaKeyRef);
       if (schemaObj) this._cache.del(schemaObj.cacheKey);
       delete this._schemas[schemaKeyRef];
       delete this._refs[schemaKeyRef];
-      return;
+      return this;
     case 'object':
       var serialize = this._opts.serialize;
       var cacheKey = serialize ? serialize(schemaKeyRef) : schemaKeyRef;
@@ -277,6 +282,7 @@ function removeSchema(schemaKeyRef) {
         delete this._refs[id];
       }
   }
+  return this;
 }
 
 
@@ -427,10 +433,12 @@ function errorsText(errors, options) {
  * @this   Ajv
  * @param {String} name format name
  * @param {String|RegExp|Function} format string is converted to RegExp; function should return boolean (true when valid)
+ * @return {Ajv} this for method chaining
  */
 function addFormat(name, format) {
   if (typeof format == 'string') format = new RegExp(format);
   this._formats[name] = format;
+  return this;
 }
 
 

--- a/lib/keyword.js
+++ b/lib/keyword.js
@@ -14,6 +14,7 @@ module.exports = {
  * @this  Ajv
  * @param {String} keyword custom keyword, should be unique (including different from all standard, custom and macro keywords).
  * @param {Object} definition keyword definition object with properties `type` (type(s) which the keyword applies to), `validate` or `compile`.
+ * @return {Ajv} this for method chaining
  */
 function addKeyword(keyword, definition) {
   /* jshint validthis: true */
@@ -91,6 +92,8 @@ function addKeyword(keyword, definition) {
   function checkDataType(dataType) {
     if (!RULES.types[dataType]) throw new Error('Unknown type ' + dataType);
   }
+
+  return this;
 }
 
 
@@ -111,6 +114,7 @@ function getKeyword(keyword) {
  * Remove keyword
  * @this  Ajv
  * @param {String} keyword pre-defined or custom keyword.
+ * @return {Ajv} this for method chaining
  */
 function removeKeyword(keyword) {
   /* jshint validthis: true */
@@ -127,4 +131,5 @@ function removeKeyword(keyword) {
       }
     }
   }
+  return this;
 }

--- a/spec/ajv.spec.js
+++ b/spec/ajv.spec.js
@@ -119,8 +119,7 @@ describe('Ajv', function () {
 
   describe('addSchema method', function() {
     it('should add and compile schema with key', function() {
-      var res = ajv.addSchema({ type: 'integer' }, 'int');
-      should.not.exist(res);
+      ajv.addSchema({ type: 'integer' }, 'int');
       var validate = ajv.getSchema('int');
       validate .should.be.a('function');
 
@@ -216,6 +215,11 @@ describe('Ajv', function () {
       } catch(e) {
         e.message .should.equal('schema id must be string');
       }
+    });
+
+    it('should return instance of itself', function() {
+      var res = ajv.addSchema({ type: 'integer' }, 'int');
+      res.should.equal(ajv);
     });
   });
 
@@ -382,6 +386,13 @@ describe('Ajv', function () {
       should.not.exist(ajv._cache.get(str2));
       ajv._cache.get(str3) .should.be.an('object');
     });
+
+    it('should return instance of itself', function() {
+      var res = ajv
+        .addSchema({ type: 'integer' }, 'int')
+        .removeSchema('int');
+      res.should.equal(ajv);
+    });
   });
 
 
@@ -406,6 +417,11 @@ describe('Ajv', function () {
         validate: function (str) { return /^[a-z_$][a-z0-9_$]*$/i.test(str); },
       });
       testFormat();
+    });
+
+    it('should return instance of itself', function() {
+      var res = ajv.addFormat('identifier', /^[a-z_$][a-z0-9_$]*$/i);
+      res.should.equal(ajv);
     });
 
     function testFormat() {

--- a/spec/custom.spec.js
+++ b/spec/custom.spec.js
@@ -939,6 +939,13 @@ describe('Custom keywords', function () {
       });
     });
 
+    it('should return instance of itself', function() {
+      var res = ajv.addKeyword('any', {
+        validate: function() { return true; }
+      });
+      res.should.equal(ajv);
+    });
+
     it('should throw if unknown type is passed', function() {
       should.throw(function() {
         addKeyword('custom1', 'wrongtype');
@@ -1040,6 +1047,15 @@ describe('Custom keywords', function () {
       validate(0) .should.equal(false);
       validate(1) .should.equal(false);
       validate(2) .should.equal(true);
+    });
+
+    it('should return instance of itself', function() {
+      var res = ajv
+        .addKeyword('any', {
+          validate: function() { return true; }
+        })
+        .removeKeyword('any');
+      res.should.equal(ajv);
     });
   });
 


### PR DESCRIPTION
This pull request add method chaining to all add* and remove* methods.

According to issue #625 this enables more compact code like

```
new Ajv().addSchema(mySchema).validate(schema, data)
```
I am still thinking about, how to get rid of the `add` ;)

**What changes did you make?**

I add `return this` to 6 methods: `addSchema`, `addMetaSchema`,  `removeSchema`, `addFormat`, `addKeyword`, `removeKeyword`.
updated jsdoc and the typescript definitions. 

I added tests for the methods with an extra method test, except for `addMetaSchema`, because i couldn't find a good place for the test.

I hope i didn't oversee anything, if so let me know, would be great if it get merged  

