### PR TITLE
Make addSchema chainable when submitting an array of schemas.

### DIFF
--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -131,7 +131,7 @@ function compile(schema, _meta) {
 function addSchema(schema, key, _skipValidation, _meta) {
   if (Array.isArray(schema)){
     for (var i=0; i<schema.length; i++) this.addSchema(schema[i], undefined, _skipValidation, _meta);
-    return;
+    return this;
   }
   var id = this._getId(schema);
   if (id !== undefined && typeof id != 'string')


### PR DESCRIPTION
**What issue does this pull request resolve?**
#625 `addSchema` is not chainable if an array of schemas is provided.

**What changes did you make?**
I changed `return;` to `return this;` when processing an array of schemas.

**Is there anything that requires more attention while reviewing?**
Not that I can see.