### PR TITLE
feat: ES module default export interop

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -349,4 +349,4 @@ declare class MissingRefError extends Error {
   missingSchema: string;
 }
 
-export = ajv;
+export default ajv;

--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -11,6 +11,7 @@ var compileSchema = require('./compile')
   , util = require('./compile/util');
 
 module.exports = Ajv;
+module.exports.default = Ajv;
 
 Ajv.prototype.validate = validate;
 Ajv.prototype.compile = compile;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

#687 


**What changes did you make?**

- Added a `default` property on the package top-level module.
- Changed the TypeScript definition to use an ES module default export. This will require TypeScript consumers to change `import Ajv = require('ajv')` to `import Ajx from 'ajv'`.

**Is there anything that requires more attention while reviewing?**


