### PR TITLE
Fix typescript defs to allow numeric validators.

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -1,4 +1,4 @@
-declare var ajv: { 
+declare var ajv: {
   (options?: ajv.Options): ajv.Ajv;
   new (options?: ajv.Options): ajv.Ajv;
   ValidationError: ValidationError;
@@ -160,12 +160,23 @@ declare namespace ajv {
   }
 
   type FormatValidator = string | RegExp | ((data: string) => boolean | PromiseLike<any>);
+  type NumberFormatValidator = ((data: number) => boolean | PromiseLike<any>);
 
-  interface FormatDefinition {
-    validate: FormatValidator;
-    compare: (data1: string, data2: string) => number;
+  interface NumberFormatDefinition {
+    type: "number",
+    validate: NumberFormatValidator;
+    compare?: (data1: number, data2: number) => number;
     async?: boolean;
   }
+
+  interface StringFormatDefinition {
+    type?: "string",
+    validate: FormatValidator;
+    compare?: (data1: string, data2: string) => number;
+    async?: boolean;
+  }
+
+  type FormatDefinition = NumberFormatDefinition | StringFormatDefinition;
 
   interface KeywordDefinition {
     type?: string | Array<string>;


### PR DESCRIPTION
**What issue does this pull request resolve?**

https://github.com/epoberezkin/ajv/issues/760

**What changes did you make?**

I fixed it so `FormatDefinition` is now split into `StringFormatDefinition` and `NumberFormatDefinition`.  `NumberFormatDefinition` requires the "type" field, and requires it to be "number", whereas in StringFormatDefinition "type" is optional, but if there it has to be "string".

The upshot of this is, if you don't specify "type" or you specify it as "string", then you must supply a `validate` function that takes a string as the first parameter.  If you specify "type" as "number", then you must specify a `validate` function that takes a number.  Same for `compare`.

**Is there anything that requires more attention while reviewing?**

No.