### PR TITLE
passContext in recursive $ref

### DIFF
--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -363,9 +363,11 @@ function _compile(schemaObj, root) {
   return v;
 
 
+  /* @this   {*} - custom context, see passContext option */
   function callValidate() {
+    /* jshint validthis: true */
     var _validate = schemaObj.validate;
-    var result = _validate.apply(null, arguments);
+    var result = _validate.apply(this, arguments);
     callValidate.errors = _validate.errors;
     return result;
   }

--- a/lib/compile/index.js
+++ b/lib/compile/index.js
@@ -69,9 +69,11 @@ function compile(schema, root, localRefs, baseId) {
     endCompiling.call(this, schema, root, baseId);
   }
 
+  /* @this   {*} - custom context, see passContext option */
   function callValidate() {
+    /* jshint validthis: true */
     var validate = compilation.validate;
-    var result = validate.apply(null, arguments);
+    var result = validate.apply(this, arguments);
     callValidate.errors = validate.errors;
     return result;
   }

--- a/spec/issues.spec.js
+++ b/spec/issues.spec.js
@@ -703,3 +703,113 @@ describe('property __proto__ should be removed with removeAdditional option, iss
     Object.keys(data.obj) .should.eql(['a', 'b']);
   });
 });
+
+
+describe('issue #768, fix passContext in recursive $ref', function() {
+  var ajv, contexts;
+
+  beforeEach(function() {
+    contexts = [];
+  });
+
+  describe('passContext = true', function() {
+    it('should pass this value as context to custom keyword validation function', function() {
+      var validate = getValidate(true);
+      var self = {};
+      validate.call(self, { bar: 'a', baz: { bar: 'b' } });
+      contexts .should.have.length(2);
+      contexts.forEach(function(ctx) {
+        ctx .should.equal(self);
+      });
+    });
+  });
+
+  describe('passContext = false', function() {
+    it('should pass ajv instance as context to custom keyword validation function', function() {
+      var validate = getValidate(false);
+      validate({ bar: 'a', baz: { bar: 'b' } });
+      contexts .should.have.length(2);
+      contexts.forEach(function(ctx) {
+        ctx .should.equal(ajv);
+      });
+    });
+  });
+
+  describe('ref is fragment and passContext = true', function() {
+    it('should pass this value as context to custom keyword validation function', function() {
+      var validate = getValidateFragments(true);
+      var self = {};
+      validate.call(self, { baz: { corge: 'a', quux: { baz: { corge: 'b' } } } });
+      contexts .should.have.length(2);
+      contexts.forEach(function(ctx) {
+        ctx .should.equal(self);
+      });
+    });
+  });
+
+  describe('ref is fragment and passContext = false', function() {
+    it('should pass ajv instance as context to custom keyword validation function', function() {
+      var validate = getValidateFragments(false);
+      validate({ baz: { corge: 'a', quux: { baz: { corge: 'b' } } } });
+      contexts .should.have.length(2);
+      contexts.forEach(function(ctx) {
+        ctx .should.equal(ajv);
+      });
+    });
+  });
+
+  function getValidate(passContext) {
+    ajv = new Ajv({ passContext: passContext });
+    ajv.addKeyword('testValidate', { validate: storeContext });
+
+    var schema = {
+      "$id" : "foo",
+      "type": "object",
+      "required": ["bar"],
+      "properties": {
+        "bar": { "testValidate": true },
+        "baz": {
+          "$ref": "foo"
+        }
+      }
+    };
+
+    return ajv.compile(schema);
+  }
+
+
+  function getValidateFragments(passContext) {
+    ajv = new Ajv({ passContext: passContext });
+    ajv.addKeyword('testValidate', { validate: storeContext });
+
+    ajv.addSchema({
+      "$id" : "foo",
+      "definitions": {
+        "bar": {
+          "properties": {
+            "baz": {
+              "$ref": "boo"
+            }
+          }
+        }
+      }
+    });
+
+    ajv.addSchema({
+      "$id" : "boo",
+      "type": "object",
+      "required": ["corge"],
+      "properties": {
+        "quux": { "$ref": "foo#/definitions/bar" },
+        "corge": { "testValidate": true }
+      }
+    });
+
+    return ajv.compile({ "$ref": "foo#/definitions/bar" });
+  }
+
+  function storeContext() {
+    contexts.push(this);
+    return true;
+  }
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
Fix #768 

**What changes did you make?**
`.apply(null, arguments)` -> `.apply(this, arguments)` in 2 `callValidate` functions to pass custom context.
I'm not sure which are all cases when `callValidate`s are triggered. I added 2 tests. First triggers `callValidate` from `/lib/ajv.js` and second from `/lib/compile/index.js` and in both this tests $ref is recursive.

**Is there anything that requires more attention while reviewing?**
I made changes in `ref.jst`. My goal is, now and in future, `callValidate` always to be called with `this` as `undefined` when `passContext` is `false`. (Always `callValidate()` but not `someObj.callValidate()`)

Straight ahead way is to change 
```javascript
{{## def._validateRef:_v:
  {{? it.opts.passContext }}
    {{=_v}}.call(this,
  {{??}}
    {{=_v}}(
  {{?}}
    {{=$data}}, {{# def.dataPath }}{{# def.passParentData }}, rootData)
#}}
```
to
```javascript
{{## def._validateRef:_v:
  {{? it.opts.passContext }}
    {{=_v}}.call(this,
  {{??}}
    {{=_v}}.call(undefined,
  {{?}}
    {{=$data}}, {{# def.dataPath }}{{# def.passParentData }}, rootData)
#}}
```

but `fn.call(undefined, ...)` is slower than `fn()`.
Faster method that I implemented is to create aditional var
```javascript
var $refCodeFn = {{= $refCode }};
...
$refCodeFn();
```
in case of `$refCode` = `fn` or `$refCode` = `someObj.fn` always will be passed `this` as `undefined`, but not `someObj`.

On the other hand `{{=_v}}.call(undefined,` is more readable and easier to understand.

Thank You!



 