### PR TITLE
support resolving internal refs from macro keywords

### DIFF
--- a/lib/compile/resolve.js
+++ b/lib/compile/resolve.js
@@ -70,7 +70,7 @@ function resolveSchema(root, ref) {
   var p = URI.parse(ref)
     , refPath = _getFullPath(p)
     , baseId = getFullPath(this._getId(root.schema));
-  if (refPath !== baseId) {
+  if (Object.keys(root.schema).length === 0 || refPath !== baseId) {
     var id = normalizeId(refPath);
     var refVal = this._refs[id];
     if (typeof refVal == 'string') {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
As described in epoberezkin/ajv-merge-patch/issues/24, macro keywords cannot resolve internal refs when the schema lacks id.

**What changes did you make?**
I added an instanceof check during fragment resolution to find internal refs during compilation (when schema is not a SchemaObject).

**Is there anything that requires more attention while reviewing?**
Not that I know of... I added a test case to demonstrate what did not work previously.