### PR TITLE
Upgrade uri-js dependency to the ES5 fixed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "fast-deep-equal": "^2.0.1",
     "fast-json-stable-stringify": "^2.0.0",
     "json-schema-traverse": "^0.4.1",
-    "uri-js": "^4.2.1"
+    "uri-js": "^4.2.2"
   },
   "devDependencies": {
     "ajv-async": "^1.0.0",


### PR DESCRIPTION
**Issue**

#833

**What issue does this pull request resolve?**

Updates the dependency to uri-js to version 4.2.2 which fixes the esnext/es5 issue and therefore makes ajv compatible with IE11 again. For more info about this issue see this issue over at uri-js: https://github.com/garycourt/uri-js/issues/24

**What changes did you make?**

Updated the package dependency of uri-js from 4.2.1 (broken ES5) to 4.2.2 (fixed ES5).

**Is there anything that requires more attention while reviewing?**

no