### PR TITLE
Adding logger to typescript Options declaration.

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -107,6 +107,12 @@ declare namespace ajv {
     errors?: Array<ErrorObject>;
   }
 
+  interface CustomLogger {
+    log(...args: any[]): any;
+    warn(...args: any[]): any;
+    error(...args: any[]): any;
+  }
+
   interface ValidateFunction {
     (
       data: any,
@@ -157,6 +163,7 @@ declare namespace ajv {
     sourceCode?: boolean;
     processCode?: (code: string) => string;
     cache?: object;
+    logger?: CustomLogger | false
   }
 
   type FormatValidator = string | RegExp | ((data: string) => boolean | PromiseLike<any>);


### PR DESCRIPTION
**What issue does this pull request resolve?**
Logger wasn't in the `Ajv.Options` declaration, causing my code to break when moving to typescript.

**What changes did you make?**
Updated `lib/ajv.d.ts`

**Is there anything that requires more attention while reviewing?**
Is there a specific interface for the added `CustomLogger` declaration?