### PR TITLE
Add Typewriter to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1256,6 +1256,7 @@ If you have published a useful plugin please submit a PR to add it to the next s
 - [addons-linter](https://github.com/mozilla/addons-linter) - Mozilla Add-ons Linter
 - [gh-pages-generator](https://github.com/epoberezkin/gh-pages-generator) - multi-page site generator converting markdown files to GitHub pages
 - [ESLint](https://github.com/eslint/eslint) - the pluggable linting utility for JavaScript and JSX
+- [Typewriter](https://github.com/segmentio/typewriter) - A compiler for generating strongly typed analytics clients from a tracking spec
 
 
 ## Tests


### PR DESCRIPTION
**What changes did you make?**

Typewriter uses AJV to perform validation in our Javascript-based clients. This PR adds it to the list of packages utilizing AJV. 

https://github.com/segmentio/typewriter

For example: https://github.com/segmentio/typewriter/blob/master/examples/gen-js/js/analytics/generated/index.js