### PR TITLE
fix(issue#897): Wrong results with {removeAdditional: 'failing', allErrors: false} and additionalProperties as failing schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,7 +1112,7 @@ Defaults:
   - `false` (default) - not to remove additional properties
   - `"all"` - all additional properties are removed, regardless of `additionalProperties` keyword in schema (and no validation is made for them).
   - `true` - only additional properties with `additionalProperties` keyword equal to `false` are removed.
-  - `"failing"` - additional properties that fail schema validation will be removed (where `additionalProperties` keyword is `false` or schema).
+  - `"failing"` - additional properties that fail schema validation will be removed (where `additionalProperties` keyword is `false` or schema). Note that for invalid data with `allErrors: false` removing additional properties is not guaranteed.
 - _useDefaults_: replace missing properties and items with the values from corresponding `default` keywords. Default behaviour is to ignore `default` keywords. This option is not used if schema is added with `addMetaSchema` method. See examples in [Assigning defaults](#assigning-defaults). Option values:
   - `false` (default) - do not use defaults
   - `true` - insert defaults by value (safer and slower, object literal is used).

--- a/lib/dot/properties.jst
+++ b/lib/dot/properties.jst
@@ -107,11 +107,12 @@ var {{=$nextValid}} = true;
 
           if (!{{=$nextValid}}) {
             errors = {{=$errs}};
-            if (validate.errors !== null) {
-              if (errors) validate.errors.length = errors;
-              else validate.errors = null;
+            if (vErrors !== null) {
+              if (errors) vErrors.length = errors;
+              else vErrors = null;
             }
             delete {{=$data}}[{{=$key}}];
+            {{=$nextValid}} = true;
           }
 
           {{# def.resetCompositeRule }}


### PR DESCRIPTION
**What issue does this pull request resolve?**
Fixes [897](https://github.com/epoberezkin/ajv/issues/897)

**What changes did you make?**
1. When additional property is removed, then `nextValid` is reset to `true`.
2. Used common `vErrors` variable instead of `validate.errors`.
3. Added in documentation, that is not guaranteed removing additional properties for invalid data with `allErrors: false`.
4. Added some tests.

**Is there anything that requires more attention while reviewing?**
I work with the source code of the project for the first time, so I'm not sure that I understood everything. Please check everything carefully, maybe add tests.