### PR TITLE
Properly fix type definition for ValidationError and MissingRefError (#568)

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -1,12 +1,36 @@
 declare var ajv: {
   (options?: ajv.Options): ajv.Ajv;
-  new (options?: ajv.Options): ajv.Ajv;
-  ValidationError: ValidationError;
-  MissingRefError: MissingRefError;
+  new(options?: ajv.Options): ajv.Ajv;
+  ValidationError: typeof AjvErrors.ValidationError;
+  MissingRefError: typeof AjvErrors.MissingRefError;
   $dataMetaSchema: object;
 }
 
+declare namespace AjvErrors {
+  class ValidationError extends Error {
+    constructor(errors: Array<ajv.ErrorObject>);
+
+    message: string;
+    errors: Array<ajv.ErrorObject>;
+    ajv: true;
+    validation: true;
+  }
+
+  class MissingRefError extends Error {
+    constructor(baseId: string, ref: string, message?: string);
+    static message: (baseId: string, ref: string) => string;
+
+    message: string;
+    missingRef: string;
+    missingSchema: string;
+  }
+}
+
 declare namespace ajv {
+  type ValidationError = AjvErrors.ValidationError;
+
+  type MissingRefError = AjvErrors.MissingRefError;
+
   interface Ajv {
     /**
     * Validate data using schema
@@ -15,7 +39,7 @@ declare namespace ajv {
     * @param  {Any} data to be validated
     * @return {Boolean} validation result. Errors from the last validation will be available in `ajv.errors` (and also in compiled schema: `schema.errors`).
     */
-    validate(schemaKeyRef: object | string | boolean, data: any): boolean | PromiseLike<any>;
+    validate<T>(schemaKeyRef: object | string | boolean, data: T): boolean | PromiseLike<T>;
     /**
     * Create validating function for passed schema.
     * @param  {object|Boolean} schema schema object
@@ -114,13 +138,13 @@ declare namespace ajv {
   }
 
   interface ValidateFunction {
-    (
-      data: any,
+    <T>(
+      data: T,
       dataPath?: string,
       parentData?: object | Array<any>,
       parentDataProperty?: string | number,
       rootData?: object | Array<any>
-    ): boolean | PromiseLike<any>;
+    ): boolean | PromiseLike<T>;
     schema?: object | boolean;
     errors?: null | Array<ErrorObject>;
     refs?: object;
@@ -268,11 +292,11 @@ declare namespace ajv {
   }
 
   type ErrorParameters = RefParams | LimitParams | AdditionalPropertiesParams |
-                          DependenciesParams | FormatParams | ComparisonParams |
-                          MultipleOfParams | PatternParams | RequiredParams |
-                          TypeParams | UniqueItemsParams | CustomParams |
-                          PatternRequiredParams | PropertyNamesParams |
-                          IfParams | SwitchParams | NoParams | EnumParams;
+    DependenciesParams | FormatParams | ComparisonParams |
+    MultipleOfParams | PatternParams | RequiredParams |
+    TypeParams | UniqueItemsParams | CustomParams |
+    PatternRequiredParams | PropertyNamesParams |
+    IfParams | SwitchParams | NoParams | EnumParams;
 
   interface RefParams {
     ref: string;
@@ -344,29 +368,11 @@ declare namespace ajv {
     caseIndex: number;
   }
 
-  interface NoParams {}
+  interface NoParams { }
 
   interface EnumParams {
     allowedValues: Array<any>;
   }
-}
-
-declare class ValidationError extends Error {
-  constructor(errors: Array<ajv.ErrorObject>);
-
-  message: string;
-  errors: Array<ajv.ErrorObject>;
-  ajv: true;
-  validation: true;
-}
-
-declare class MissingRefError extends Error {
-  constructor(baseId: string, ref: string, message?: string);
-  static message: (baseId: string, ref: string) => string;
-
-  message: string;
-  missingRef: string;
-  missingSchema: string;
 }
 
 export = ajv;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test-fast": "AJV_FAST_TEST=true npm run test-spec",
     "test-debug": "mocha spec/*.spec.js --debug-brk -R spec",
     "test-cov": "nyc npm run test-spec",
-    "test-ts": "tsc --target ES5 --noImplicitAny lib/ajv.d.ts",
+    "test-ts": "tsc --target ES5 --noImplicitAny --noEmit spec/typescript/index.ts",
     "bundle": "del-cli dist && node ./scripts/bundle.js . Ajv pure_getters",
     "bundle-beautify": "node ./scripts/bundle.js js-beautify",
     "build": "del-cli lib/dotjs/*.js '!lib/dotjs/index.js' && node scripts/compile-dots.js",

--- a/spec/typescript/index.ts
+++ b/spec/typescript/index.ts
@@ -1,0 +1,60 @@
+import ajv = require("../..");
+
+// #region new()
+const options: ajv.Options = {
+    verbose: true,
+};
+
+let instance: ajv.Ajv;
+
+instance = ajv();
+instance = ajv(options);
+
+instance = new ajv();
+instance = new ajv(options);
+// #endregion new()
+
+// #region validate()
+let data = {
+    foo: 42,
+}
+
+let result = instance.validate("", data);
+
+if (typeof result === "boolean") {
+    // sync
+    console.log(result);
+} else {
+    // async
+    result.then(value => {
+        data = value;
+    });
+}
+// #endregion validate()
+
+// #region compile()
+const validator = instance.compile({});
+result = validator(data);
+
+if (typeof result === "boolean") {
+    // sync
+    console.log(result);
+} else {
+    // async
+    result.then(value => {
+        data = value;
+    });
+}
+// #endregion compile()
+
+// #region errors
+const validationError: ajv.ValidationError = new ajv.ValidationError([]);
+validationError instanceof ajv.ValidationError;
+validationError.ajv === true;
+validationError.validation === true;
+
+ajv.MissingRefError.message("", "");
+const missingRefError: ajv.MissingRefError = new ajv.MissingRefError("", "", "");
+missingRefError instanceof ajv.MissingRefError;
+missingRefError.missingRef;
+// #endregion


### PR DESCRIPTION
**What issue does this pull request resolve?**

#568

**What changes did you make?**

https://github.com/epoberezkin/ajv/issues/568#issuecomment-446890570

**Is there anything that requires more attention while reviewing?**

replaces #868

Added a generic argument for `validate` and `ValidateFunction`, and some formatting changes.