### PR TITLE
Add ability to track all required fields

### DIFF
--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -94,6 +94,7 @@ function validate(schemaKeyRef, data) {
     v = schemaObj.validate || this._compile(schemaObj);
   }
 
+  this.allrequired = [];
   var valid = v(data);
   if (v.$async !== true) this.errors = v.errors;
   return valid;

--- a/lib/dot/required.jst
+++ b/lib/dot/required.jst
@@ -6,6 +6,23 @@
 
 {{ var $vSchema = 'schema' + $lvl; }}
 
+{{? !it.compositeRule }}
+  {{# def.setupLoop }}
+  {{? $isData }}
+    if ({{=$vSchema}} && !Array.isArray({{=$vSchema}})) {
+      {{# def.addError:'required' }}
+      self.allrequired = (self.allrequired || []).concat(vErrors.pop());
+      errors--;
+    } else if ({{=$vSchema}} !== undefined) {
+  {{?}}
+
+  for (var {{=$i}} = 0; {{=$i}} < {{=$vSchema}}.length; {{=$i}}++) {
+    {{# def.addError:'required' }}
+    self.allrequired = (self.allrequired || []).concat(vErrors.pop());
+    errors--;
+  }
+{{?}}
+
 {{## def.setupLoop:
   {{? !$isData }}
     var {{=$vSchema}} = validate.schema{{=$schemaPath}};


### PR DESCRIPTION
Sometimes one may need to dynamically extract a list of all required fields from a schema for dynamic forms. Some schemas may be too complex to do so by simple analysis, in which case it is easier to perform a full validation and keep track of the fields that are required.

This commit does exactly that, forcefully generating errors for all required fields, even if they pass validation, and storing those errors in `ajv.allrequired`. The format of this array is exactly the same as that of `ajv.errors`.

We've been using this patch privately for a couple of years, and when I recently came accross https://github.com/epoberezkin/ajv/issues/661 I saw that other people had the same need and decided to try and get this into the main project.

Please advise on:
1. Async validation. We don't use this, but this PR should probably work with async validation as well.
2. Tests. Currently tests fail on master, so of course they fail here as well. We might want a test for the functionality offered here, even if it is only one basic test.
3. Docs. Under what section(s) should this be documented?

Please note that I'm not at all familiar with the ajv codebase. As far as I'm concerned, I just hacked this together, but it has been working well for us for years.