### PR TITLE
Allow nullable property of JSON Schema object to be false

### DIFF
--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -70,7 +70,7 @@ function Ajv(opts) {
   if (opts.formats) addInitialFormats(this);
   addDefaultMetaSchema(this);
   if (typeof opts.meta == 'object') this.addMetaSchema(opts.meta);
-  if (opts.nullable) this.addKeyword('nullable', {metaSchema: {const: true}});
+  if (opts.nullable) this.addKeyword('nullable', {metaSchema: {type: "boolean"}});
   addInitialSchemas(this);
 }
 

--- a/spec/options.spec.js
+++ b/spec/options.spec.js
@@ -1519,12 +1519,6 @@ describe('Ajv Options', function () {
 
         testNotNullable({type: ['number']});
       });
-
-      it('"nullable" keyword must be "true" if present', function() {
-        should.throw(function() {
-          ajv.compile({nullable: false});
-        });
-      });
     });
 
     describe('without option "nullable"', function() {

--- a/spec/options.spec.js
+++ b/spec/options.spec.js
@@ -1519,6 +1519,18 @@ describe('Ajv Options', function () {
 
         testNotNullable({type: ['number']});
       });
+      
+      it('should respect "nullable" == false with opts.nullable == true', function() {
+        testNotNullable({
+          type: 'number',
+          nullable: false
+        });
+
+        testNotNullable({
+          type: ['number'],
+          nullable: false
+        });
+      });
     });
 
     describe('without option "nullable"', function() {


### PR DESCRIPTION
**What issue does this pull request resolve?**
https://github.com/epoberezkin/ajv/issues/934

**What changes did you make?**
Made the meta-schema for `nullable` property accept both true and false.

**Is there anything that requires more attention while reviewing?**
Nope.