### PR TITLE
fix: log instead of throw when definition validation fails

### DIFF
--- a/lib/keyword.js
+++ b/lib/keyword.js
@@ -62,7 +62,7 @@ function addKeyword(keyword, definition) {
     validateDefinition = validateDefinition || this.compile(definitionSchema);
 
     if (!validateDefinition(definition))
-      throw new Error('custom keyword definition is invalid: '  + this.errorsText(validateDefinition.errors));
+      this.logger.error('custom keyword definition is invalid: '  + this.errorsText(validateDefinition.errors));
 
     var dataType = definition.type;
     if (Array.isArray(dataType)) {

--- a/spec/custom.spec.js
+++ b/spec/custom.spec.js
@@ -6,6 +6,16 @@ var getAjvInstances = require('./ajv_instances')
   , customRules = require('./custom_rules');
 
 
+function throwOnLogError(logger) {
+  var originalLogError = logger.error;
+  logger.error = function(msg) {
+    throw new Error(msg);
+  };
+  return function() {
+    logger.error = originalLogError;
+  };
+}
+
 describe('Custom keywords', function () {
   var ajv, instances;
 
@@ -707,6 +717,7 @@ describe('Custom keywords', function () {
     });
 
     it('should fail if keyword definition has "$data" but no "validate"', function() {
+      var restore = throwOnLogError(ajv.logger);
       should.throw(function() {
         ajv.addKeyword('even', {
           type: 'number',
@@ -714,6 +725,7 @@ describe('Custom keywords', function () {
           macro: function() { return {}; }
         });
       });
+      restore();
     });
   });
 
@@ -985,6 +997,7 @@ describe('Custom keywords', function () {
     });
 
     it('should throw if unknown type is passed', function() {
+      var restore = throwOnLogError(ajv.logger);
       should.throw(function() {
         addKeyword('custom1', 'wrongtype');
       });
@@ -996,6 +1009,7 @@ describe('Custom keywords', function () {
       should.throw(function() {
         addKeyword('custom3', ['number', undefined]);
       });
+      restore();
     });
 
     function addKeyword(keyword, dataType) {
@@ -1167,6 +1181,7 @@ describe('Custom keywords', function () {
     });
 
     it('should throw exception if used with macro keyword', function() {
+      var restore = throwOnLogError(ajv.logger);
       should.throw(function() {
         ajv.addKeyword('pass', {
           macro: function() { return {}; },
@@ -1180,6 +1195,7 @@ describe('Custom keywords', function () {
           valid: false
         });
       });
+      restore();
     });
   });
 
@@ -1215,6 +1231,7 @@ describe('Custom keywords', function () {
     });
 
     it("'dependencies'should be array of valid strings", function() {
+      var restore = throwOnLogError(ajv.logger);
       ajv.addKeyword('newKeyword1', {
         metaSchema: {type: 'boolean'},
         dependencies: ['dep1']
@@ -1226,6 +1243,7 @@ describe('Custom keywords', function () {
           dependencies: [1]
         });
       });
+      restore();
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

https://github.com/epoberezkin/ajv/issues/941

**What changes did you make?**

When definition validation fails in keyword.js, log the error instead of throwing it so that it doesn't break dependent packages that were passing invalid definitions to it, but still notifies users in some manner.

As this is a breaking change, I believe the throwing should be coupled with a major version bump, rather than a minor one.

**Is there anything that requires more attention while reviewing?**

I am not sure if there may be other ways in which the latest changes could be breaking dependent packages, but this is the part that surfaced.

To make the tests pass again, I stubbed the error logger to throw so that this change can be rolled out again with a major version bump with minimal effort to fix the tests.