### PR TITLE
Replace single quotes with double quotes (fix #931)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "test-ts": "tsc --target ES5 --noImplicitAny --noEmit spec/typescript/index.ts",
     "bundle": "del-cli dist && node ./scripts/bundle.js . Ajv pure_getters",
     "bundle-beautify": "node ./scripts/bundle.js js-beautify",
-    "build": "del-cli lib/dotjs/*.js '!lib/dotjs/index.js' && node scripts/compile-dots.js",
+    "build": "del-cli lib/dotjs/*.js \"!lib/dotjs/index.js\" && node scripts/compile-dots.js",
     "test-karma": "karma start",
     "test-browser": "del-cli .browser && npm run bundle && scripts/prepare-tests && npm run test-karma",
     "test-all": "npm run test-ts && npm run test-cov && if-node-version 10 npm run test-browser",
     "test": "npm run lint && npm run build && npm run test-all",
     "prepublish": "npm run build && npm run bundle",
-    "watch": "watch 'npm run build' ./lib/dot"
+    "watch": "watch \"npm run build\" ./lib/dot"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
Fix #931 
Replace single quotes with double quotes to get build scripts running on Windows.
Ensure still works ok in Linux environment.