### PR TITLE
Enable running in console less environments

### DIFF
--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -485,7 +485,14 @@ function setLogger(self) {
   if (logger === false) {
     self.logger = {log: noop, warn: noop, error: noop};
   } else {
-    if (logger === undefined) logger = console;
+    if (logger === undefined) {
+      if (typeof console === 'undefined') { // #950 fix for environments without global `console`
+        logger = { log: function () {}, warn: function () {}, error: function () {} }
+      }
+      else {
+        logger = console
+      }
+    };
     if (!(typeof logger == 'object' && logger.log && logger.warn && logger.error))
       throw new Error('logger must implement log, warn and error methods');
     self.logger = logger;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
Ajv assumes console to be present in the environment. It is an acceptable for all normal use cases. But we use AJV within Node VM module and that is sandboxed to not have console.

The following line https://github.com/epoberezkin/ajv/blob/master/lib/ajv.js#L488 assumes console to be present. This results in issues such as [postmanlabs/postman-app-support#3199](https://github.com/postmanlabs/postman-app-support/issues/3199) and requires to have a longer boilerplate code.

As reported in: https://github.com/epoberezkin/ajv/issues/950

**What changes did you make?**
Inserted a stub console if global console is absent

**Is there anything that requires more attention while reviewing?**
- Is it okay to inset a stub console or is it wise to check for console before every use? I prefer the former.
