### PR TITLE
Fix wrong json schema reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ JSON Schema specification defines several annotation keywords that describe sche
 - `title` and `description`: information about the data represented by that schema
 - `$comment` (NEW in draft-07): information for developers. With option `$comment` Ajv logs or passes the comment string to the user-supplied function. See [Options](#options).
 - `default`: a default value of the data instance, see [Assigning defaults](#assigning-defaults).
-- `examples` (NEW in draft-07): an array of data instances. Ajv does not check the validity of these instances against the schema.
+- `examples` (NEW in draft-06): an array of data instances. Ajv does not check the validity of these instances against the schema.
 - `readOnly` and `writeOnly` (NEW in draft-07): marks data-instance as read-only or write-only in relation to the source of the data (database, api, etc.).
 - `contentEncoding`: [RFC 2045](https://tools.ietf.org/html/rfc2045#section-6.1 ), e.g., "base64".
 - `contentMediaType`: [RFC 2046](https://tools.ietf.org/html/rfc2046), e.g., "image/png".


### PR DESCRIPTION
`examples` is a new keyword introduce in `draft-06`.

Source : [JSON Schema Draft 6 MetaSchema](http://json-schema.org/draft-06/schema)

<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**


**What changes did you make?**


**Is there anything that requires more attention while reviewing?**
