### PR TITLE
fix(types): add strictKeywords to Options interface

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -181,6 +181,7 @@ declare namespace ajv {
     useDefaults?: boolean | 'shared';
     coerceTypes?: boolean | 'array';
     strictDefaults?: boolean | 'log';
+    strictKeywords?: boolean | 'log';
     async?: boolean | string;
     transpile?: string | ((code: string) => string);
     meta?: boolean | object;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

None as it's only a typing correction in order to be up to date.
This pull request adds **strictKeywords** parameter to the **Options interface**.

**What changes did you make?**

I only modified the type of the `Options` interface in order to add the `strictKeywords` (optional union types that can be either boolean or 'log').

**Is there anything that requires more attention while reviewing?**

Not that I am aware of
