### PR TITLE
feat: group anyOf errors under each branch

### DIFF
--- a/lib/dot/anyOf.jst
+++ b/lib/dot/anyOf.jst
@@ -15,6 +15,8 @@
 
   {{# def.setCompositeRule }}
 
+  var anyOf_vErrors_{{=$dataLvl}} = vErrors;
+  var anyOf_errors_{{=$dataLvl}} = null;
   {{~ $schema:$sch:$i }}
     {{
       $it.schema = $sch;
@@ -22,17 +24,25 @@
       $it.errSchemaPath = $errSchemaPath + '/' + $i;
     }}
 
+    vErrors = null;
     {{# def.insertSubschemaCode }}
 
     {{=$valid}} = {{=$valid}} || {{=$nextValid}};
 
     if (!{{=$valid}}) {
+      if (anyOf_errors_{{=$dataLvl}} == null) {
+        anyOf_errors_{{=$dataLvl}} = [vErrors];
+      } else {
+        anyOf_errors_{{=$dataLvl}}.push(vErrors);
+      }
     {{ $closingBraces += '}'; }}
   {{~}}
 
   {{# def.resetCompositeRule }}
 
   {{= $closingBraces }}
+
+  vErrors = anyOf_vErrors_{{=$dataLvl}};
 
   if (!{{=$valid}}) {
     {{# def.extraError:'anyOf' }}

--- a/lib/dot/errors.def
+++ b/lib/dot/errors.def
@@ -166,7 +166,7 @@
   $ref:            "{ ref: '{{=it.util.escapeQuotes($schema)}}' }",
   additionalItems: "{ limit: {{=$schema.length}} }",
   additionalProperties: "{ additionalProperty: '{{=$additionalProperty}}' }",
-  anyOf:           "{}",
+  anyOf:           "{ errors: anyOf_errors_{{=$dataLvl}}}",
   const:           "{ allowedValue: schema{{=$lvl}} }",
   contains:        "{}",
   dependencies:    "{ property: '{{= it.util.escapeQuotes($property) }}', missingProperty: '{{=$missingProperty}}', depsCount: {{=$deps.length}}, deps: '{{= it.util.escapeQuotes($deps.length==1 ? $deps[0] : $deps.join(\", \")) }}' }",

--- a/spec/errors.spec.js
+++ b/spec/errors.spec.js
@@ -597,7 +597,8 @@ describe('Validation errors', function () {
       function test(_ajv) {
         var validate = _ajv.compile(schema);
         validate('foo') .should.equal(false);
-        validate.errors.length .should.equal(3);
+        validate.errors.length .should.equal(1);
+        validate.errors[0].params.errors.length .should.equal(2);
         validate(1) .should.equal(true);
         validate(1.5) .should.equal(true);
       }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

It looks like there are a number of issues where people are complaining about how difficult it is to tell what the real errors are when a schema fails to match an `anyOf` constraint. I think the problem is that you can get two conflicting errors for two different branches, and there's nothing to indicate which conditions are "or" and which are "and".

I think this would go a long way towards resolving issues reported in #201 #980 #828 

**What changes did you make?**

My solution is a structure like:

```js
[ { keyword: 'anyOf',
    dataPath: '',
    schemaPath: '#/anyOf',
    params:
     { errors:
        [ [ { keyword: 'type',
              dataPath: '',
              schemaPath: '#/anyOf/0/type',
              params: { type: 'number' },
              message: 'should be number',
              schema: 'number',
              parentSchema: { type: 'number' },
              data: 'foo' } ],
          [ { keyword: 'type',
              dataPath: '',
              schemaPath: '#/anyOf/1/type',
              params: { type: 'integer' },
              message: 'should be integer',
              schema: 'integer',
              parentSchema: { type: 'integer' },
              data: 'foo' } ] ] },
    message: 'should match some schema in anyOf',
    schema: [ { type: 'number' }, { type: 'integer' } ],
    parentSchema: { anyOf: [ { type: 'number' }, { type: 'integer' } ] },
    data: 'foo' } ]
```

which indicates that one branch of the `anyOf` had the error "should be number" and the other branch had the error "should be integer".

**Is there anything that requires more attention while reviewing?**

This fails some of the tests in json-schema-test about recursive schemas, I'm not 100% sure how I should go about fixing those.

BREAKING CHANGE: the error structure has changed for `anyOf` errors.