### PR TITLE
Add "empty" to useDefaults Ajv.Options type definition

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -178,7 +178,7 @@ declare namespace ajv {
     extendRefs?: true | 'ignore' | 'fail';
     loadSchema?: (uri: string, cb?: (err: Error, schema: object) => void) => PromiseLike<object | boolean>;
     removeAdditional?: boolean | 'all' | 'failing';
-    useDefaults?: boolean | 'shared';
+    useDefaults?: boolean | 'empty' | 'shared';
     coerceTypes?: boolean | 'array';
     strictDefaults?: boolean | 'log';
     strictKeywords?: boolean | 'log';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
`'empty'` was missing from Typescript definition for `useDefaults`,  causing build errors when using `ajv` in a TS project

**What changes did you make?**
Updated `Ajv.Options` interface in `lib/ajv.d.ts` so `useDefaults` covers all cases outlined in the docs: `boolean | 'empty' | 'shared'`

**Is there anything that requires more attention while reviewing?**
Not that I'm aware of.