### PR TITLE
add: `omitDataPath` option to `ajv.errorsText` for ajv-errors custom …

### DIFF
--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -404,7 +404,7 @@ function _get$IdOrId(schema) {
  * Convert array of error message objects to string
  * @this   Ajv
  * @param  {Array<Object>} errors optional array of validation errors, if not passed errors from the instance are used.
- * @param  {Object} options optional options with properties `separator` and `dataVar`.
+ * @param  {Object} options optional options with properties `separator`, `dataVar` and `omitDataPath`.
  * @return {String} human readable string with all errors descriptions
  */
 function errorsText(errors, options) {
@@ -417,7 +417,7 @@ function errorsText(errors, options) {
   var text = '';
   for (var i=0; i<errors.length; i++) {
     var e = errors[i];
-    if (e) text += dataVar + e.dataPath + ' ' + e.message + separator;
+    if (e) text += (options.omitDataPath ? '' : dataVar + e.dataPath + ' ') + e.message + separator;
   }
   return text.slice(0, -separator.length);
 }


### PR DESCRIPTION
```js
var Ajv = require('ajv')
var ajv = new Ajv({ allErrors: true })
require('ajv-errors')(ajv)

var validate = ajv.compile({
  type: 'object',
  properties: {
    name: {
      type: 'string',
      minLength: 6,
      errorMessage: 'Your name should more than 6 characters'
    }
  }
})

validate({ name: 'xxx' })

console.log(ajv.errorsText(validate.errors))
// data/name Your name should more than 6 characters
```

But i want get raw errorMessage.

```js
console.log(ajv.errorsText(validate.errors, { omitDataPath: true }))
// Your name should more than 6 characters
```