### PR TITLE
Fix chart URL showing as a table

### DIFF
--- a/index.md
+++ b/index.md
@@ -91,7 +91,7 @@ Currently Ajv is the fastest and the most standard compliant validator according
 
 Performance of different validators by [json-schema-benchmark](https://github.com/ebdrup/json-schema-benchmark):
 
-[![performance](https://chart.googleapis.com/chart?chxt=x,y&cht=bhs&chco=76A4FB&chls=2.0&chbh=32,4,1&chs=600x416&chxl=-1:|djv|ajv|json-schema-validator-generator|jsen|is-my-json-valid|themis|z-schema|jsck|skeemas|json-schema-library|tv4&chd=t:100,98,72.1,66.8,50.1,15.1,6.1,3.8,1.2,0.7,0.2)](https://github.com/ebdrup/json-schema-benchmark/blob/master/README.md#performance)
+[![performance](https://chart.googleapis.com/chart?chxt=x,y&cht=bhs&chco=76A4FB&chls=2.0&chbh=32,4,1&chs=600x416&chxl=-1:%7Cdjv%7Cajv%7Cjson-schema-validator-generator%7Cjsen%7Cis-my-json-valid%7Cthemis%7Cz-schema%7Cjsck%7Cskeemas%7Cjson-schema-library%7Ctv4&chd=t:100,98,72.1,66.8,50.1,15.1,6.1,3.8,1.2,0.7,0.2)](https://github.com/ebdrup/json-schema-benchmark/blob/master/README.md#performance)
 
 
 ## Features


### PR DESCRIPTION
The github pages markdown processor seems to be processing the performance chart URL as a table.

URL encoding the pipes should prevent this.

Fixes https://github.com/epoberezkin/ajv/issues/1065