### PR TITLE
Updated readme with proposed ReDoS solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@ __Please note__: some formats that Ajv implements use [regular expressions](http
 - making assessment of "format" implementations in Ajv.
 - using `format: 'fast'` option that simplifies some of the regular expressions (although it does not guarantee that they are safe).
 - replacing format implementations provided by Ajv with your own implementations of "format" keyword that either uses different regular expressions or another approach to format validation. Please see [addFormat](#api-addformat) method.
+- running the format validation in a separate thread, with a timeout specified.
 - disabling format validation by ignoring "format" keyword with option `format: false`
 
 Whatever mitigation you choose, please assume all formats provided by Ajv as potentially unsafe and make your own assessment of their suitability for your validation scenarios.


### PR DESCRIPTION
The solution being to run the format validation in a separate thread, with a timeout specified. If it doesn't complete within the timeout period, the data is assumed invalid, and the thread killed.

Granted, this breaks the synchronous nature of AJV validation, and is therefore outside of the library's own validation stack. But it might still be worth noting as a library-external solution to the problem.

<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**


**What changes did you make?**


**Is there anything that requires more attention while reviewing?**
