### PR TITLE
Add dataPathArr to CompilationContext interface type definition

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -243,6 +243,7 @@ declare namespace ajv {
   interface CompilationContext {
     level: number;
     dataLevel: number;
+    dataPathArr: string[];
     schema: any;
     schemaPath: string;
     baseId: string;


### PR DESCRIPTION
**What issue does this pull request resolve?**
https://github.com/epoberezkin/ajv/issues/1096

**What changes did you make?**
Only update `CompilationContext` type definition to include `dataPathArr`.

**Is there anything that requires more attention while reviewing?**
I guess no