### PR TITLE
Add keywords to Ajv options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,7 @@ Defaults:
   - `"full"` - more restrictive and slow validation. E.g., 25:00:00 and 2015/14/33 will be invalid time and date in 'full' mode but it will be valid in 'fast' mode.
   - `false` - ignore all format keywords.
 - _formats_: an object with custom formats. Keys and values will be passed to `addFormat` method.
+- _keywords_: an object with custom keywords. Keys and values will be passed to `addKeyword` method.
 - _unknownFormats_: handling of unknown formats. Option values:
   - `true` (default) - if an unknown format is encountered the exception is thrown during schema compilation. If `format` keyword value is [$data reference](#data-reference) and it is unknown the validation will fail.
   - `[String]` - an array of unknown format names that will be ignored. This option can be used to allow usage of third party schemas with format(s) for which you don't have definitions, but still fail if another unknown format is used. If `format` keyword value is [$data reference](#data-reference) and it is not in this array the validation will fail.

--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -171,6 +171,7 @@ declare namespace ajv {
     unicode?: boolean;
     format?: false | string;
     formats?: object;
+    keywords?: object;
     unknownFormats?: true | string[] | 'ignore';
     schemas?: Array<object> | object;
     schemaId?: '$id' | 'id' | 'auto';
@@ -251,6 +252,9 @@ declare namespace ajv {
     opts: Options;
     formats: {
       [index: string]: FormatDefinition | undefined;
+    };
+    keywords: {
+      [index: string]: KeywordDefinition | undefined;
     };
     compositeRule: boolean;
     validate: (schema: object) => boolean;

--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -69,6 +69,7 @@ function Ajv(opts) {
   this._metaOpts = getMetaSchemaOptions(this);
 
   if (opts.formats) addInitialFormats(this);
+  if (opts.keywords) addInitialKeywords(this);
   addDefaultMetaSchema(this);
   if (typeof opts.meta == 'object') this.addMetaSchema(opts.meta);
   if (opts.nullable) this.addKeyword('nullable', {metaSchema: {type: 'boolean'}});
@@ -463,6 +464,14 @@ function addInitialFormats(self) {
   for (var name in self._opts.formats) {
     var format = self._opts.formats[name];
     self.addFormat(name, format);
+  }
+}
+
+
+function addInitialKeywords(self) {
+  for (var name in self._opts.keywords) {
+    var keyword = self._opts.keywords[name];
+    self.addKeyword(name, keyword);
   }
 }
 

--- a/spec/options/options_validation.spec.js
+++ b/spec/options/options_validation.spec.js
@@ -26,9 +26,32 @@ describe('validation options', function() {
       }});
 
       var validate = ajv.compile({ format: 'identifier' });
+
       validate('Abc1') .should.equal(true);
       validate('123') .should.equal(false);
       validate(123) .should.equal(true);
+    });
+  });
+
+  describe('keywords', function() {
+    it('should add keywords from options', function() {
+      var ajv = new Ajv({ keywords: {
+        string: {
+          validate: function (schema, data ) {
+
+            console.log(">>", data);
+            return /^[a-z_$][a-z0-9_$]*$/i.test(data);
+          }
+        }
+      }});
+
+      var validate = ajv.compile({ string: true });
+
+      validate('Abc1') .should.equal(true);
+      validate('foo bar').should.equal(false);
+      validate('123').should.equal(false);
+      validate(123).should.equal(false);
+      validate(123).should.equal(false);
     });
   });
 


### PR DESCRIPTION
This PR adds the `keywords` option to the Ajv options to add custom keywords, without having to call `addKeyword`.

**What issue does this pull request resolve?**
#1136

**What changes did you make?**
Add the keywords option to the Ajv options to add custom keywords, without having to call addKeyword.

**Is there anything that requires more attention while reviewing?**
No