### PR TITLE
fix(types) added undefined to getSchema()

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -80,9 +80,9 @@ declare namespace ajv {
     /**
     * Get compiled schema from the instance by `key` or `ref`.
     * @param  {string} keyRef `key` that was passed to `addSchema` or full schema reference (`schema.id` or resolved id).
-    * @return {Function} schema validating function (with property `schema`).
+    * @return {Function} schema validating function (with property `schema`). Returns undefined if keyRef can't be resolved to an existing schema.
     */
-    getSchema(keyRef: string): ValidateFunction;
+    getSchema(keyRef: string): ValidateFunction | undefined;
     /**
     * Remove cached schema(s).
     * If no parameter is passed all schemas but meta-schemas are removed.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

getSchema() may return undefined if the key does not resolve to a previously added schema. Users should be encouraged to check for that. Since there isn't a separate method to check if a keyRef would resolve (without getting and compiling the schema), checking the return value seems like the best way.

**What changes did you make?**

Added undefined as a possible return type of getSchema(). While one could check the return value even without this change, linters would complain about it, as an undefined check would always be false according to the types.


**Is there anything that requires more attention while reviewing?**
