### PR TITLE
Fixed the TypeScript type definition for Options' "format"

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -169,7 +169,7 @@ declare namespace ajv {
     jsonPointers?: boolean;
     uniqueItems?: boolean;
     unicode?: boolean;
-    format?: string;
+    format?: false | string;
     formats?: object;
     unknownFormats?: true | string[] | 'ignore';
     schemas?: Array<object> | object;


### PR DESCRIPTION
**What issue does this pull request resolve?**
According to documentation "false" is valid input for ajvOptions.format. However typescript definition only lists the type string for it, which causes an error:
"Type 'false' is not assignable to type 'string'.ts(2322)
ajv.d.ts(172, 5): The expected type comes from property 'format' which is declared here on type 'Partial<Options>'"

Existing documentation for avjOptions.format:
"format: formats validation mode. Option values:
"fast" (default) - simplified and fast validation (see Formats for details of which formats are available and affected by this option).
"full" - more restrictive and slow validation. E.g., 25:00:00 and 2015/14/33 will be invalid time and date in 'full' mode but it will be valid in 'fast' mode.
false - ignore all format keywords."

**What changes did you make?**
Add the false as allowed type

**Is there anything that requires more attention while reviewing?**
No