### PR TITLE
feat: Make the validation error more detailed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1079,7 +1079,7 @@ __Please note__: schemas compiled before the keyword is removed will continue to
 
 Returns the text with all errors in a String.
 
-Options can have properties `separator` (string used to separate errors, ", " by default) and `dataVar` (the variable name that dataPaths are prefixed with, "data" by default).
+Options can have properties `separator` (string used to separate errors, ", " by default) `dataVar` (the variable name that dataPaths are prefixed with, "data" by default) and `extraInfo` (should the error message be more detailed).
 
 
 ## Options

--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -132,7 +132,7 @@ declare namespace ajv {
     /**
     * Convert array of error message objects to string
     * @param  {Array<object>} errors optional array of validation errors, if not passed errors from the instance are used.
-    * @param  {object} options optional options with properties `separator` and `dataVar`.
+    * @param  {object} options optional options with properties `separator`, `dataVar` and `extraInfo`.
     * @return {string} human readable string with all errors descriptions
     */
     errorsText(errors?: Array<ErrorObject> | null, options?: ErrorsTextOptions): string;
@@ -287,6 +287,7 @@ declare namespace ajv {
   interface ErrorsTextOptions {
     separator?: string;
     dataVar?: string;
+    extraInfo?: boolean;
   }
 
   interface ErrorObject {

--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -413,11 +413,20 @@ function errorsText(errors, options) {
   options = options || {};
   var separator = options.separator === undefined ? ', ' : options.separator;
   var dataVar = options.dataVar === undefined ? 'data' : options.dataVar;
+  var extraInfo = options.extraInfo === true;
 
   var text = '';
   for (var i=0; i<errors.length; i++) {
     var e = errors[i];
-    if (e) text += dataVar + e.dataPath + ' ' + e.message + separator;
+    if (e) {
+      text += dataVar + e.dataPath + ' ' + e.message + separator;
+      if(extraInfo) {
+        if (e.params && e.params.allowedValues)
+          text += ' (' + e.params.allowedValues.join(',') + ')';
+        else if (e.params && e.params.additionalProperty)
+          text += ' (' + e.params.additionalProperty + ')';
+      }
+    }
   }
   return text.slice(0, -separator.length);
 }

--- a/lib/ajv.js
+++ b/lib/ajv.js
@@ -404,7 +404,7 @@ function _get$IdOrId(schema) {
  * Convert array of error message objects to string
  * @this   Ajv
  * @param  {Array<Object>} errors optional array of validation errors, if not passed errors from the instance are used.
- * @param  {Object} options optional options with properties `separator` and `dataVar`.
+ * @param  {Object} options optional options with properties `separator`, `dataVar` and `extraInfo`.
  * @return {String} human readable string with all errors descriptions
  */
 function errorsText(errors, options) {
@@ -416,16 +416,17 @@ function errorsText(errors, options) {
   var extraInfo = options.extraInfo === true;
 
   var text = '';
+  var extraText = '';
   for (var i=0; i<errors.length; i++) {
     var e = errors[i];
     if (e) {
-      text += dataVar + e.dataPath + ' ' + e.message + separator;
       if(extraInfo) {
         if (e.params && e.params.allowedValues)
-          text += ' (' + e.params.allowedValues.join(',') + ')';
+          extraText += ' (' + e.params.allowedValues.join(',') + ')';
         else if (e.params && e.params.additionalProperty)
-          text += ' (' + e.params.additionalProperty + ')';
+          extraText += ' (' + e.params.additionalProperty + ')';
       }
+      text += dataVar + e.dataPath + ' ' + e.message + extraText + separator;
     }
   }
   return text.slice(0, -separator.length);


### PR DESCRIPTION
**What issue does this pull request resolve?**
This feature will improve the validation message returned from function: .errorsText

*example message*

before change:
data.env should be equal to one of the allowed values

after change:
data.env should be equal to one of the allowed values (nodejs,python,jvm)

**What changes did you make?**

Add an optional boolean property to decide if message should be more specific.

```javascript

validator.errorsText(errors, { extraInfo: true });

```

**Is there anything that requires more attention while reviewing?**
Yes, add tests