### PR TITLE
patternProperties: skip keys with undefined values

### DIFF
--- a/lib/dot/properties.jst
+++ b/lib/dot/properties.jst
@@ -215,7 +215,7 @@ var {{=$nextValid}} = true;
       }}
 
       {{# def.iterateProperties }}
-        if ({{= it.usePattern($pProperty) }}.test({{=$key}})) {
+        if ({{=$data}}[{{=$key}}] !== undefined && {{= it.usePattern($pProperty) }}.test({{=$key}})) {
           {{
             $it.errorPath = it.util.getPathExpr(it.errorPath, $key, it.opts.jsonPointers);
             var $passData = $data + '[' + $key + ']';

--- a/spec/issues/1173_patternProperties_with_undefined_value.spec.js
+++ b/spec/issues/1173_patternProperties_with_undefined_value.spec.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var Ajv = require('../ajv');
+require('../chai').should();
+
+
+describe('issue #1173: properties matched by patternProperties with `undefined` values', function() {
+  it('should ignore `undefined` values for properties matched by patternProperties ', function() {
+    var schema = {
+      type: "object",
+      patternProperties: {
+        '^pattern.*': false
+      }
+    };
+
+    var data = {
+      patternProp: undefined
+    };
+
+    var ajv = new Ajv();
+    var validate = ajv.compile(schema);
+
+    var valid = validate(data);
+    valid.should.be.true;
+  });
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/epoberezkin/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

Fixes #1173 

When iterating over object keys that match patternProperties, ignore keys whose data values that are `undefined`. This makes it consistent with how regular properties are handled.


**What changes did you make?**

In `properties.jst`, when iterating over properties in an object, check both that the property key matches the given RegExp (this check is not new) *and* that the data value is not `undefined` (this part is new).


**Is there anything that requires more attention while reviewing?**

First time making changes to this codebase. Not sure if there's anything I missed.