### PR TITLE
Document pre-compiled schemas for CSP in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,13 +238,14 @@ Ajv is tested with these browsers:
 __Please note__: some frameworks, e.g. Dojo, may redefine global require in such way that is not compatible with CommonJS module format. In such case Ajv bundle has to be loaded before the framework and then you can use global Ajv (see issue [#234](https://github.com/ajv-validator/ajv/issues/234)).
 
 
-### Ajv & Content Security Policies (CSP)
+### Ajv and Content Security Policies (CSP)
 
 If you're using Ajv to compile a schema (the typical use) in a browser document that is loaded with a Content Security Policy (CSP), that policy will require a `script-src` directive that includes the value `'unsafe-eval'`.
 :warning: NOTE, however, that `unsafe-eval` is NOT recommended in a secure CSP[[1]](https://developer.chrome.com/extensions/contentSecurityPolicy#relaxing-eval), as it has the potential to open the document to cross-site scripting (XSS) attacks.
 
 In order to make use of Ajv without easing your CSP, you can [pre-compile a schema using the CLI](https://github.com/ajv-validator/ajv-cli#compile-schemas). This will transpile the schema JSON into a JavaScript file that exports a `validate` function that works simlarly to a schema compiled at runtime.
-Note that the pre-compiled schemas, which are created using [ajv-pack](https://github.com/ajv-validator/ajv-pack#limitations), are not functionally equivalent to Ajv and there are known limitations.
+
+Note that pre-compilation of schemas is performed using [ajv-pack](https://github.com/ajv-validator/ajv-pack) and there are [some limitations to the schema features it can compile](https://github.com/ajv-validator/ajv-pack#limitations). A successfully pre-compiled schema is equivalent to the same schema compiled at runtime.
 
 
 ## Command line interface

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
 - [Getting started](#getting-started)
 - [Frequently Asked Questions](https://github.com/ajv-validator/ajv/blob/master/FAQ.md)
 - [Using in browser](#using-in-browser)
+  - [Ajv and Content Security Policies (CSP)](#ajv-and-content-security-policies-csp)
 - [Command line interface](#command-line-interface)
 - Validation
   - [Keywords](#validation-keywords)

--- a/README.md
+++ b/README.md
@@ -733,6 +733,10 @@ isSchemaSecure(schema2); // true
 __Please note__: following all these recommendation is not a guarantee that validation of untrusted data is safe - it can still lead to some undesirable results.
 
 
+##### Content Security Policies (CSP)
+See [Ajv and Content Security Policies (CSP)](#ajv-and-content-security-policies-csp)
+
+
 ## ReDoS attack
 
 Certain regular expressions can lead to the exponential evaluation time even with relatively short strings.

--- a/README.md
+++ b/README.md
@@ -238,6 +238,15 @@ Ajv is tested with these browsers:
 __Please note__: some frameworks, e.g. Dojo, may redefine global require in such way that is not compatible with CommonJS module format. In such case Ajv bundle has to be loaded before the framework and then you can use global Ajv (see issue [#234](https://github.com/ajv-validator/ajv/issues/234)).
 
 
+### Ajv & Content Security Policies (CSP)
+
+If you're using Ajv to compile a schema (the typical use) in a browser document that is loaded with a Content Security Policy (CSP), that policy will require a `script-src` directive that includes the value `'unsafe-eval'`.
+:warning: NOTE, however, that `unsafe-eval` is NOT recommended in a secure CSP[[1]](https://developer.chrome.com/extensions/contentSecurityPolicy#relaxing-eval), as it has the potential to open the document to cross-site scripting (XSS) attacks.
+
+In order to make use of Ajv without easing your CSP, you can [pre-compile a schema using the CLI](https://github.com/ajv-validator/ajv-cli#compile-schemas). This will transpile the schema JSON into a JavaScript file that exports a `validate` function that works simlarly to a schema compiled at runtime.
+Note that the pre-compiled schemas, which are created using [ajv-pack](https://github.com/ajv-validator/ajv-pack#limitations), are not functionally equivalent to Ajv and there are known limitations.
+
+
 ## Command line interface
 
 CLI is available as a separate npm package [ajv-cli](https://github.com/ajv-validator/ajv-cli). It supports:


### PR DESCRIPTION
Pre-compiled schemas are a workaround for maintaining a secure Content Security Policy (CSP)

**What issue does this pull request resolve?**
#1228

**What changes did you make?**
Added two paragraphs to the README

**Is there anything that requires more attention while reviewing?**
Unlikely