### PR TITLE
Bugfix should skip extendError if "error" option is "full" for custom keyword validate function

### DIFF
--- a/lib/dot/custom.jst
+++ b/lib/dot/custom.jst
@@ -180,7 +180,9 @@ var {{=$valid}};
           if (vErrors === null) vErrors = {{=$ruleErrs}};
           else vErrors = vErrors.concat({{=$ruleErrs}});
           errors = vErrors.length;
-          {{# def.extendErrors:false }}
+          {{? $rDef.errors != 'full' }}
+            {{# def.extendErrors:false }}
+          {{?}}
         } else {
           {{= def_customError }}
         }

--- a/spec/issues/1244_custom_validate_should_skip_extenderrors.spec.js
+++ b/spec/issues/1244_custom_validate_should_skip_extenderrors.spec.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var Ajv = require('../ajv');
+require('../chai').should();
+
+
+describe('issue #1244: Should skip extendError if "error" option is "full"', function() {
+  it('should skip extendError if "error" option is "full"', function() {
+    var ajv = new Ajv({
+      verbose: true
+    });
+    ajv.addKeyword("propertyMustBeTrue", {
+      // eslint-disable-next-line no-unused-vars
+      validate: function v(schema, data, _parentSchema, dataPath) {
+        if (data && !data[schema]) {
+          v.errors = [{
+            keyword: "propertyMustBeTrue",
+            dataPath: dataPath + "." + schema,
+            data: data[schema]
+          }];
+          return false;
+        }
+        return true;
+      },
+      errors: "full",
+      metaSchema: { type: "string" }
+    });
+
+    var schema = {
+      properties: {
+        a: { type: "boolean" },
+      },
+      propertyMustBeTrue: "a"
+    };
+    var data = { a: false };
+
+    var validate = ajv.compile(schema);
+    validate(data) .should.equal(false);
+    validate.errors.length .should.equal(1);
+    validate.errors[0].data .should.equal(false);
+    validate.errors[0].dataPath .should.equal(".a");
+  });
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
#1244

**What changes did you make?**


**Is there anything that requires more attention while reviewing?**
