### PR TITLE
Add _opts property type in Ajv.Ajv

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -137,7 +137,7 @@ declare namespace ajv {
     */
     errorsText(errors?: Array<ErrorObject> | null, options?: ErrorsTextOptions): string;
     errors?: Array<ErrorObject> | null;
-    _opts: any;
+    _opts: Options;
   }
 
   interface CustomLogger {

--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -137,6 +137,7 @@ declare namespace ajv {
     */
     errorsText(errors?: Array<ErrorObject> | null, options?: ErrorsTextOptions): string;
     errors?: Array<ErrorObject> | null;
+    _opts: any;
   }
 
   interface CustomLogger {


### PR DESCRIPTION
**What issue does this pull request resolve?**
resolve #1253 issue.

**What changes did you make?**
Add type declaration Ajv.Ajv._opt

**Is there anything that requires more attention while reviewing?**
The reason why I set any type is other any object( ex. `_metaOpts` ) could not compatible with detailed objects.