### PR TITLE
Make compiled validation interface async aware

### DIFF
--- a/lib/ajv.ts
+++ b/lib/ajv.ts
@@ -1,11 +1,15 @@
 import {
   Schema,
   SchemaObject,
+  SyncSchemaObject,
+  AsyncSchemaObject,
   Vocabulary,
   KeywordDefinition,
   Options,
   InstanceOptions,
   ValidateFunction,
+  SyncValidateFunction,
+  AsyncValidateFunction,
   CacheInterface,
   Logger,
   ErrorObject,
@@ -111,6 +115,10 @@ export default class Ajv {
   }
 
   // Create validation function for passed schema
+  compile(s: {$async?: never}, _?: boolean): ValidateFunction
+  compile(s: SyncSchemaObject, _?: boolean): SyncValidateFunction
+  compile(s: AsyncSchemaObject, _?: boolean): AsyncValidateFunction
+  compile(s: Schema, _?: boolean): ValidateFunction
   compile(
     schema: Schema,
     _meta?: boolean // true if schema is a meta-schema. Used internally to compile meta schemas of custom keywords.
@@ -121,6 +129,26 @@ export default class Ajv {
 
   // Creates validating function for passed schema with asynchronous loading of missing schemas.
   // `loadSchema` option should be a function that accepts schema uri and returns promise that resolves with the schema.
+  compileAsync(
+    s: {$async?: never},
+    m?: boolean | CompileAsyncCallback,
+    c?: CompileAsyncCallback
+  ): Promise<ValidateFunction>
+  compileAsync(
+    s: SyncSchemaObject,
+    m?: boolean | CompileAsyncCallback,
+    c?: CompileAsyncCallback
+  ): Promise<SyncValidateFunction>
+  compileAsync(
+    s: AsyncSchemaObject,
+    m?: boolean | CompileAsyncCallback,
+    c?: CompileAsyncCallback
+  ): Promise<AsyncValidateFunction>
+  compileAsync(
+    s: SchemaObject,
+    m?: boolean | CompileAsyncCallback,
+    c?: CompileAsyncCallback
+  ): Promise<ValidateFunction>
   compileAsync(
     schema: SchemaObject,
     metaOrCallback?: boolean | CompileAsyncCallback, // optional true to compile meta-schema; this parameter can be skipped

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,6 +5,7 @@ import Ajv from "./ajv"
 
 export interface SchemaObject {
   $id?: string
+  $async?: boolean
   $schema?: string
   [x: string]: any // TODO
 }
@@ -116,6 +117,38 @@ export interface ValidateFunction {
   $async?: true
   source?: SourceCode
   validate?: ValidateFunction // it will be only set on wrappers
+}
+
+export interface SyncSchemaObject extends SchemaObject {
+  $async: false
+}
+
+export interface SyncValidateFunction extends ValidateFunction {
+  (
+    this: Ajv | any,
+    data: any,
+    dataPath?: string,
+    parentData?: Record<string, any> | any[],
+    parentDataProperty?: string | number,
+    rootData?: Record<string, any> | any[]
+  ): boolean
+  $async: undefined
+}
+
+export interface AsyncSchemaObject extends SchemaObject {
+  $async: true
+}
+
+export interface AsyncValidateFunction extends ValidateFunction {
+  (
+    this: Ajv | any,
+    data: any,
+    dataPath?: string,
+    parentData?: Record<string, any> | any[],
+    parentDataProperty?: string | number,
+    rootData?: Record<string, any> | any[]
+  ): Promise<any>
+  $async: true
 }
 
 export interface SchemaValidateFunction {

--- a/spec/options/async.spec.ts
+++ b/spec/options/async.spec.ts
@@ -1,0 +1,73 @@
+import _Ajv from "../ajv"
+require("../chai").should()
+
+describe("$async option", () => {
+  const ajv = new _Ajv()
+
+  describe("= undefined", () => {
+    const validate = ajv.compile({})
+    it("should return a boolean or promise", async () => {
+      const result = validate({})
+      if (typeof result === "boolean") {
+        result.should.exist
+      } else {
+        await result.then((data) => data.should.exist)
+      }
+    })
+  })
+
+  describe("= false", () => {
+    const validate = ajv.compile({$async: false})
+    it("should return a boolean", () => {
+      const result: boolean = validate({})
+      result.should.exist
+    })
+  })
+
+  describe("= true", () => {
+    const validate = ajv.compile({$async: true})
+    it("should return a promise", async () => {
+      const result: Promise<any> = validate({})
+      await result.then((data) => data.should.exist)
+    })
+  })
+
+  describe("= boolean", () => {
+    const schema = {$async: true}
+    const validate = ajv.compile(schema)
+    it("should return boolean or promise", async () => {
+      const result = validate({})
+      if (typeof result === "boolean") {
+        result.should.exist
+      } else {
+        await result.then((data) => data.should.exist)
+      }
+    })
+  })
+
+  describe("of type unknown", () => {
+    const schema: Record<string, unknown> = {}
+    const validate = ajv.compile(schema)
+    it("should return boolean or promise", async () => {
+      const result = validate({})
+      if (typeof result === "boolean") {
+        result.should.exist
+      } else {
+        await result.then((data) => data.should.exist)
+      }
+    })
+  })
+
+  describe("of type any", () => {
+    const schema: any = {}
+    const validate = ajv.compile(schema)
+    it("should return boolean or promise", async () => {
+      const result = validate({})
+      if (typeof result === "boolean") {
+        result.should.exist
+      } else {
+        await result.then((data) => data.should.exist)
+      }
+    })
+  })
+})


### PR DESCRIPTION
**What issue does this pull request resolve?**
Fixes #1279

**What changes did you make?**
1. Added specific interfaces for schemas with `$async: true` and schemas with `$async: false`
2. Added specific interfaces for validation functions compiled from said specific schemas
3. Overloaded the `compile` and `compileAsync` with a different signatures for each schema subtype

**Is there anything that requires more attention while reviewing?**

This will be a major compilation breaking change. The following code will not compile anymore, because `validator` now will return a narrower type. In truth, the problematic code was never running anyway, it should be just deleted.

```typescript
const validator = ajv.compile({ $async: false });
const result = validator(data);

if (typeof result === "boolean") {
    // sync
    console.log(result);
} else {
    // async
    result.then(value => { // Property 'then' does not exist on type 'never'.ts(2339)
        data = value;
    });
}
```

However, using `ajv.compile({})` or broad types like `{ $async: boolean }` will maintain old behavior:

```typescript
const schema = { $async: true };
const validator = ajv.compile(schema);
const result = validator(data);
//      ^^^^ still boolean | Promise<any>
```

This happens because the first overloaded signature had to be

```typescript
compile(s: {$async?: never}, _?: boolean): ValidateFunction
```

Otherwise using `ajv.compile({} as any)` would yield an incorrectly narrow-typed validator.

So I had to choose between wrongly narrowed types for `any` and `Record<string, unknown>` typed schemas (which are common); or failing to guess that `{ $async: undefined }` is the same as `{ $async: false }`. I chose the latter.