### PR TITLE
Turn ErrorObject into a tagged union type

### DIFF
--- a/lib/ajv.d.ts
+++ b/lib/ajv.d.ts
@@ -295,21 +295,48 @@ declare namespace ajv {
     dataVar?: string;
   }
 
-  interface ErrorObject {
-    keyword: string;
+  type ErrorObject = {
     dataPath: string;
     schemaPath: string;
-    params: ErrorParameters;
-    // Added to validation errors of propertyNames keyword schema
-    propertyName?: string;
     // Excluded if messages set to false.
     message?: string;
     // These are added with the `verbose` option.
     schema?: any;
     parentSchema?: object;
     data?: any;
-  }
+  } & (
+    | { keyword: "false schema"; params: NoParams }
+    | { keyword: "$ref"; params: RefParams }
+    | { keyword: "additionalItems"; params: LimitParams }
+    | { keyword: "additionalProperties"; params: AdditionalPropertiesParams }
+    | { keyword: "anyOf"; params:  NoParams }
+    | { keyword: "const"; params: EnumParams }
+    | { keyword: "contains"; params: NoParams  }
+    | { keyword: "dependencies"; params: DependenciesParams }
+    | { keyword: "enum"; params: EnumParams }
+    | { keyword: "format"; params: FormatParams }
+    | { keyword: "if"; params: IfParams }
+    | { keyword: "_limit"; params: ComparisonParams }
+    | { keyword: "_exclusiveLimit"; params: NoParams }
+    | { keyword: "_limitItems"; params: LimitParams }
+    | { keyword: "_limitLength"; params: LimitParams }
+    | { keyword: "_limitProperties"; params: LimitParams }
+    | { keyword: "multipleOf"; params: MultipleOfParams }
+    | { keyword: "not"; params: NoParams }
+    | { keyword: "oneOf"; params: OneOfParams }
+    | { keyword: "pattern"; params: PatternParams }
+    | { keyword: "propertyNames"; params: PropertyNamesParams; propertyName: string }
+    | { keyword: "required"; params: RequiredParams }
+    | { keyword: "type"; params: TypeParams }
+    | { keyword: "uniqueItems"; params: UniqueItemsParams }
+    | { keyword: "custom"; params: CustomParams }
+    | { keyword: "patternRequired"; params: PatternRequiredParams }
+    | { keyword: "switch"; params: SwitchParams }
+    | { keyword: "_formatLimit"; params: ComparisonParams }
+    | { keyword: "_formatExclusiveLimit"; params: NoParams }
+  )
 
+  // TODO: Remove if okay with breaking changes; it's no longer needed
   type ErrorParameters = RefParams | LimitParams | AdditionalPropertiesParams |
     DependenciesParams | FormatParams | ComparisonParams |
     MultipleOfParams | PatternParams | RequiredParams |
@@ -391,6 +418,10 @@ declare namespace ajv {
 
   interface EnumParams {
     allowedValues: Array<any>;
+  }
+
+  interface OneOfParams {
+    passingSchemas: Array<number> | null;
   }
 }
 

--- a/spec/typescript/index.ts
+++ b/spec/typescript/index.ts
@@ -48,10 +48,90 @@ if (typeof result === "boolean") {
 // #endregion compile()
 
 // #region errors
-const validationError: ajv.ValidationError = new ajv.ValidationError([]);
+const validationError: ajv.ValidationError = new ajv.ValidationError([{
+    dataPath: ".someKey",
+    keyword: "enum",
+    params: { allowedValues: ["1", "2", "3"] },
+    schemaPath: "",
+}]);
 validationError instanceof ajv.ValidationError;
 validationError.ajv === true;
 validationError.validation === true;
+const firstError = validationError.errors[0];
+switch (firstError.keyword) {
+    case "false schema":
+        {}; break;
+    case "$ref":
+        firstError.params.ref; break;
+    case "additionalItems":
+        firstError.params.limit; break;
+    case "additionalProperties":
+        firstError.params.additionalProperty; break;
+    case "anyOf":
+        {}; break;
+    case "const":
+        firstError.params.allowedValues; break;
+    case "contains":
+        {}; break;
+    case "dependencies":
+        firstError.params.deps;
+        firstError.params.depsCount;
+        firstError.params.missingProperty;
+        firstError.params.property;
+        break;
+    case "enum":
+        firstError.params.allowedValues; break;
+    case "format":
+        firstError.params.format; break;
+    case "if":
+        firstError.params.failingKeyword; break;
+    case "_limit":
+        firstError.params.comparison;
+        firstError.params.exclusive;
+        firstError.params.limit;
+        break;
+    case "_exclusiveLimit":
+        {}; break;
+    case "_limitItems":
+        firstError.params.limit; break;
+    case "_limitLength":
+        firstError.params.limit; break;
+    case "_limitProperties":
+        firstError.params.limit; break;
+    case "multipleOf":
+        firstError.params.multipleOf; break;
+    case "not":
+        {}; break;
+    case "oneOf":
+        firstError.params.passingSchemas; break;
+    case "pattern":
+        firstError.params.pattern; break;
+    case "propertyNames":
+        firstError.params.propertyName;
+        firstError.propertyName;
+        break;
+    case "required":
+        firstError.params.missingProperty; break;
+    case "type":
+        firstError.params.type; break;
+    case "uniqueItems":
+        firstError.params.i;
+        firstError.params.j;
+        break;
+    case "custom":
+        firstError.params.keyword; break;
+    case "patternRequired":
+        firstError.params.missingPattern; break;
+    case "switch":
+        firstError.params.caseIndex; break;
+    case "_formatLimit":
+        firstError.params.comparison;
+        firstError.params.exclusive;
+        firstError.params.limit;
+        break;
+    case "_formatExclusiveLimit":
+        {}; break;
+}
 
 ajv.MissingRefError.message("", "");
 const missingRefError: ajv.MissingRefError = new ajv.MissingRefError("", "", "");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
https://github.com/ajv-validator/ajv/issues/1319: The `ErrorObject`'s params are inaccessible in TypeScript. Example code:
```ts
const validationError: ajv.ValidationError = new ajv.ValidationError([{
    dataPath: ".someKey",
    keyword: "enum",
    params: { allowedValues: ["1", "2", "3"] },
    schemaPath: "",
}]);
validationError.errors[0].params.allowedValues; // TypeError, see below
```

```
$ tsc --target ES5 --noImplicitAny --noEmit spec/typescript/index.ts
spec/typescript/index.ts:60:34 - error TS2339: Property 'allowedValues' does not exist on type 'ErrorParameters'.
  Property 'allowedValues' does not exist on type 'RefParams'.

60 validationError.errors[0].params.allowedValues;
```


**What changes did you make?**
Turned `ErrorObject` into a tagged union type, the tag being the keyword; based on the [errors definition file](https://github.com/ajv-validator/ajv/blob/master/lib/dot/errors.def#L93-L123). I also discovered that there might have been one error params type missing, namely the `OneOfParams` type. So, I added it.


**Is there anything that requires more attention while reviewing?**
Yes, I didn't understand very well the code and the project structure, so I couldn't verify if all keywords are correct and that the relationship between a keyword and its params type is also correct.