### PR TITLE
Add user-friendly message for maxLength validation

### DIFF
--- a/lib/vocabularies/validation/limitLength.ts
+++ b/lib/vocabularies/validation/limitLength.ts
@@ -6,7 +6,7 @@ import ucs2length from "../../compile/ucs2length"
 const error: KeywordErrorDefinition = {
   message({keyword, schemaCode}) {
     const comp = keyword === "maxLength" ? "more" : "fewer"
-    return str`should NOT have ${comp} than ${schemaCode} items`
+    return str`should NOT have ${comp} than ${schemaCode} characters`
   },
   params: ({schemaCode}) => _`{limit: ${schemaCode}}`,
 }


### PR DESCRIPTION
The error message "should not have fewer than 5 items" feels weird for a string of characters. I think we should revert back to v6 terminology and say "characters" instead of "items".
