### PR TITLE
errorsText: Fallback to this.errors for null/undefined

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -577,9 +577,10 @@ export default class Ajv {
   }
 
   errorsText(
-    errors: ErrorObject[] | null | undefined = this.errors, // optional array of validation errors
+    errors: ErrorObject[] | null | undefined = undefined, // optional array of validation errors
     {separator = ", ", dataVar = "data"}: ErrorsTextOptions = {} // optional options with properties `separator` and `dataVar`
   ): string {
+    if (!errors) errors = this.errors;
     if (!errors || errors.length === 0) return "No errors"
     return errors
       .map((e) => `${dataVar}${e.dataPath} ${e.message}`)


### PR DESCRIPTION
**What issue does this pull request resolve?**
Backwards compatibility with v6.

**What changes did you make?**
Fallback to this.errors when the input is null/undefined.
