### PR TITLE
Add gitattributes to force eol=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js eol=lf
+*.ts eol=lf


### PR DESCRIPTION
Without this, eslint fails on Windows when core.autocrlf is true