### PR TITLE
Imports that are generated from standalone code generation are invalid

### DIFF
--- a/lib/compile/index.ts
+++ b/lib/compile/index.ts
@@ -108,7 +108,7 @@ export function compileSchema(this: Ajv, sch: SchemaEnv): SchemaEnv {
   if (sch.$async) {
     _ValidationError = gen.scopeValue("Error", {
       ref: ValidationError,
-      code: _`require("ajv/dist/compile/error_classes").ValidationError`,
+      code: _`require("ajv/lib/compile/error_classes").ValidationError`,
     })
   }
 

--- a/lib/vocabularies/validation/const.ts
+++ b/lib/vocabularies/validation/const.ts
@@ -17,7 +17,7 @@ const def: CodeKeywordDefinition = {
   code(cxt: KeywordCxt) {
     const eql = cxt.gen.scopeValue("func", {
       ref: equal,
-      code: _`require("ajv/dist/compile/equal")`,
+      code: _`require("ajv/lib/compile/equal")`,
     })
     // TODO optimize for scalar values in schema
     cxt.fail$data(_`!${eql}(${cxt.data}, ${cxt.schemaCode})`)

--- a/lib/vocabularies/validation/enum.ts
+++ b/lib/vocabularies/validation/enum.ts
@@ -21,7 +21,7 @@ const def: CodeKeywordDefinition = {
     const useLoop = schema.length >= it.opts.loopEnum
     const eql = cxt.gen.scopeValue("func", {
       ref: equal,
-      code: _`require("ajv/dist/compile/equal")`,
+      code: _`require("ajv/lib/compile/equal")`,
     })
     let valid: Code
     if (useLoop || $data) {

--- a/lib/vocabularies/validation/limitLength.ts
+++ b/lib/vocabularies/validation/limitLength.ts
@@ -26,7 +26,7 @@ const def: CodeKeywordDefinition = {
     } else {
       const u2l = cxt.gen.scopeValue("func", {
         ref: ucs2length,
-        code: _`require("ajv/dist/compile/ucs2length").default`,
+        code: _`require("ajv/lib/compile/ucs2length")`,
       })
       len = _`${u2l}(${data})`
     }

--- a/lib/vocabularies/validation/uniqueItems.ts
+++ b/lib/vocabularies/validation/uniqueItems.ts
@@ -63,7 +63,7 @@ const def: CodeKeywordDefinition = {
     function loopN2(i: Name, j: Name): void {
       const eql = cxt.gen.scopeValue("func", {
         ref: equal,
-        code: _`require("ajv/dist/compile/equal")`,
+        code: _`require("ajv/lib/compile/equal")`,
       })
       const outer = gen.name("outer")
       gen.label(outer).for(_`;${i}--;`, () =>


### PR DESCRIPTION
**What issue does this pull request resolve?**
When using ajv's 'standalone' module, imports to modules seem to be invalid. It looks like the files they should reference are in the `lib` directory. I don't know about ajv's internals, but this fixes my use case.

**What changes did you make?**
I searched for `require`'s of "dist" modules (the one I had troubles with was ecs2length), replacing ones that presumably should be "lib" modules.

**Is there anything that requires more attention while reviewing?**
I don't have context about why this is the way it is, maybe I'm missing something.