### PR TITLE
Issue 1421 - allow colons in keyword names

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -739,7 +739,7 @@ function getLogger(logger?: Partial<Logger> | false): Logger {
   throw new Error("logger must implement log, warn and error methods")
 }
 
-const KEYWORD_NAME = /^[a-z_$][a-z0-9_$-]*$/i
+const KEYWORD_NAME = /^[a-z_$][a-z0-9_$-:]*$/i
 
 function checkKeyword(this: Ajv, keyword: string | string[], def?: KeywordDefinition): void {
   const {RULES} = this

--- a/spec/keyword.spec.ts
+++ b/spec/keyword.spec.ts
@@ -1095,6 +1095,10 @@ describe("User-defined keywords", () => {
         ajv.addKeyword("hyphens-are-valid")
       })
 
+      should.not.throw(() => {
+        ajv.addKeyword("colons:are-valid")
+      })
+
       should.throw(() => {
         ajv.addKeyword("3-start-with-number-not-valid")
       }, /invalid name/)


### PR DESCRIPTION
**What issue does this pull request resolve?**
https://github.com/ajv-validator/ajv/issues/1421

**What changes did you make?**
Added ':' to the list of valid characters in the `KEYWORD_NAME` regex in `lib/core.ts`, plus a test for this in `spec/keyword.spec.ts`

**Is there anything that requires more attention while reviewing?**
No.
