### PR TITLE
Issue 1441

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -742,7 +742,7 @@ function getLogger(logger?: Partial<Logger> | false): Logger {
   throw new Error("logger must implement log, warn and error methods")
 }
 
-const KEYWORD_NAME = /^[a-z_$][a-z0-9_$-:]*$/i
+const KEYWORD_NAME = /^[a-z_$][a-z0-9_$:-]*$/i
 
 function checkKeyword(this: Ajv, keyword: string | string[], def?: KeywordDefinition): void {
   const {RULES} = this

--- a/spec/keyword.spec.ts
+++ b/spec/keyword.spec.ts
@@ -1100,6 +1100,10 @@ describe("User-defined keywords", () => {
       })
 
       should.throw(() => {
+        ajv.addKeyword("single-'quote-not-valid")
+      }, /invalid name/)
+
+      should.throw(() => {
         ajv.addKeyword("3-start-with-number-not-valid")
       }, /invalid name/)
 


### PR DESCRIPTION
**What issue does this pull request resolve?**
1441 - https://github.com/ajv-validator/ajv/issues/1441

**What changes did you make?**
Fixed the KEYWORD_NAME regex in `lib/core.ts` to change the range `$-:` to be the explicit characters `$:-`.
Added a test in `spec/keyword.spec.ts` to check that extraneous characters are now excluded.

**Is there anything that requires more attention while reviewing?**
No