### PR TITLE
Add URI import option

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,10 @@ Try it in the Node.js REPL: https://runkit.com/npm/ajv
 In JavaScript:
 
 ```javascript
-// or ESM/TypeScript import
+// ESM/TypeScript import when it's installed locally
 import Ajv from "ajv"
+// ESM/TypeScript import when using inside <script type="module"> or Deno
+import Ajv from "https://cdn.skypack.dev/ajv"
 // Node.js require:
 const Ajv = require("ajv").default
 


### PR DESCRIPTION
**What issue does this pull request resolve?**

No opened issue

**What changes did you make?**

AJV can be imported directly from a URL and besides that being nice to know when coding a client app, that's the only way to import it when using it with Deno

**Is there anything that requires more attention while reviewing?**

I used [Skypack](https://www.skypack.dev/) as the standard because IMHO that's the most promising service to deliver ES modules but don't hesitate to use another service in the example
