### PR TITLE
[RFC] JTD Schema Object

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -428,7 +428,7 @@ interface JTDErrorObject {
 
 This error format is used when using JTD schemas. To simplify usage, you may still generate Ajv error objects using `ajvErrors` option. You can also add a human-readable error message to error objects using option `messages`.
 
-**Please note**: Ajv is not fully consistent with JTD regarding the error objects in some scenarios - it will be consistent by  the time Ajv version 8 is released. Therefore it is not recommended yet to use error objects for any advanced application logic.
+**Please note**: Ajv is not fully consistent with JTD regarding the error objects in some scenarios - it will be consistent by the time Ajv version 8 is released. Therefore it is not recommended yet to use error objects for any advanced application logic.
 
 ### Error parameters
 

--- a/lib/ajv.ts
+++ b/lib/ajv.ts
@@ -26,7 +26,6 @@ export {KeywordCxt}
 export {DefinedError} from "./vocabularies/errors"
 export {JSONType} from "./compile/rules"
 export {JSONSchemaType} from "./types/json-schema"
-export {JTDSchema} from "./types/jtd-schema"
 export {_, str, stringify, nil, Name, Code, CodeGen, CodeGenOptions} from "./compile/codegen"
 
 import type {AnySchemaObject} from "./types"

--- a/lib/ajv.ts
+++ b/lib/ajv.ts
@@ -26,6 +26,7 @@ export {KeywordCxt}
 export {DefinedError} from "./vocabularies/errors"
 export {JSONType} from "./compile/rules"
 export {JSONSchemaType} from "./types/json-schema"
+export {JTDSchema} from "./types/jtd-schema"
 export {_, str, stringify, nil, Name, Code, CodeGen, CodeGenOptions} from "./compile/codegen"
 
 import type {AnySchemaObject} from "./types"

--- a/lib/jtd.ts
+++ b/lib/jtd.ts
@@ -27,6 +27,7 @@ export {KeywordCxt}
 export {_, str, stringify, nil, Name, Code, CodeGen, CodeGenOptions} from "./compile/codegen"
 
 import type {AnySchemaObject} from "./types"
+export {JTDSchemaType} from "./types/jtd-schema"
 import AjvCore, {CurrentOptions} from "./core"
 import jtdVocabulary from "./vocabularies/jtd"
 import jtdMetaSchema from "./refs/jtd-schema"

--- a/lib/types/jtd-schema.ts
+++ b/lib/types/jtd-schema.ts
@@ -1,0 +1,103 @@
+/** required keys of an object, not undefined */
+type RequiredKeys<T> = {
+  [K in keyof T]-?: undefined extends T[K] ? never : K
+}[keyof T]
+
+/** optional or undifined-able keys of an object */
+type OptionalKeys<T> = {
+  [K in keyof T]-?: undefined extends T[K] ? K : never
+}[keyof T]
+
+/** type is true if all elements of T extend T */
+type AllExtend_<T, E> = T extends E ? true : false
+type AllExtend<T, E> = false extends AllExtend_<T, E> ? false : true
+
+/** type is true if type is identically string */
+type IsString_<T> = T extends string ? (string extends T ? true : false) : false
+type IsString<T> = false extends IsString_<T> ? false : true
+
+/** gets only the string literals of a type or null if a type isn't a string literal */
+type NullableStringLiterals<T> = T extends string ? (string extends T ? null : T) : null
+
+/** numeric strings */
+type NumberType = "float32" | "float64" | "int8" | "uint8" | "int16" | "uint16" | "int32" | "uint32"
+
+/** string strings */
+type StringType = "string" | "timestamp"
+
+/** actual schema */
+export type JTDSchema<T, D extends Record<string, unknown> = Record<string, never>> = (
+  | // refs - accepts any key in definitions of the right type
+  {[K in keyof D]: T extends D[K] ? {ref: K} : never}[keyof D]
+  // numbers - only accepts number or union of number literals
+  | (AllExtend<T, number | null> extends true ? {type: NumberType} : never)
+  // booleans - accepts any boolean, incluting just true or false literals
+  | (AllExtend<T, boolean | null> extends true ? {type: "boolean"} : never)
+  // strings - only accepts the type string
+  // TODO accept Date?
+  | (IsString<Exclude<T, null>> extends true ? {type: StringType} : never)
+  // enums - only accepts union of string literals
+  | (// TODO we can't actually check that everything in the union was specified
+    null extends NullableStringLiterals<Exclude<T, null>>
+      ? never
+      : {enum: NullableStringLiterals<Exclude<T, null>>[]})
+  // arrays - only accepts arrays, could be array of unions to be resolved later
+  | (T extends (infer E)[]
+      ? {
+          elements: JTDSchema<E, D>
+        }
+      : never)
+  // all object like
+  | (keyof T extends string
+      ?
+          | // values
+          {
+              values: JTDSchema<T[keyof T], D>
+            }
+          // explicit keys
+          | ((RequiredKeys<Exclude<T, null>> extends never
+              ? {
+                  properties?: Record<string, never>
+                }
+              : {
+                  properties: {[K in RequiredKeys<T>]: JTDSchema<T[K], D>}
+                }) &
+              (OptionalKeys<Exclude<T, null>> extends never
+                ? {
+                    optionalProperties?: Record<string, never>
+                  }
+                : {
+                    optionalProperties: {
+                      [K in OptionalKeys<T>]: JTDSchema<Exclude<T[K], undefined>, D>
+                    }
+                  }) & {
+                additionalProperties?: boolean
+              })
+          // tagged unions
+          | {
+              [K in keyof T]-?: T[K] extends string
+                ? {
+                    discriminator: K
+                    mapping: {
+                      // TODO currently allows descriminator to be present in schema
+                      [M in T[K]]: JTDSchema<Omit<T extends {[D in K]: M} ? T : never, K>, D>
+                    }
+                  }
+                : never
+            }[keyof T]
+          // empty
+          // TODO as written, and object like could get an empty schema which
+          // potentially breaks guarantees, but does match the spec
+          | Record<string, never>
+      : never)
+) & {
+  // extra properties
+  // TODO handle ajv extensions to metadata?
+  metadata?: {[name: string]: unknown}
+  // TODO these should only be allowed at the top level, but typescript doesn't like saying no
+  definitions?: {[K in keyof D]: JTDSchema<D[K], D>}
+} & (null extends T
+    ? {
+        nullable: true
+      }
+    : {nullable?: false})

--- a/spec/types/jtd-schema.spec.ts
+++ b/spec/types/jtd-schema.spec.ts
@@ -1,0 +1,212 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+import type {JTDSchema} from "../.."
+import chai from "../chai"
+const should = chai.should()
+
+describe("JTDSchema typechecks", () => {
+  it("should typecheck number schemas", () => {
+    const numf: JTDSchema<number> = {type: "float64"}
+    should.exist(numf)
+    const numi: JTDSchema<number> = {type: "int32"}
+    should.exist(numi)
+    // @ts-expect-error
+    const numl: JTDSchema<number> = {type: "int64"}
+    should.exist(numl)
+  })
+
+  it("should typecheck boolean schemas", () => {
+    const bool: JTDSchema<boolean> = {type: "boolean"}
+    should.exist(bool)
+    // boolean literals can't be reduced
+    const boolTrue: JTDSchema<true> = {type: "boolean"}
+    should.exist(boolTrue)
+  })
+
+  it("should typecheck string schemas", () => {
+    const str: JTDSchema<string> = {type: "string"}
+    should.exist(str)
+    const time: JTDSchema<string> = {type: "timestamp"}
+    should.exist(time)
+  })
+
+  it("should typecheck enumeration schemas", () => {
+    const enumerate: JTDSchema<"a" | "b"> = {enum: ["a", "b"]}
+    should.exist(enumerate)
+    // don't need to specify everything
+    const enumerateMissing: JTDSchema<"a" | "b" | "c"> = {enum: ["a", "b"]}
+    should.exist(enumerateMissing)
+    // @ts-expect-error
+    const enumerateNumber: JTDSchema<"a" | "b" | 5> = {enum: ["a", "b"]}
+    should.exist(enumerateNumber)
+    // @ts-expect-error
+    const enumerateString: JTDSchema<"a" | "b"> = {type: "string"}
+    should.exist(enumerateString)
+  })
+
+  it("should typecheck elements schemas", () => {
+    const elements: JTDSchema<number[]> = {elements: {type: "float64"}}
+    should.exist(elements)
+    // homogenous tuples works
+    const tupleHomo: JTDSchema<[number, number]> = {elements: {type: "float64"}}
+    should.exist(tupleHomo)
+    // not heterogeneous
+    const tupleHeteroNum: JTDSchema<[number, string]> = {
+      // @ts-expect-error
+      elements: {type: "float64"},
+    }
+    should.exist(tupleHeteroNum)
+    const tupleHeteroString: JTDSchema<[number, string]> = {
+      // @ts-expect-error
+      elements: {type: "string"},
+    }
+    should.exist(tupleHeteroString)
+  })
+
+  it("should typecheck values schemas", () => {
+    const values: JTDSchema<Record<string, number>> = {values: {type: "float64"}}
+    should.exist(values)
+    const valuesDefined: JTDSchema<{prop: number}> = {values: {type: "float64"}}
+    should.exist(valuesDefined)
+  })
+
+  it("should typecheck properties schemas", () => {
+    const properties: JTDSchema<{a: number; b: string}> = {
+      properties: {a: {type: "float64"}, b: {type: "string"}},
+    }
+    should.exist(properties)
+    const optionalProperties: JTDSchema<{a?: number; b?: string}> = {
+      optionalProperties: {a: {type: "float64"}, b: {type: "string"}},
+      additionalProperties: false,
+    }
+    should.exist(optionalProperties)
+    const mixedProperties: JTDSchema<{a: number; b?: string}> = {
+      properties: {a: {type: "float64"}},
+      optionalProperties: {b: {type: "string"}},
+      additionalProperties: true,
+    }
+    should.exist(mixedProperties)
+    const fewerProperties: JTDSchema<{a: number; b: string}> = {
+      // @ts-expect-error
+      properties: {a: {type: "float64"}},
+    }
+    should.exist(fewerProperties)
+  })
+
+  it("should typecheck discriminator schemas", () => {
+    interface A {
+      type: "a"
+      a: number
+    }
+    interface B {
+      type: "b"
+      b?: string
+    }
+
+    const union: JTDSchema<A | B> = {
+      discriminator: "type",
+      mapping: {
+        a: {properties: {a: {type: "float64"}}},
+        b: {
+          optionalProperties: {b: {type: "string"}},
+        },
+      },
+    }
+    should.exist(union)
+    const unionDuplicate: JTDSchema<A | B> = {
+      discriminator: "type",
+      mapping: {
+        a: {properties: {a: {type: "float64"}}},
+        // @ts-expect-error
+        b: {properties: {a: {type: "float64"}}},
+      },
+    }
+    should.exist(unionDuplicate)
+    const unionMissing: JTDSchema<A | B> = {
+      discriminator: "type",
+      // @ts-expect-error
+      mapping: {
+        a: {properties: {a: {type: "float64"}}},
+      },
+    }
+    should.exist(unionMissing)
+  })
+
+  it("should typecheck empty schemas", () => {
+    const empty: JTDSchema<Record<string, never>> = {}
+    should.exist(empty)
+    // probably shouldn't accept this
+    const emptyButFull: JTDSchema<{a: string}> = {}
+    should.exist(emptyButFull)
+  })
+
+  it("should typecheck ref schemas", () => {
+    const refs: JTDSchema<number[], {num: number}> = {
+      definitions: {
+        num: {type: "float64"},
+      },
+      elements: {ref: "num"},
+    }
+    should.exist(refs)
+    const missingDef: JTDSchema<number[], {num: number}> = {
+      // @ts-expect-error
+      definitions: {},
+      elements: {ref: "num"},
+    }
+    should.exist(missingDef)
+    const missingType: JTDSchema<number[]> = {
+      definitions: {},
+      // @ts-expect-error
+      elements: {ref: "num"},
+    }
+    should.exist(missingType)
+  })
+
+  it("should typecheck metadata schemas", () => {
+    const meta: JTDSchema<number> = {type: "float32", metadata: {key: "val"}}
+    should.exist(meta)
+  })
+
+  it("should typecheck nullable schemas", () => {
+    const isNull: JTDSchema<null> = {nullable: true}
+    should.exist(isNull)
+    const notNull: JTDSchema<number> = {type: "float32", nullable: false}
+    should.exist(notNull)
+    const numNull: JTDSchema<number | null> = {type: "float32", nullable: true}
+    should.exist(numNull)
+    // @ts-expect-error
+    const numNotNull: JTDSchema<number | null> = {type: "float32"}
+    should.exist(numNotNull)
+    const boolNull: JTDSchema<boolean | null> = {type: "boolean", nullable: true}
+    should.exist(boolNull)
+    const stringNull: JTDSchema<string | null> = {type: "string", nullable: true}
+    should.exist(stringNull)
+    const enumNull: JTDSchema<"a" | "b" | null> = {enum: ["a", "b"], nullable: true}
+    should.exist(enumNull)
+    const elementsNull: JTDSchema<string[] | null> = {
+      elements: {type: "string"},
+      nullable: true,
+    }
+    should.exist(elementsNull)
+    const valuesNull: JTDSchema<Record<string, string> | null> = {
+      values: {type: "string"},
+      nullable: true,
+    }
+    should.exist(valuesNull)
+    const propsNull: JTDSchema<{a: string; b: number} | null> = {
+      properties: {a: {type: "string"}, b: {type: "int32"}},
+      nullable: true,
+    }
+    should.exist(propsNull)
+    const optPropsNull: JTDSchema<{a?: string; b?: number} | null> = {
+      optionalProperties: {a: {type: "string"}, b: {type: "int32"}},
+      nullable: true,
+    }
+    should.exist(optPropsNull)
+    const refNull: JTDSchema<number | null, {num: number}> = {
+      ref: "num",
+      nullable: true,
+      definitions: {num: {type: "float64"}},
+    }
+    should.exist(refNull)
+  })
+})


### PR DESCRIPTION
**What issue does this pull request resolve?**
Adds a type like the `JSONSchemaType` but for JTD schemas. Notably, because unions are tagged in JTD by default, the discriminator type can determine if the sub schemas match each of the union elements, and there's no indecisiveness between `undefined` and `null`.

This is very much an RFC in that there's a few design decisions that should probably be made before adding this, and there's a few behaviors of this current submission that aren't ideal.

**What changes did you make?**
Added the type, and tests to verify typescripts behavior, although some of the verified behavior is not ideal.

**Is there anything that requires more attention while reviewing?**
There are three major decisions that should probably be decided on, and then there's a number of behaviors that I've called out as odd in the code that should probably also be resolved.

1. The first major decision is if this should only accept schemas that fit the JTD schema definition? For example, JTD says `definitions` is only allowed in a root schema, but typescript doesn't like forbidding properties (but it can be done). Should this definition error if anything extra is specified in a schema (at least anything that's expressly forbidden).
2. Should this type definition be "complete" (not sure if this is really the correct word). I tend to lean towards `iii`, but that's a preference. My thoughts here are messy, but basically the type could:
   1. typecheck if the schema is valid for that type. e.g. this would allow the empty schema for anything. This is valid according to the JTD schema, but invalid for a type assertion.
   2. typecheck if the schema is valid for an instance. e.g. this would allow `Schema<number | string> = { type: "string" }` on other words, validating the schema would produce an instance of the presented type, even if it's narrower.
   3. Both of these. This would mean there are types where the valid schema is `never`, like the above `number | string` since it's not a tagged union.
3. How should AJV extensions be handled, e.g. currently there's no support for `Date` being a valid `timestamp` or specific fields in `metadata` like untagged unions that I'm not sure can be done well.

Other notes from the code that don't fall under the above decisions:
1. for `enum` types there's no way to make sure that everything was specified. This technically means that only `ii` above is possible, but could potentially be overlooked. There might be a way to create a sorted tuple type, but it would add the complexity that enum type must be in sorted order. Not clear how feasible this is or what the runtime of checking it would be for large enumerations.