### PR TITLE
fix: allow readonly arrays in interfaces

### DIFF
--- a/lib/types/json-schema.ts
+++ b/lib/types/json-schema.ts
@@ -38,7 +38,7 @@ export type JSONSchemaType<T, _partial extends boolean = false> = (T extends num
       } & {length: T["length"]}
       minItems: T["length"]
     } & ({maxItems: T["length"]} | {additionalItems: false})
-  : T extends any[]
+  : T extends readonly any[]
   ? {
       type: JSONType<"array", _partial>
       items: JSONSchemaType<T[0]>


### PR DESCRIPTION
Before this change, a readonly array would be inferred as "object":

```ts
interface TransactionInput {
  items: readonly { count: number, productId: string }[]
}

const transactionInputValidator = ajv.compile<TransactionInput>({
  additionalProperties: false,
  properties: {
    items: { type: 'array' }, // <--- Error: TS wants this to be "object"
  },
  required: ['items'],
  type: 'object'
})
```

Now this is properly inferred as "array".

-----

**What issue does this pull request resolve?**

#1447

**What changes did you make?**

Changed `T extends any[]` to `T extends readonly any[]`. This works since `readonly T[]` is a subset of `T[]`, and thus `T[]` always satisfies `readonly T[]`.

**Is there anything that requires more attention while reviewing?**

The one word changed 😄 
