### PR TITLE
add unknown => empty mapping in JTDSchemaType

### DIFF
--- a/lib/types/jtd-schema.ts
+++ b/lib/types/jtd-schema.ts
@@ -133,6 +133,8 @@ export type JTDSchemaType<T, D extends Record<string, unknown> = Record<string, 
       // NOTE there should only be one type that extends Record<string, never> so unions
       // shouldn't be a worry
       | (T extends Record<string, never> ? unknown : never)
+      // unknown also allows empty schema
+      | (unknown extends T ? unknown : never)
       // null
       // NOTE we have to check this too because null as an exclusive type also
       // qualifies for the empty schema

--- a/spec/types/jtd-schema.spec.ts
+++ b/spec/types/jtd-schema.spec.ts
@@ -147,17 +147,7 @@ describe("JTDSchemaType typechecks", () => {
       nullable: true,
     }
 
-    // can't use properties for any object (e.g. keyof = never)
-    const noProperties: TypeEquality<JTDSchemaType<unknown>, never> = true
-
-    void [
-      properties,
-      optionalProperties,
-      mixedProperties,
-      fewerProperties,
-      propertiesNull,
-      noProperties,
-    ]
+    void [properties, optionalProperties, mixedProperties, fewerProperties, propertiesNull]
   })
 
   it("should typecheck discriminator schemas", () => {
@@ -209,6 +199,15 @@ describe("JTDSchemaType typechecks", () => {
         },
       },
     }
+    const unionWithDiscriminator: JTDSchemaType<A | B> = {
+      discriminator: "type",
+      mapping: {
+        a: {properties: {type: {enum: ["a"]}, a: {type: "float64"}}},
+        b: {
+          optionalProperties: {b: {type: "string"}},
+        },
+      },
+    }
     const unionNull: JTDSchemaType<A | B | null> = {
       discriminator: "type",
       mapping: {
@@ -226,18 +225,29 @@ describe("JTDSchemaType typechecks", () => {
       never
     > = true
 
-    void [union, unionDuplicate, unionMissing, multOne, multTwo, unionNull, noCommon]
+    void [
+      union,
+      unionDuplicate,
+      unionMissing,
+      multOne,
+      multTwo,
+      unionWithDiscriminator,
+      unionNull,
+      noCommon,
+    ]
   })
 
   it("should typecheck empty schemas", () => {
     const empty: JTDSchemaType<Record<string, never>> = {}
+    // unknown can be null
+    const emptyUnknown: JTDSchemaType<unknown> = {nullable: true}
     // can only use empty for empty and null
     // @ts-expect-error
     const emptyButFull: JTDSchemaType<{a: string}> = {}
     const emptyNull: JTDSchemaType<null> = {nullable: true}
     const emptyMeta: JTDSchemaType<Record<string, never>> = {metadata: {}}
 
-    void [empty, emptyButFull, emptyNull, emptyMeta]
+    void [empty, emptyUnknown, emptyButFull, emptyNull, emptyMeta]
   })
 
   it("should typecheck ref schemas", () => {
@@ -278,7 +288,22 @@ describe("JTDSchemaType typechecks", () => {
       nullable: true,
     }
 
-    void [refs, missingDef, missingType, nullRefs, refsNullOne, refsNullTwo]
+    // can type recursive schemas
+    type LinkedList = {val: number; next: LinkedList} | null
+    const linkedListSchema: JTDSchemaType<LinkedList, {node: LinkedList}> = {
+      definitions: {
+        node: {
+          properties: {
+            val: {type: "float64"},
+            next: {ref: "node"},
+          },
+          nullable: true,
+        },
+      },
+      ref: "node",
+    }
+
+    void [refs, missingDef, missingType, nullRefs, refsNullOne, refsNullTwo, linkedListSchema]
   })
 
   it("should typecheck metadata schemas", () => {


### PR DESCRIPTION
**What issue does this pull request resolve?**
Makes sure that unknown types can be validated with an empty schema

**What changes did you make?**
Added the above change, and also some tests, notably a test that shows that typescript doesn't error when specifying the discriminator again in the schema (although I'm not sure why). And a test of a recursive schema.

**Is there anything that requires more attention while reviewing?**
should be pretty straightforward
