### PR TITLE
Documentation for JTDSchemaType

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ if (validate(data)) {
 
 With JSON Type Definition schema:
 
+In JavaScript:
+
 ```javascript
 const Ajv = require("ajv").default
 
@@ -290,6 +292,22 @@ if (!valid) console.log(validate.errors)
 const valid1 = validate(1) // false, bot an object
 const valid2 = validate({}) // false, foo is required
 const valid3 = validate({foo: 1, bar: 2}) // false, bar is additional
+```
+
+In TypeScript:
+
+```typescript
+import {JTDSchemaType} from "ajv"
+
+type MyData = {foo: number}
+
+// Optional schema type annotation for schema to match MyData type.
+// To use JTDSchemaType set `strictNullChecks: true` in tsconfig `compilerOptions`.
+const schema: JTDSchemaType<MyData> = {
+  properties: {
+    foo: {type: "float64"},
+  },
+}
 ```
 
 See [this test](./spec/types/json-schema.spec.ts) for an advanced example, [API reference](./docs/api.md) and [Options](./docs/api.md#options) for more details.

--- a/docs/json-type-definition.md
+++ b/docs/json-type-definition.md
@@ -325,14 +325,14 @@ Most straightforward types should work with `JTDSchemaType`, e.g.
 interface MyType {
     num: number;
     optionalStr?: string;
-    nullableEnum: "1" | "2";
+    nullableEnum: "v1.0" | "v1.2" | null;
     values: Record<string, number>;
 }
 
 const schema: JTDSchemaType<MyType> = {
     properties: {
         num: { type: "float64" },
-        nullableEnum: { enum: ["1", "2"], nullable: true },
+        nullableEnum: { enum: ["v1.0", "v1.2"], nullable: true },
         values: { values: { type: "int32" } },
     },
     optionalProperties: {


### PR DESCRIPTION
**What issue does this pull request resolve?**

Adds some documentation to `JTDSchemaType`

**What changes did you make?**

See above

**Is there anything that requires more attention while reviewing?**

I'm not really sure how much detail you want. This seems like enough to me, but I'm definitely open. I'm not sure the usage of JTD in the readme is correct. Can you just import AJV or do you need to import AjvJTD? Or pass the `jtd: true` option? Can you import nested directories in typescript, (e.g. does `import AjvJTD from "ajv/dist/jtd";` work?) ?I've only used the types in deno.

Again, this is stacked, so ignore the first commit.
