### PR TITLE
Migrate to ES imports

### DIFF
--- a/lib/ajv.ts
+++ b/lib/ajv.ts
@@ -31,7 +31,7 @@ export {_, str, stringify, nil, Name, Code, CodeGen, CodeGenOptions} from "./com
 import type {AnySchemaObject} from "./types"
 import AjvCore from "./core"
 import draft7Vocabularies from "./vocabularies/draft7"
-import draft7MetaSchema = require("./refs/json-schema-draft-07.json")
+import * as draft7MetaSchema from "./refs/json-schema-draft-07.json"
 
 const META_SUPPORT_DATA = ["/properties"]
 

--- a/lib/compile/index.ts
+++ b/lib/compile/index.ts
@@ -14,7 +14,7 @@ import N from "./names"
 import {LocalRefs, getFullPath, _getFullPath, inlineRef, normalizeId, resolveUrl} from "./resolve"
 import {schemaHasRulesButRef, unescapeFragment} from "./util"
 import {validateFunctionCode} from "./validate"
-import URI = require("uri-js")
+import * as URI from "uri-js"
 import {JSONType} from "./rules"
 
 export type SchemaRefs = {

--- a/lib/compile/resolve.ts
+++ b/lib/compile/resolve.ts
@@ -1,9 +1,9 @@
 import type {AnySchema, AnySchemaObject} from "../types"
 import type Ajv from "../ajv"
 import {eachItem} from "./util"
-import equal = require("fast-deep-equal")
-import traverse = require("json-schema-traverse")
-import URI = require("uri-js")
+import * as equal from "fast-deep-equal"
+import * as traverse from "json-schema-traverse"
+import * as URI from "uri-js"
 
 // the hash of local references inside the schema (created by getSchemaRefs), used for inline resolution
 export type LocalRefs = {[Ref in string]?: AnySchemaObject}

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -58,7 +58,7 @@ import {normalizeId, getSchemaRefs} from "./compile/resolve"
 import {getJSONTypes} from "./compile/validate/dataType"
 import {eachItem} from "./compile/util"
 
-import $dataRefSchema = require("./refs/data.json")
+import * as $dataRefSchema from "./refs/data.json"
 
 const META_IGNORE_OPTIONS: (keyof Options)[] = ["removeAdditional", "useDefaults", "coerceTypes"]
 const EXT_SCOPE_NAMES = new Set([

--- a/lib/refs/json-schema-2019-09/index.ts
+++ b/lib/refs/json-schema-2019-09/index.ts
@@ -1,12 +1,12 @@
 import type Ajv from "../../core"
 import type {AnySchemaObject} from "../../types"
-import metaSchema = require("./schema.json")
-import metaApplicator = require("./meta/applicator.json")
-import metaContent = require("./meta/content.json")
-import metaCore = require("./meta/core.json")
-import metaFormat = require("./meta/format.json")
-import metaMetadata = require("./meta/meta-data.json")
-import metaValidation = require("./meta/validation.json")
+import * as metaSchema from "./schema.json"
+import * as metaApplicator from "./meta/applicator.json"
+import * as metaContent from "./meta/content.json"
+import * as metaCore from "./meta/core.json"
+import * as metaFormat from "./meta/format.json"
+import * as metaMetadata from "./meta/meta-data.json"
+import * as metaValidation from "./meta/validation.json"
 
 const META_SUPPORT_DATA = ["/properties"]
 

--- a/lib/standalone/instance.ts
+++ b/lib/standalone/instance.ts
@@ -1,6 +1,6 @@
 import Ajv, {AnySchema, AnyValidateFunction, ErrorObject} from "../core"
 import standaloneCode from "."
-import requireFromString = require("require-from-string")
+import * as requireFromString from "require-from-string"
 
 export default class AjvPack {
   errors?: ErrorObject[] | null // errors from the last validation

--- a/lib/vocabularies/validation/const.ts
+++ b/lib/vocabularies/validation/const.ts
@@ -1,7 +1,7 @@
 import type {CodeKeywordDefinition, ErrorObject, KeywordErrorDefinition} from "../../types"
 import type KeywordCxt from "../../compile/context"
 import {_} from "../../compile/codegen"
-import equal = require("fast-deep-equal")
+import * as equal from "fast-deep-equal"
 
 export type ConstError = ErrorObject<"const", {allowedValue: any}>
 

--- a/lib/vocabularies/validation/enum.ts
+++ b/lib/vocabularies/validation/enum.ts
@@ -1,7 +1,7 @@
 import type {CodeKeywordDefinition, ErrorObject, KeywordErrorDefinition} from "../../types"
 import type KeywordCxt from "../../compile/context"
 import {_, or, Name, Code} from "../../compile/codegen"
-import equal = require("fast-deep-equal")
+import * as equal from "fast-deep-equal"
 
 export type EnumError = ErrorObject<"enum", {allowedValues: any[]}, any[] | {$data: string}>
 

--- a/lib/vocabularies/validation/uniqueItems.ts
+++ b/lib/vocabularies/validation/uniqueItems.ts
@@ -2,7 +2,7 @@ import type {CodeKeywordDefinition, ErrorObject, KeywordErrorDefinition} from ".
 import type KeywordCxt from "../../compile/context"
 import {checkDataTypes, getSchemaTypes, DataType} from "../../compile/validate/dataType"
 import {_, str, Name} from "../../compile/codegen"
-import equal = require("fast-deep-equal")
+import * as equal from "fast-deep-equal"
 
 export type UniqueItemsError = ErrorObject<
   "uniqueItems",


### PR DESCRIPTION
**What issue does this pull request resolve?**
Removes the use of "require" in es code. This should allow using ajv with deno, and arguably makes the code cleaner by removing one dependency on common-js-like syntax.

**What changes did you make?**
This replaces almost all instances of require with `import * as <name> from "<path>"`. It's not clear to me why these weren't using es imports, and I could believe there is a reason so feel free to reject it. All tests passed on my local machine.

**Is there anything that requires more attention while reviewing?**
If there's some reason why this is a bad idea that I missed. I scanned for similar PRs / issues, but didn't find anything.
