### PR TITLE
types: expose SchemaValidateFunction

### DIFF
--- a/lib/ajv.ts
+++ b/lib/ajv.ts
@@ -15,6 +15,7 @@ export {
   AnySchema,
   ValidateFunction,
   AsyncValidateFunction,
+  SchemaValidateFunction,
   ErrorObject,
   ErrorNoParams,
 } from "./types"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

I'm trying to update `ajv` from v6 to v7.
In that way, we had to define the type of a validation function locally even `ajv` has the type definition.
This PR allows us to use `SchemaValidateFunction` to define a validation function.

- https://ajv.js.org/docs/keywords.html#define-keyword-with-validation-function
- https://github.com/kintone/js-sdk/pull/636/files#diff-d5a911011e45cad491e7becc159811e9b989c609694dc91a5aea51c797f17d40R14-R18

**What changes did you make?**

I've exposed `SchemaValidateFunction` from the entry point of `ajv`.

**Is there anything that requires more attention while reviewing?**
