### PR TITLE
feat: expose PropertiesSchema and RequiredMembers types

### DIFF
--- a/lib/types/json-schema.ts
+++ b/lib/types/json-schema.ts
@@ -98,11 +98,11 @@ type Known = KnownRecord | [Known, ...Known[]] | Known[] | number | string | boo
 
 interface KnownRecord extends Record<string, Known> {}
 
-type PropertiesSchema<T> = {
+export type PropertiesSchema<T> = {
   [K in keyof T]-?: (JSONSchemaType<T[K]> & Nullable<T[K]>) | {$ref: string}
 }
 
-type RequiredMembers<T> = {
+export type RequiredMembers<T> = {
   [K in keyof T]-?: undefined extends T[K] ? never : K
 }[keyof T]
 


### PR DESCRIPTION
**What issue does this pull request resolve?**
If we have a properties schema or required members that share across multiple schema then we would like to declare it separately. So, we need `PropertiesSchema` and `RequiredMembers` types to help us declare value.

**What changes did you make?**
Export type `PropertiesSchema` and type `RequiredMembers`.

**Is there anything that requires more attention while reviewing?**
No.