### PR TITLE
fix: Array type in JSONSchemaType should allow ReadonlyArray too

### DIFF
--- a/lib/types/json-schema.ts
+++ b/lib/types/json-schema.ts
@@ -34,7 +34,7 @@ export type JSONSchemaType<T, _partial extends boolean = false> = (T extends num
       // JSON AnySchema for tuple
       type: JSONType<"array", _partial>
       items: {
-        [K in keyof T]-?: JSONSchemaType<T[K]> & Nullable<T[K]>
+        readonly [K in keyof T]-?: JSONSchemaType<T[K]> & Nullable<T[K]>
       } & {length: T["length"]}
       minItems: T["length"]
     } & ({maxItems: T["length"]} | {additionalItems: false})
@@ -59,14 +59,14 @@ export type JSONSchemaType<T, _partial extends boolean = false> = (T extends num
       type: JSONType<"object", _partial>
       // "required" type does not guarantee that all required properties are listed
       // it only asserts that optional cannot be listed
-      required: _partial extends true ? (keyof T)[] : RequiredMembers<T>[]
+      required: _partial extends true ? Readonly<(keyof T)[]> : Readonly<RequiredMembers<T>[]>
       additionalProperties?: boolean | JSONSchemaType<T[string]>
       unevaluatedProperties?: boolean | JSONSchemaType<T[string]>
       properties?: _partial extends true ? Partial<PropertiesSchema<T>> : PropertiesSchema<T>
       patternProperties?: {[Pattern in string]?: JSONSchemaType<T[string]>}
       propertyNames?: JSONSchemaType<string>
-      dependencies?: {[K in keyof T]?: (keyof T)[] | PartialSchema<T>}
-      dependentRequired?: {[K in keyof T]?: (keyof T)[]}
+      dependencies?: {[K in keyof T]?: Readonly<(keyof T)[]> | PartialSchema<T>}
+      dependentRequired?: {[K in keyof T]?: Readonly<(keyof T)[]>}
       dependentSchemas?: {[K in keyof T]?: PartialSchema<T>}
       minProperties?: number
       maxProperties?: number
@@ -85,9 +85,9 @@ export type JSONSchemaType<T, _partial extends boolean = false> = (T extends num
   definitions?: {
     [Key in string]?: JSONSchemaType<Known, true>
   }
-  allOf?: PartialSchema<T>[]
-  anyOf?: PartialSchema<T>[]
-  oneOf?: PartialSchema<T>[]
+  allOf?: Readonly<PartialSchema<T>[]>
+  anyOf?: Readonly<PartialSchema<T>[]>
+  oneOf?: Readonly<PartialSchema<T>[]>
   if?: PartialSchema<T>
   then?: PartialSchema<T>
   else?: PartialSchema<T>
@@ -110,11 +110,11 @@ type Nullable<T> = undefined extends T
   ? {
       nullable: true
       const?: never // any non-null value would fail `const: null`, `null` would fail any other value in const
-      enum?: (T | null)[] // `null` must be explicitly included in "enum" for `null` to pass
+      enum?: Readonly<(T | null)[]> // `null` must be explicitly included in "enum" for `null` to pass
       default?: T | null
     }
   : {
       const?: T
-      enum?: T[]
+      enum?: Readonly<T[]>
       default?: T
     }


### PR DESCRIPTION
**What issue does this pull request resolve?**
Currently developers can not use `ReadonlyArray` in `JSONSchemaType` like `enum`, `items` (for tuple), `required`, ...

This because in TypeScript, mutable array can assign to read-only array but read-only can not assign to mutable array.

[Example](https://www.typescriptlang.org/play?#code/DYUwLgBAZg9jBcEBKICGATGA7YBPAggE6Gq4A8AzmIQJZYDmAfANwBQrsMEAvBANoByAIwCANBAEAmAQF02rUJABGqQoiq0GfOexWEe-YWInSZEVBQgBjbFTYQIQA)

**What changes did you make?**
Convert every mutable array types to read-only array types in `lib/types/json-schema.ts`.

**Is there anything that requires more attention while reviewing?**
No.
