### PR TITLE
fix: reexport PropertiesSchema and RequiredMember types in ajv.ts

### DIFF
--- a/lib/ajv.ts
+++ b/lib/ajv.ts
@@ -26,7 +26,7 @@ import KeywordCxt from "./compile/context"
 export {KeywordCxt}
 export {DefinedError} from "./vocabularies/errors"
 export {JSONType} from "./compile/rules"
-export {JSONSchemaType} from "./types/json-schema"
+export {JSONSchemaType, PropertiesSchema, RequiredMembers} from "./types/json-schema"
 export {_, str, stringify, nil, Name, Code, CodeGen, CodeGenOptions} from "./compile/codegen"
 
 import type {AnySchemaObject} from "./types"


### PR DESCRIPTION
**What issue does this pull request resolve?**
Last time PR https://github.com/ajv-validator/ajv/pull/1472 did not reexport this two types in `ajv.ts`.

**What changes did you make?**
Reexport `PropertiesSchema` and `RequiredMember` types in `ajv.ts`.

**Is there anything that requires more attention while reviewing?**
No.