### PR TITLE
Mark JSONSchemaType's Record<string,any> required property as optional

### DIFF
--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -363,7 +363,11 @@ _invalid_: `{a: 1, b: 2, c: 3}`
 
 ### `required`
 
-The value of the keyword should be an array of unique strings. The data object to be valid should contain all properties with names equal to the elements in the keyword value.
+The value of this keyword MUST be an array. Elements of this array, if any, MUST be strings, and MUST be unique.
+
+An object instance is valid against this keyword if every item in the array is the name of a property in the instance.
+
+Omitting this keyword has the same behavior as an empty array.
 
 **Example**
 

--- a/lib/types/json-schema.ts
+++ b/lib/types/json-schema.ts
@@ -59,7 +59,7 @@ export type JSONSchemaType<T, _partial extends boolean = false> = (T extends num
       type: JSONType<"object", _partial>
       // "required" type does not guarantee that all required properties are listed
       // it only asserts that optional cannot be listed
-      required: _partial extends true ? Readonly<(keyof T)[]> : Readonly<RequiredMembers<T>[]>
+      required?: _partial extends true ? Readonly<(keyof T)[]> : Readonly<RequiredMembers<T>[]>
       additionalProperties?: boolean | JSONSchemaType<T[string]>
       unevaluatedProperties?: boolean | JSONSchemaType<T[string]>
       properties?: _partial extends true ? Partial<PropertiesSchema<T>> : PropertiesSchema<T>

--- a/lib/types/json-schema.ts
+++ b/lib/types/json-schema.ts
@@ -53,7 +53,6 @@ export type JSONSchemaType<T, _partial extends boolean = false> = (T extends num
   : T extends Record<string, any>
   ? {
       // JSON AnySchema for records and dictionaries
-      // "required" is not optional because it is often forgotten
       // "properties" are optional for more concise dictionary schemas
       // "patternProperties" and can be only used with interfaces that have string index
       type: JSONType<"object", _partial>

--- a/lib/vocabularies/validation/required.ts
+++ b/lib/vocabularies/validation/required.ts
@@ -25,12 +25,13 @@ const def: CodeKeywordDefinition = {
   keyword: "required",
   type: "object",
   schemaType: "array",
+  allowUndefined: true,
   $data: true,
   error,
   code(cxt: KeywordCxt) {
     const {gen, schema, schemaCode, data, $data, it} = cxt
     const {opts} = it
-    if (!$data && schema.length === 0) return
+    if (typeof schema === 'undefined' || (!$data && schema.length === 0)) return
     const useLoop = schema.length >= opts.loopRequired
     if (it.allErrors) allErrorsMode()
     else exitOnErrorMode()


### PR DESCRIPTION
This ensures that the required type can be omitted per: https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.5.3

<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
The current json-schema-validation spec suggests that the `required` property can be omitted, behaving as if an empty array were provided.  This updated the type definition for that property to allow it to be omitted.

The relevant text from the spec is the last line in this section:
https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.5.3

It was introduced with Draft 6:
https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.17

**What changes did you make?**
I marked the `required` keyword as optional for JSONSchemaType's Record format and updated all references that I could find for relevant documentation and code comments. I also updated the required vocabulary definition.

**Is there anything that requires more attention while reviewing?**
There is a peculiar compilation error occuring while attempting to run the tests. The failure occurs with only the first commit (that updates the type using the optional property flag via typescript).

I have since attempted to also update the vocabulary for the `required` keyword but am still seeing the same type of compilation error and cannot quite make sense of how that change seemingly breaks the compilation (only while running tests).