### PR TITLE
add union support to JSONSchemaType

### DIFF
--- a/docs/guide/typescript.md
+++ b/docs/guide/typescript.md
@@ -243,3 +243,36 @@ function parseAndLogFoo(json: string): void {
 ```
 </code-block>
 </code-group>
+
+## Type-safe Unions
+
+JSON Type Definition only supports tagged unions, so unions in JTD are fully supported for `JTDSchemaType` and `JTDDataType`.
+JSON Schema is more complex and so `JSONSchemaType` has limited support for type safe unions.
+`JSONSchemaType` will type check unions where each union element is fully specified as an element of an `anyOf` array or `oneOf` array.
+Additionaly, unions of primitives will type check appropriately if they're combined into an array `type`, e.g. `{ type: ["string", "number"] }`.
+Note that due to current restrictions in typescript, these can't verify that every element is typechecked, and the following example is still valid `const schema: JSONSchemaType<number | string> = { type: "string" }`.
+
+Here's a more detailed example showing several union types:
+<code-group>
+<code-block title="JSON Schema">
+```typescript
+import Ajv, {JSONSchemaType} from "ajv"
+const ajv = new Ajv()
+
+type MyUnion = { prop: boolean } | string | number
+
+const schema: JSONSchemaType<MyUnion> = {
+  anyOf: [
+    {
+      type: "object",
+      properties: { prop: { type: "boolean" } },
+      required: ["prop"],
+    },
+    {
+      type: ["string", "number"]
+    }
+  ]
+}
+```
+</code-block>
+</code-group>

--- a/lib/types/json-schema.ts
+++ b/lib/types/json-schema.ts
@@ -85,12 +85,42 @@ export type JSONSchemaType<T, _partial extends boolean = false> = (
       else?: PartialSchema<T>
       not?: PartialSchema<T>
     })
+  // these two unions allow arbitrary unions of types
   | {
       anyOf: readonly JSONSchemaType<T, _partial>[]
     }
   | {
       oneOf: readonly JSONSchemaType<T, _partial>[]
     }
+  // this union allows for { type: (primitive)[] } style schemas
+  | ({
+      type: (T extends number
+        ? JSONType<"number" | "integer", _partial>
+        : T extends string
+        ? JSONType<"string", _partial>
+        : T extends boolean
+        ? JSONType<"boolean", _partial>
+        : never)[]
+    } & (T extends number
+      ? {
+          minimum?: number
+          maximum?: number
+          exclusiveMinimum?: number
+          exclusiveMaximum?: number
+          multipleOf?: number
+          format?: string
+        }
+      : T extends string
+      ? {
+          type: JSONType<"string", _partial>
+          minLength?: number
+          maxLength?: number
+          pattern?: string
+          format?: string
+        }
+      : T extends boolean
+      ? unknown
+      : never))
 ) & {
   [keyword: string]: any
   $id?: string

--- a/lib/types/json-schema.ts
+++ b/lib/types/json-schema.ts
@@ -7,75 +7,91 @@ type JSONType<T extends string, _partial extends boolean> = _partial extends tru
   ? T | undefined
   : T
 
-export type JSONSchemaType<T, _partial extends boolean = false> = (T extends number
-  ? {
-      type: JSONType<"number" | "integer", _partial>
-      minimum?: number
-      maximum?: number
-      exclusiveMinimum?: number
-      exclusiveMaximum?: number
-      multipleOf?: number
-      format?: string
+export type JSONSchemaType<T, _partial extends boolean = false> = (
+  | ((T extends number
+      ? {
+          type: JSONType<"number" | "integer", _partial>
+          minimum?: number
+          maximum?: number
+          exclusiveMinimum?: number
+          exclusiveMaximum?: number
+          multipleOf?: number
+          format?: string
+        }
+      : T extends string
+      ? {
+          type: JSONType<"string", _partial>
+          minLength?: number
+          maxLength?: number
+          pattern?: string
+          format?: string
+        }
+      : T extends boolean
+      ? {
+          type: "boolean"
+        }
+      : T extends [any, ...any[]]
+      ? {
+          // JSON AnySchema for tuple
+          type: JSONType<"array", _partial>
+          items: {
+            readonly [K in keyof T]-?: JSONSchemaType<T[K]> & Nullable<T[K]>
+          } & {length: T["length"]}
+          minItems: T["length"]
+        } & ({maxItems: T["length"]} | {additionalItems: false})
+      : T extends readonly any[]
+      ? {
+          type: JSONType<"array", _partial>
+          items: JSONSchemaType<T[0]>
+          contains?: PartialSchema<T[0]>
+          minItems?: number
+          maxItems?: number
+          minContains?: number
+          maxContains?: number
+          uniqueItems?: true
+          additionalItems?: never
+        }
+      : T extends Record<string, any>
+      ? {
+          // JSON AnySchema for records and dictionaries
+          // "required" is not optional because it is often forgotten
+          // "properties" are optional for more concise dictionary schemas
+          // "patternProperties" and can be only used with interfaces that have string index
+          type: JSONType<"object", _partial>
+          // "required" type does not guarantee that all required properties are listed
+          // it only asserts that optional cannot be listed
+          required: _partial extends true ? Readonly<(keyof T)[]> : Readonly<RequiredMembers<T>[]>
+          additionalProperties?: boolean | JSONSchemaType<T[string]>
+          unevaluatedProperties?: boolean | JSONSchemaType<T[string]>
+          properties?: _partial extends true ? Partial<PropertiesSchema<T>> : PropertiesSchema<T>
+          patternProperties?: {[Pattern in string]?: JSONSchemaType<T[string]>}
+          propertyNames?: JSONSchemaType<string>
+          dependencies?: {[K in keyof T]?: Readonly<(keyof T)[]> | PartialSchema<T>}
+          dependentRequired?: {[K in keyof T]?: Readonly<(keyof T)[]>}
+          dependentSchemas?: {[K in keyof T]?: PartialSchema<T>}
+          minProperties?: number
+          maxProperties?: number
+        }
+      : T extends null
+      ? {
+          nullable: true
+        }
+      : never) & {
+      allOf?: Readonly<PartialSchema<T>[]>
+      anyOf?: Readonly<PartialSchema<T>[]>
+      oneOf?: Readonly<PartialSchema<T>[]>
+      if?: PartialSchema<T>
+      then?: PartialSchema<T>
+      else?: PartialSchema<T>
+      not?: PartialSchema<T>
+    })
+  | {
+      anyOf: readonly JSONSchemaType<T, _partial>[]
     }
-  : T extends string
-  ? {
-      type: JSONType<"string", _partial>
-      minLength?: number
-      maxLength?: number
-      pattern?: string
-      format?: string
+  | {
+      oneOf: readonly JSONSchemaType<T, _partial>[]
     }
-  : T extends boolean
-  ? {
-      type: "boolean"
-    }
-  : T extends [any, ...any[]]
-  ? {
-      // JSON AnySchema for tuple
-      type: JSONType<"array", _partial>
-      items: {
-        readonly [K in keyof T]-?: JSONSchemaType<T[K]> & Nullable<T[K]>
-      } & {length: T["length"]}
-      minItems: T["length"]
-    } & ({maxItems: T["length"]} | {additionalItems: false})
-  : T extends readonly any[]
-  ? {
-      type: JSONType<"array", _partial>
-      items: JSONSchemaType<T[0]>
-      contains?: PartialSchema<T[0]>
-      minItems?: number
-      maxItems?: number
-      minContains?: number
-      maxContains?: number
-      uniqueItems?: true
-      additionalItems?: never
-    }
-  : T extends Record<string, any>
-  ? {
-      // JSON AnySchema for records and dictionaries
-      // "required" is not optional because it is often forgotten
-      // "properties" are optional for more concise dictionary schemas
-      // "patternProperties" and can be only used with interfaces that have string index
-      type: JSONType<"object", _partial>
-      // "required" type does not guarantee that all required properties are listed
-      // it only asserts that optional cannot be listed
-      required: _partial extends true ? Readonly<(keyof T)[]> : Readonly<RequiredMembers<T>[]>
-      additionalProperties?: boolean | JSONSchemaType<T[string]>
-      unevaluatedProperties?: boolean | JSONSchemaType<T[string]>
-      properties?: _partial extends true ? Partial<PropertiesSchema<T>> : PropertiesSchema<T>
-      patternProperties?: {[Pattern in string]?: JSONSchemaType<T[string]>}
-      propertyNames?: JSONSchemaType<string>
-      dependencies?: {[K in keyof T]?: Readonly<(keyof T)[]> | PartialSchema<T>}
-      dependentRequired?: {[K in keyof T]?: Readonly<(keyof T)[]>}
-      dependentSchemas?: {[K in keyof T]?: PartialSchema<T>}
-      minProperties?: number
-      maxProperties?: number
-    }
-  : T extends null
-  ? {
-      nullable: true
-    }
-  : never) & {
+) & {
   [keyword: string]: any
   $id?: string
   $ref?: string
@@ -85,13 +101,6 @@ export type JSONSchemaType<T, _partial extends boolean = false> = (T extends num
   definitions?: {
     [Key in string]?: JSONSchemaType<Known, true>
   }
-  allOf?: Readonly<PartialSchema<T>[]>
-  anyOf?: Readonly<PartialSchema<T>[]>
-  oneOf?: Readonly<PartialSchema<T>[]>
-  if?: PartialSchema<T>
-  then?: PartialSchema<T>
-  else?: PartialSchema<T>
-  not?: PartialSchema<T>
 }
 
 type Known = KnownRecord | [Known, ...Known[]] | Known[] | number | string | boolean | null

--- a/lib/types/json-schema.ts
+++ b/lib/types/json-schema.ts
@@ -7,25 +7,31 @@ type JSONType<T extends string, _partial extends boolean> = _partial extends tru
   ? T | undefined
   : T
 
+interface NumberKeywords {
+  minimum?: number
+  maximum?: number
+  exclusiveMinimum?: number
+  exclusiveMaximum?: number
+  multipleOf?: number
+  format?: string
+}
+
+interface StringKeywords {
+  minLength?: number
+  maxLength?: number
+  pattern?: string
+  format?: string
+}
+
 export type JSONSchemaType<T, _partial extends boolean = false> = (
   | ((T extends number
       ? {
           type: JSONType<"number" | "integer", _partial>
-          minimum?: number
-          maximum?: number
-          exclusiveMinimum?: number
-          exclusiveMaximum?: number
-          multipleOf?: number
-          format?: string
-        }
+        } & NumberKeywords
       : T extends string
       ? {
           type: JSONType<"string", _partial>
-          minLength?: number
-          maxLength?: number
-          pattern?: string
-          format?: string
-        }
+        } & StringKeywords
       : T extends boolean
       ? {
           type: "boolean"
@@ -102,22 +108,9 @@ export type JSONSchemaType<T, _partial extends boolean = false> = (
         ? JSONType<"boolean", _partial>
         : never)[]
     } & (T extends number
-      ? {
-          minimum?: number
-          maximum?: number
-          exclusiveMinimum?: number
-          exclusiveMaximum?: number
-          multipleOf?: number
-          format?: string
-        }
+      ? NumberKeywords
       : T extends string
-      ? {
-          type: JSONType<"string", _partial>
-          minLength?: number
-          maxLength?: number
-          pattern?: string
-          format?: string
-        }
+      ? StringKeywords
       : T extends boolean
       ? unknown
       : never))


### PR DESCRIPTION
**What issue does this pull request resolve?**

fixes #1302

somewhat anyway

**What changes did you make?**

In addition to the full JSONSchemaType, it can not also be an empty `anyOf` or `oneOf` construct containing any array of valid schemas. I thought about supporting combinations, but I'm not sure how much sense that makes.

**Is there anything that requires more attention while reviewing?**

A typescript error moved positions in one of the tests, although where there error should throw doesn't seem super relevant.

This does add some weird nested possibilities, but these are all valid schemas.

It's important to note that this is very rudimentary, but it does open some typed schemas up.

Also, the changes to the body of JSONSchemaType besides the part at the end is just whitespace.