### PR TITLE
Add error path to strict mode tuple warning

### DIFF
--- a/lib/vocabularies/applicator/items.ts
+++ b/lib/vocabularies/applicator/items.ts
@@ -46,11 +46,12 @@ export function validateTuple(
   })
 
   function checkStrictTuple(sch: AnySchemaObject): void {
+    const {opts, errSchemaPath} = it
     const l = schArr.length
     const fullTuple = l === sch.minItems && (l === sch.maxItems || sch[extraItems] === false)
-    if (it.opts.strictTuples && !fullTuple) {
-      const msg = `"${keyword}" is ${l}-tuple, but minItems or maxItems/${extraItems} are not specified or different`
-      checkStrictMode(it, msg, it.opts.strictTuples)
+    if (opts.strictTuples && !fullTuple) {
+      const msg = `"${keyword}" is ${l}-tuple, but minItems or maxItems/${extraItems} are not specified or different at path "${errSchemaPath}"`
+      checkStrictMode(it, msg, opts.strictTuples)
     }
   }
 }

--- a/spec/options/strict.spec.ts
+++ b/spec/options/strict.spec.ts
@@ -208,34 +208,49 @@ describe("strict mode", () => {
 
       //@ts-expect-error
       const badSchema1: JSONSchemaType<MyTuple> = {
-        type: "array",
-        items: [{type: "string"}, {type: "number"}],
-        additionalItems: false,
+        type: "object",
+        properties: {
+          test: {
+            type: "array",
+            items: [{type: "string"}, {type: "number"}],
+            additionalItems: false,
+          },
+        },
       }
       should.throw(() => {
         ajv.compile(badSchema1)
-      }, / minItems or maxItems\/additionalItems are not specified or different/)
+      }, / minItems or maxItems\/additionalItems are not specified or different at path "#\/properties\/test"/)
 
       //@ts-expect-error
       const badSchema2: JSONSchemaType<MyTuple> = {
-        type: "array",
-        items: [{type: "string"}, {type: "number"}],
-        minItems: 2,
+        type: "object",
+        properties: {
+          test: {
+            type: "array",
+            items: [{type: "string"}, {type: "number"}],
+            minItems: 2,
+          },
+        },
       }
       should.throw(() => {
         ajv.compile(badSchema2)
-      }, / minItems or maxItems\/additionalItems are not specified or different/)
+      }, / minItems or maxItems\/additionalItems are not specified or different at path "#\/properties\/test"/)
 
       //@ts-expect-error
       const badSchema3: JSONSchemaType<MyTuple> = {
-        type: "array",
-        items: [{type: "string"}, {type: "number"}],
-        minItems: 2,
-        maxItems: 3,
+        type: "object",
+        properties: {
+          test: {
+            type: "array",
+            items: [{type: "string"}, {type: "number"}],
+            minItems: 2,
+            maxItems: 3,
+          },
+        },
       }
       should.throw(() => {
         ajv.compile(badSchema3)
-      }, / minItems or maxItems\/additionalItems are not specified or different/)
+      }, / minItems or maxItems\/additionalItems are not specified or different at path "#\/properties\/test"/)
     })
   })
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
Fixes #1509 
**What changes did you make?**
Added error schema path to the warning message
**Is there anything that requires more attention while reviewing?**
No