### PR TITLE
docs(json-type-definition): fix missing bullet

### DIFF
--- a/docs/json-type-definition.md
+++ b/docs/json-type-definition.md
@@ -53,7 +53,7 @@ It has a required member `type` and an optional members `nullable` and `metadata
   - `"uint16"` - unsigned word value (0 .. 65535)
   - `"int32"` - signed 32-bit integer value
   - `"uint32"` - unsigned 32-bit integer value
-    `type` values that define floating point numbers:
+- `type` values that define floating point numbers:
   - `"float32"` - 32-bit real number
   - `"float64"` - 64-bit real number
 


### PR DESCRIPTION
**What issue does this pull request resolve?**

Fixes unreadable docs:

![image](https://user-images.githubusercontent.com/20914054/112994522-b70dc700-9140-11eb-97b2-7ba2667f7bea.png)

**What changes did you make?** Fixed markdown typo

**Is there anything that requires more attention while reviewing?** No
