### PR TITLE
Smaller package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "files": [
     "lib/",
     "dist/",
-    "scripts/",
     ".tonic_example.js"
   ],
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "types": ["node"],
     "allowJs": true,
     "target": "ES2018",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "sourceMap": false
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

Continuous improvement to #940 

**What changes did you make?**

While digging through the ajv source to look into the ESM creation, I noticed two opportunities to slim down the package size a little bit:

- SourceMaps are generated by Typescript. Since the code is not minified, I don't think this is a major aid in debugging (especially since Node.js, by default, doesn't take them into consideration when creating stack traces) they are big of dead weight. Saving: 268 KB
- The `scripts/` folder is included in the package. This was originally done in fe18ed52f89bc690838940228f2185bae9646df5 to ship the `compile-dots` script. Since that script no longer exists, it might be safe to no longer ship these. Saving: 7KB.

Together this would slash more than 25% of the package size (excluding dependencies).

**Is there anything that requires more attention while reviewing?**

An additional option could be to not ship the `lib/` folder (another 322 KB) but I'm not sure if some other ajv project might consume those files.
