### PR TITLE
Added keyword name and schema path to keyword usage validation error

### DIFF
--- a/lib/compile/validate/keyword.ts
+++ b/lib/compile/validate/keyword.ts
@@ -144,7 +144,7 @@ export function validSchemaType(
 }
 
 export function validateKeywordUsage(
-  {schema, opts, self}: SchemaObjCxt,
+  {schema, opts, self, errSchemaPath}: SchemaObjCxt,
   def: AddedKeywordDefinition,
   keyword: string
 ): void {
@@ -161,7 +161,13 @@ export function validateKeywordUsage(
   if (def.validateSchema) {
     const valid = def.validateSchema(schema[keyword])
     if (!valid) {
-      const msg = "keyword value is invalid: " + self.errorsText(def.validateSchema.errors)
+      const msg =
+        "keyword '" +
+        keyword +
+        "' value is invalid at path '" +
+        errSchemaPath +
+        "': " +
+        self.errorsText(def.validateSchema.errors)
       if (opts.validateSchema === "log") self.logger.error(msg)
       else throw new Error(msg)
     }

--- a/spec/issues/1539_add_keyword_name_to_validation_error.spec.ts
+++ b/spec/issues/1539_add_keyword_name_to_validation_error.spec.ts
@@ -1,0 +1,38 @@
+import _Ajv from "../ajv2019"
+import chai from "../chai"
+const should = chai.should()
+
+describe("keyword usage validation error", () => {
+  it("should include the keyword name and schema path in the message", () => {
+    const ajv = new _Ajv({
+      keywords: [
+        {
+          keyword: "customKeyword",
+          metaSchema: {
+            type: "string",
+          },
+          macro() {
+            return {}
+          },
+        },
+      ],
+    })
+
+    const schema = {
+      type: "object",
+      properties: {
+        foo: {
+          type: "object",
+          customKeyword: {
+            bar: true,
+          },
+        },
+      },
+    }
+
+    should.throw(
+      () => ajv.compile(schema),
+      "keyword 'customKeyword' value is invalid at path '#/properties/foo': data must be string"
+    )
+  })
+})

--- a/spec/keyword.spec.ts
+++ b/spec/keyword.spec.ts
@@ -1055,7 +1055,7 @@ describe("User-defined keywords", () => {
     validate.errors.should.have.length(numErrors)
   }
 
-  function shouldBeInvalidSchema(schema, msg: string | RegExp = /keyword value is invalid/) {
+  function shouldBeInvalidSchema(schema, msg: string | RegExp = /keyword '.+' value is invalid at path/) {
     instances.forEach((_ajv) => {
       should.throw(() => {
         _ajv.compile(schema)

--- a/spec/keyword.spec.ts
+++ b/spec/keyword.spec.ts
@@ -1055,7 +1055,10 @@ describe("User-defined keywords", () => {
     validate.errors.should.have.length(numErrors)
   }
 
-  function shouldBeInvalidSchema(schema, msg: string | RegExp = /keyword '.+' value is invalid at path/) {
+  function shouldBeInvalidSchema(
+    schema,
+    msg: string | RegExp = /keyword '.+' value is invalid at path/
+  ) {
     instances.forEach((_ajv) => {
       should.throw(() => {
         _ajv.compile(schema)


### PR DESCRIPTION
**What issue does this pull request resolve?**
resolves #1539

**What changes did you make?**
Added keyword name & schema path to the reported error message during keyword usage validation.

**Is there anything that requires more attention while reviewing?**
I'm not entirely sure if we need that one extra test, but I added it anyway to be explicit and actually check the full message and not just parts of it.
