### PR TITLE
Add JTDDataType to compile signature

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -30,7 +30,7 @@ export {KeywordCxt} from "./compile/validate"
 export {DefinedError} from "./vocabularies/errors"
 export {JSONType} from "./compile/rules"
 export {JSONSchemaType} from "./types/json-schema"
-export {JTDSchemaType} from "./types/jtd-schema"
+export {JTDSchemaType, SomeJTDSchemaType, JTDDataType} from "./types/jtd-schema"
 export {_, str, stringify, nil, Name, Code, CodeGen, CodeGenOptions} from "./compile/codegen"
 
 import type {
@@ -50,7 +50,7 @@ import type {
   AddedFormat,
 } from "./types"
 import type {JSONSchemaType} from "./types/json-schema"
-import type {JTDSchemaType} from "./types/jtd-schema"
+import type {JTDSchemaType, SomeJTDSchemaType, JTDDataType} from "./types/jtd-schema"
 import ValidationError from "./runtime/validation_error"
 import MissingRefError from "./compile/ref_error"
 import {getRules, ValidationRules, Rule, RuleGroup, JSONType} from "./compile/rules"
@@ -313,6 +313,12 @@ export default class Ajv {
   // Separated for type inference to work
   // eslint-disable-next-line @typescript-eslint/unified-signatures
   validate<T>(schema: JTDSchemaType<T>, data: unknown): data is T
+  // This overload is only intended for typescript inference, the first
+  // argument prevents manual type annotation from matching this overload
+  validate<N extends never, T extends SomeJTDSchemaType>(
+    schema: T,
+    data: unknown
+  ): data is JTDDataType<T>
   validate<T>(schema: AsyncSchema, data: unknown | T): Promise<T>
   validate<T>(schemaKeyRef: AnySchema | string, data: unknown): data is T | Promise<T>
   validate<T>(
@@ -338,6 +344,12 @@ export default class Ajv {
   // Separated for type inference to work
   // eslint-disable-next-line @typescript-eslint/unified-signatures
   compile<T = unknown>(schema: JTDSchemaType<T>, _meta?: boolean): ValidateFunction<T>
+  // This overload is only intended for typescript inference, the first
+  // argument prevents manual type annotation from matching this overload
+  compile<N extends never, T extends SomeJTDSchemaType>(
+    schema: T,
+    _meta?: boolean
+  ): ValidateFunction<JTDDataType<T>>
   compile<T = unknown>(schema: AsyncSchema, _meta?: boolean): AsyncValidateFunction<T>
   compile<T = unknown>(schema: AnySchema, _meta?: boolean): AnyValidateFunction<T>
   compile<T = unknown>(schema: AnySchema, _meta?: boolean): AnyValidateFunction<T> {

--- a/lib/jtd.ts
+++ b/lib/jtd.ts
@@ -1,5 +1,5 @@
 import type {AnySchemaObject, SchemaObject, JTDParser} from "./types"
-import type {JTDSchemaType, JTDDataType} from "./types/jtd-schema"
+import type {JTDSchemaType, SomeJTDSchemaType, JTDDataType} from "./types/jtd-schema"
 import AjvCore, {CurrentOptions} from "./core"
 import jtdVocabulary from "./vocabularies/jtd"
 import jtdMetaSchema from "./refs/jtd-schema"
@@ -125,5 +125,5 @@ export {KeywordCxt} from "./compile/validate"
 export {JTDErrorObject} from "./vocabularies/jtd"
 export {_, str, stringify, nil, Name, Code, CodeGen, CodeGenOptions} from "./compile/codegen"
 
-export {JTDSchemaType, JTDDataType}
+export {JTDSchemaType, SomeJTDSchemaType, JTDDataType}
 export {JTDOptions}

--- a/spec/types/jtd-schema.spec.ts
+++ b/spec/types/jtd-schema.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-interface,no-void */
 import _Ajv from "../ajv_jtd"
-import type {JTDSchemaType, JTDDataType} from "../../dist/jtd"
+import type {JTDSchemaType, SomeJTDSchemaType, JTDDataType} from "../../dist/jtd"
 import chai from "../chai"
 const should = chai.should()
 
@@ -353,16 +353,14 @@ describe("JTDDataType", () => {
       },
     } as const
 
-    type MyData1 = JTDDataType<typeof mySchema1>
-
-    const validate = ajv.compile<MyData1>(mySchema1)
+    const validate = ajv.compile(mySchema1)
     const validData: unknown = {type: "a", a: 1}
     if (validate(validData) && validData.type === "a") {
       validData.a.should.equal(1)
     }
     should.not.exist(validate.errors)
 
-    if (ajv.validate<MyData1>(mySchema1, validData) && validData.type === "a") {
+    if (ajv.validate(mySchema1, validData) && validData.type === "a") {
       validData.a.should.equal(1)
     }
     should.not.exist(ajv.errors)
@@ -490,5 +488,15 @@ describe("JTDDataType", () => {
     const empty: TypeEquality<JTDDataType<typeof emptySchema>, unknown> = true
 
     void [empty]
+  })
+})
+
+describe("SomeJTDSchemaType", () => {
+  it("should allow setting unknowns", () => {
+    // This test is basically here to assert that we should be using `{}` in
+    // SomeJTDSchemaType
+    const schema: SomeJTDSchemaType = {}
+
+    void [schema]
   })
 })


### PR DESCRIPTION
**What issue does this pull request resolve?**

#1489

**What changes did you make?**

1. The semantics of `ref` for JTDDataType had to be changed. I don't entirely understand why, but my guess is that infer steps allow the compiler to "take a break" and so this helps with the recursion checking.
2. Added `SomeJTDSchemaType`. This is necessary to prevent typescript from inferring a JTDDataType when actually it's a different schema. This is especially a problem for simple types, e.g. the empty schema is valid JTD so it can confuse things.

**Is there anything that requires more attention while reviewing?**

1. Historically specifying a type for compile indicated that that was the return type. To keep that working, the overload signatures for the JTDDataType returns need to have their first parameter extend never, so that it's only inferred (or it could be specified manually with `compile<never, ActualType>(...)`.
2. In addition, SomeJTDSchemaType needs to use the empty type `{}`, there's a note linking to the issue that discusses how this is the one instance when this is actually what you want, and it's tested.
3. Finally, this works with typescript 4.2.3. However, even with the infer trick, it's very close to the maximum complexity that typescript wants to deal with. Small changes in the overload signature or the way that typescript descides to handle this could result in compile erroring in typescript saying the type is too complex. In that event, this overload could always be removed, but I wanted to raise this potential risk now.

