### PR TITLE
doc: Fix JTD typescript sample error

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -61,15 +61,15 @@ Properties not defined in the schema will not be included in serialized JSON, un
 If you use JTD with typescript, the type for the schema can be derived from the data type, and generated serializer would only accept correct data type in this case:
 
 ```typescript
-import Ajv, {JTDSchemaType} from "ajv/dist/jtd"
+import Ajv from "ajv/dist/jtd"
 const ajv = new Ajv()
 
-interface MyData = {
+interface MyData {
   foo: number
   bar?: string
 }
 
-const mySchema: JTDSchemaType<MyData> = {
+const mySchema = {
   properties: {
     foo: {type: "int32"} // any JTD number type would be accepted here
   },

--- a/docs/api.md
+++ b/docs/api.md
@@ -61,7 +61,7 @@ Properties not defined in the schema will not be included in serialized JSON, un
 If you use JTD with typescript, the type for the schema can be derived from the data type, and generated serializer would only accept correct data type in this case:
 
 ```typescript
-import Ajv from "ajv/dist/jtd"
+import Ajv, {JTDSchemaType} from "ajv/dist/jtd"
 const ajv = new Ajv()
 
 interface MyData {
@@ -69,7 +69,7 @@ interface MyData {
   bar?: string
 }
 
-const mySchema = {
+const mySchema: JTDSchemaType<MyData> = {
   properties: {
     foo: {type: "int32"} // any JTD number type would be accepted here
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

JTD sample code for typescript does not work. tsc couldn't compile it.

ajv: 8.1.0
typescript: 4.2.4

```typescript
import Ajv, {JTDSchemaType} from "ajv/dist/jtd"
const ajv = new Ajv()

interface MyData = {
  foo: number
  bar?: string
}

const mySchema: JTDSchemaType<MyData> = {
  properties: {
    foo: {type: "int32"} // any JTD number type would be accepted here
  },
  optionalProperties: {
    bar: {type: "string"}
  }
}
```

```bash
$ npx ts-node src/main.ts
⨯ Unable to compile TypeScript:
src/main.ts:5:8 - error TS2693: 'number' only refers to a type, but is being used as a value here.

5   foo: number
         ~~~~~~
src/main.ts:6:3 - error TS2304: Cannot find name 'bar'.

6   bar?: string
    ~~~
src/main.ts:6:9 - error TS2693: 'string' only refers to a type, but is being used as a value here.

6   bar?: string
          ~~~~~~
src/main.ts:10:3 - error TS2322: Type '{ properties: { foo: { type: string; }; }; optionalProperties: { bar: { type: string; }; }; }' is not assignable to type 'JTDSchemaType<MyData, Record<string, never>>'.
  Object literal may only specify known properties, and 'properties' does not exist in type 'JTDSchemaType<MyData, Record<string, never>>'.

10   properties: {
     ~~~~~~~~~~~~~
11     foo: {type: "int32"} // any JTD number type would be accepted here
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
12   },
   ~~~
src/main.ts:4:18 - error TS1005: '{' expected.

4 interface MyData = {
                   ~
src/main.ts:6:7 - error TS1109: Expression expected.

6   bar?: string
        ~
```


**What changes did you make?**

1. Use valid syntax for interface
2. Not use JTDSchemaType

After fixing it. I think that it work.
```typescript
import Ajv from "ajv/dist/jtd"
const ajv = new Ajv()

interface MyData {
  foo: number
  bar?: string
}

const mySchema = {
  properties: {
    foo: {type: "int32"} // any JTD number type would be accepted here
  },
  optionalProperties: {
    bar: {type: "string"}
  }
}

const serializeMyData = ajv.compileSerializer(mySchema);
console.log(serializeMyData({foo: 123}));
```

```bash
$ npx ts-node src/main.ts
{"foo":123}
```


**Is there anything that requires more attention while reviewing?**
