### PR TITLE
Some improvements to JSONSchemaType for records

### DIFF
--- a/spec/types/json-schema.spec.ts
+++ b/spec/types/json-schema.spec.ts
@@ -145,6 +145,8 @@ const invalidSchema: JSONSchemaType<MyData> = {
   type: [],
 }
 
+type MyEnumRecord = Record<"a" | "b" | "c" | "d", number | undefined>
+
 describe("JSONSchemaType type and validation as a type guard", () => {
   const ajv = new _Ajv({allowUnionTypes: true})
 
@@ -257,6 +259,35 @@ describe("JSONSchemaType type and validation as a type guard", () => {
         validData.foo.should.equal("foo")
       }
       should.not.exist(ajv.errors)
+    })
+  })
+
+  describe("schema should be simple for record types", () => {
+    it("typechecks a valid type without required", () => {
+      const myEnumRecordSchema: JSONSchemaType<MyEnumRecord> = {
+        type: "object",
+        propertyNames: {enum: ["a", "b", "c", "d"]},
+        additionalProperty: {type: "number"},
+      }
+      // eslint-disable-next-line no-void
+      void myEnumRecordSchema
+    })
+
+    it("requires required for non-optional types", () => {
+      // @ts-expect-error missing required
+      const requiredSchema: JSONSchemaType<{a: number}> = {
+        type: "object",
+      }
+      // eslint-disable-next-line no-void
+      void requiredSchema
+    })
+
+    it("doesn't require required for optional types", () => {
+      const optionalSchema: JSONSchemaType<{a?: number}> = {
+        type: "object",
+      }
+      // eslint-disable-next-line no-void
+      void optionalSchema
     })
   })
 })


### PR DESCRIPTION




**What issue does this pull request resolve?**

fixes #1491

**What changes did you make?**

For `JSONSchemaType`: additional properties doesn't required `type: "string"` since it's
implied. `required` is no long required for objects without any required
members.

**Is there anything that requires more attention while reviewing?**

1. While I think that ultimately this makes the type support better for records, It does make the type definition itself a bit messier, so I'm open to the perspective that that messiness isn't worth the improvement
2. I chose to keep `required` required for partial types. I think that makes sense, but it's worth calling out.
3. The tests are only type tests, I can add schema validation tests too if you think it's necessary