### PR TITLE
ci(build): add parallel test coverage calculation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,3 +35,15 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
+          flag-name: run-${{ matrix.node-version }}-${{ matrix.os }}
+
+  coverage:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

At present, parallel jobs are run in the build workflow but only one coverage report is submitted to Coveralls.
As an example, compare the number of job reports in [this build of Fastify](https://coveralls.io/builds/39298323) with a report for an [Ajv build](https://coveralls.io/builds/39351320).

This PR resolves this by collecting all coverage from parallel jobs, allowing Coveralls to generate an aggregated score.
This will also allow developers to see where coverage is missing dependent on OS or node.js version.

**What changes did you make?**

- Added `coverage` job
- Added `parallel` and `flag-name` options (see supporting [documentation here](https://github.com/coverallsapp/github-action#inputs)) to `coveralls` step of `build` job

**Is there anything that requires more attention while reviewing?**

N/A
