### PR TITLE
Expand discriminators use case

### DIFF
--- a/lib/vocabularies/discriminator/index.ts
+++ b/lib/vocabularies/discriminator/index.ts
@@ -1,3 +1,4 @@
+import {resolveRef} from "../../compile"
 import type {CodeKeywordDefinition, AnySchemaObject, KeywordErrorDefinition} from "../../types"
 import type {KeywordCxt} from "../../compile/validate"
 import {_, getProperty, Name} from "../../compile/codegen"
@@ -63,18 +64,49 @@ const def: CodeKeywordDefinition = {
       let tagRequired = true
       for (let i = 0; i < oneOf.length; i++) {
         const sch = oneOf[i]
+
+        if (sch.properties) {
+          resolveTagName(sch, i)
+          continue
+        }
+        
+        if (sch.allOf && Array.isArray(sch.allOf)) {
+          const firstMatchingSubSchema = sch.allOf
+            .map((subSchema: AnySchemaObject) => {
+              if (subSchema.$ref === undefined) {
+                return subSchema
+              }
+
+              const {baseId, schemaEnv: env, self} = it
+              const {root} = env
+              return resolveRef.call(self, root, baseId, subSchema.$ref)
+            })
+            .find((subSchema: any) => typeof subSchema.properties?.[tagName] === "object")
+
+          if (firstMatchingSubSchema === undefined) {
+            throw new Error(
+              `discriminator: one of the allOf schemas must define properties/${tagName}`
+            )
+          }
+
+          resolveTagName(firstMatchingSubSchema, i)
+        }
+      }
+
+      if (!tagRequired) throw new Error(`discriminator: "${tagName}" must be required`)
+      return oneOfMapping
+
+      function hasRequired({required}: AnySchemaObject): boolean {
+        return Array.isArray(required) && required.includes(tagName)
+      }
+
+      function resolveTagName(sch: AnySchemaObject, i: number): void {
         const propSch = sch.properties?.[tagName]
         if (typeof propSch != "object") {
           throw new Error(`discriminator: oneOf schemas must have "properties/${tagName}"`)
         }
         tagRequired = tagRequired && (topRequired || hasRequired(sch))
         addMappings(propSch, i)
-      }
-      if (!tagRequired) throw new Error(`discriminator: "${tagName}" must be required`)
-      return oneOfMapping
-
-      function hasRequired({required}: AnySchemaObject): boolean {
-        return Array.isArray(required) && required.includes(tagName)
       }
 
       function addMappings(sch: AnySchemaObject, i: number): void {

--- a/spec/discriminator.spec.ts
+++ b/spec/discriminator.spec.ts
@@ -81,6 +81,45 @@ describe("discriminator keyword", function () {
     })
   })
 
+  describe("schemas with allOf", () => {
+    const schemas = [
+      {
+        type: "object",
+        discriminator: {propertyName: "foo"},
+        oneOf: [
+          {
+            allOf: [
+              {
+                properties: {
+                  foo: {const: "x"},
+                  a: {type: "string"},
+                },
+                required: ["foo", "a"],
+              },
+            ]
+          },
+          {
+            allOf: [
+              {
+                properties: {
+                  foo: {enum: ["y", "z"]},
+                  b: {type: "string"},
+                },
+                required: ["foo", "b"],
+              }
+            ]
+          },
+        ],
+        required: ["foo"]
+      }
+    ]
+
+    it("should allow schemas with allOf", ()=> {
+      assertValid(schemas, {foo: "x", a: "a"})
+      assertValid(schemas, {foo: "y", b: "b"})
+      assertInvalid(schemas, {foo: "x", b: "b"})
+    })
+  });
   describe("valid schemas", () => {
     it("should have oneOf", () => {
       invalidSchema(

--- a/spec/discriminator.spec.ts
+++ b/spec/discriminator.spec.ts
@@ -120,6 +120,58 @@ describe("discriminator keyword", function () {
       assertInvalid(schemas, {foo: "x", b: "b"})
     })
   });
+
+  describe("schemas with refs", () => {
+    const schemas = [
+      {
+        $id: "http://x.y.z/rootschema.json#",
+        type: "object",
+        $defs: {
+          schema1: {
+            $id: "first.json",
+            type: "object",
+            properties: {
+              foo: {const: "x"},
+              a: {type: "string"},
+            },
+            required: ["foo", "a"],
+          },
+          schema2: {
+            $id: "second.json",
+            type: "object",
+            properties: {
+              foo: {enum: ["y", "z"]},
+              b: {type: "string"},
+            },
+            required: ["foo", "b"],
+          }
+        },
+        discriminator: {propertyName: "foo"},
+        oneOf: [
+          {
+            allOf: [
+              {
+                $ref: 'first.json',
+              },
+            ]
+          },
+          {
+            allOf: [
+              {
+                $ref: "second.json"
+              }
+            ]
+          },
+        ],
+        required: ["foo"]
+      }
+    ]
+
+    it("should handle refs", ()=> {
+      assertValid(schemas, {foo: "x", a: "a"})
+    })
+  });
+
   describe("valid schemas", () => {
     it("should have oneOf", () => {
       invalidSchema(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

I think it's very unlikely that this should be merged in it's current state; the implementation is fairly naive as I'm not too familiar with ajv, as well as catering to a specific use-case. I'm mainly posting this for other people who bump into the same issue as referenced in #1554. 

I'm not sure how to best resolve handling the different cases (allOf, $ref, others?) without handling all of the cases within this keyword, nor if the approach for dereferencing the $refs is sane. 

**What issue does this pull request resolve?**
Allows using discriminators with allOf and allOf together with $ref keywords. 

**What changes did you make?**

**Is there anything that requires more attention while reviewing?**

I'm happy to refactor this given some pointers on what a better approach would be, otherwise we can close this and it can just serve as "documentation" for other travellers.
