### PR TITLE
Track evaluated properties with pattern properties of schema = true

### DIFF
--- a/lib/vocabularies/applicator/patternProperties.ts
+++ b/lib/vocabularies/applicator/patternProperties.ts
@@ -1,9 +1,10 @@
 import type {CodeKeywordDefinition} from "../../types"
 import type {KeywordCxt} from "../../compile/validate"
-import {schemaProperties, usePattern} from "../code"
+import {allSchemaProperties, usePattern} from "../code"
 import {_, not, Name} from "../../compile/codegen"
-import {checkStrictMode} from "../../compile/util"
+import {alwaysValidSchema, checkStrictMode} from "../../compile/util"
 import {evaluatedPropsToName, Type} from "../../compile/util"
+import {AnySchema} from "../../types"
 
 const def: CodeKeywordDefinition = {
   keyword: "patternProperties",
@@ -12,9 +13,16 @@ const def: CodeKeywordDefinition = {
   code(cxt: KeywordCxt) {
     const {gen, schema, data, parentSchema, it} = cxt
     const {opts} = it
-    const patterns = schemaProperties(it, schema)
-    // TODO mark properties matching patterns with always valid schemas as evaluated
-    if (patterns.length === 0) return
+    const patterns = allSchemaProperties(schema)
+    const validPatterns = patterns.filter((p) => !alwaysValidSchema(it, schema[p] as AnySchema))
+    const checkForUnevaluatedProperties =
+      parentSchema.unevaluatedProperties !== true &&
+      parentSchema.unevaluatedProperties !== undefined
+
+    if (patterns.length === 0 && (validPatterns.length === 0 || !checkForUnevaluatedProperties)) {
+      return
+    }
+
     const checkProperties =
       opts.strictSchema && !opts.allowMatchingProperties && parentSchema.properties
     const valid = gen.name("valid")
@@ -51,18 +59,22 @@ const def: CodeKeywordDefinition = {
     function validateProperties(pat: string): void {
       gen.forIn("key", data, (key) => {
         gen.if(_`${usePattern(cxt, pat)}.test(${key})`, () => {
-          cxt.subschema(
-            {
-              keyword: "patternProperties",
-              schemaProp: pat,
-              dataProp: key,
-              dataPropType: Type.Str,
-            },
-            valid
-          )
+          const alwaysValid = !validPatterns.includes(pat)
+          if (!alwaysValid) {
+            cxt.subschema(
+              {
+                keyword: "patternProperties",
+                schemaProp: pat,
+                dataProp: key,
+                dataPropType: Type.Str,
+              },
+              valid
+            )
+          }
+
           if (it.opts.unevaluated && props !== true) {
             gen.assign(_`${props}[${key}]`, true)
-          } else if (!it.allErrors) {
+          } else if (!alwaysValid && !it.allErrors) {
             // can short-circuit if `unevaluatedProperties` is not supported (opts.next === false)
             // or if all properties were evaluated (props === true)
             gen.if(not(valid), () => gen.break())

--- a/spec/issues/1625_evaluated_truthy_pattern_properties.spec.ts
+++ b/spec/issues/1625_evaluated_truthy_pattern_properties.spec.ts
@@ -1,0 +1,20 @@
+import _Ajv from "../ajv2020"
+import * as assert from "assert"
+
+describe("tracking evaluated properties with pattern properties of schema = true", () => {
+  it("should initialize evaluated properties", () => {
+    const ajv = new _Ajv()
+
+    const schema = {
+      type: "object",
+      patternProperties: {
+        "^x-": true,
+      },
+      unevaluatedProperties: false,
+    }
+
+    const validate = ajv.compile(schema)
+    assert.strictEqual(validate({bar: 1}), false)
+    assert.strictEqual(validate({"x-bar": false}), true)
+  })
+})


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

https://github.com/ajv-validator/ajv/issues/1625

**What changes did you make?**

`patternProperties` that are always valid are tracked now to ensure `unevaluatedProperties` keyword 'works'.

**Is there anything that requires more attention while reviewing?**

`checkForUnevaluatedProperties` check?
