### PR TITLE
Remove incorrect example for `prefixItems`

### DIFF
--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -451,13 +451,7 @@ For the data array to be valid, the items with indices less than the number of s
 
 **Examples**
 
-1.  _schema_: `{type: "array", prefixItems: {type: "integer"}}`
-
-    _valid_: `[1,2,3]`, `[]`
-
-    _invalid_: `[1,"abc"]`
-
-2.  _schema_:
+_schema_:
 
     ```javascript
     {
@@ -470,7 +464,7 @@ For the data array to be valid, the items with indices less than the number of s
 
     _invalid_: `["abc", 1]`, `["abc"]`
 
-The schema in example 2 will log warning by default (see `strictTuples` option), because it defines unconstrained tuple. To define a tuple with exactly 2 elements use [minItems](#minitems) and [items](#items-in-draft-2020-12) keywords (see example 2 in [items](#items-in-draft-2020-12)).
+The schema in example will log warning by default (see `strictTuples` option), because it defines unconstrained tuple. To define a tuple with exactly 2 elements use [minItems](#minitems) and [items](#items-in-draft-2020-12) keywords (see example 2 in [items](#items-in-draft-2020-12)).
 
 ### `additionalItems`
 


### PR DESCRIPTION
**What issue does this pull request resolve?**

A documentation issue: an example of `prefixItems` is incorrect.

**What changes did you make?**

I've removed the faulty example, because it was a copy-paste of previous `items` examples, which already introduce `prefixItems`.

**Is there anything that requires more attention while reviewing?**

No.