### PR TITLE
Linking to the correct keywords reference page

### DIFF
--- a/docs/guide/user-keywords.md
+++ b/docs/guide/user-keywords.md
@@ -56,4 +56,4 @@ console.log(validate(4)) // false
 
 Several keywords (typeof, instanceof, range and propertyNames) are defined in [ajv-keywords](https://github.com/ajv-validator/ajv-keywords) package - they can be used for your schemas and as a starting point for your own keywords.
 
-See [User-defined keywords](./keywords.md) reference for more details.
+See [User-defined keywords](../keywords.md) reference for more details.


### PR DESCRIPTION
**What issue does this pull request resolve?**
https://ajv.js.org/guide/user-keywords.html leads to a 404 when clicking "See User-defined keywords reference for more details."

**What changes did you make?**
I added a dot to the route, now it points to the correct readme file
