### PR TITLE
Fix doc formatting for `prefixItems`

### DIFF
--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -453,16 +453,16 @@ For the data array to be valid, the items with indices less than the number of s
 
 _schema_:
 
-    ```javascript
-    {
-      type: "array",
-      prefixItems: [{type: "integer"}, {type: "string"}]
-    }
-    ```
+```javascript
+{
+  type: "array",
+  prefixItems: [{type: "integer"}, {type: "string"}]
+}
+```
 
-    _valid_: `[1]`, `[1, "abc"]`, `[1, "abc", 2]`, `[]`
+_valid_: `[1]`, `[1, "abc"]`, `[1, "abc", 2]`, `[]`
 
-    _invalid_: `["abc", 1]`, `["abc"]`
+_invalid_: `["abc", 1]`, `["abc"]`
 
 The schema in example will log warning by default (see `strictTuples` option), because it defines unconstrained tuple. To define a tuple with exactly 2 elements use [minItems](#minitems) and [items](#items-in-draft-2020-12) keywords (see example 2 in [items](#items-in-draft-2020-12)).
 


### PR DESCRIPTION
Hello, I was browsing the documentation and the [prefixItems example](https://ajv.js.org/json-schema.html#prefixitems) doesn't seem to be displayed correctly.

I think deindenting the block should fix it:

![Screenshot 2021-07-12 at 9 09 12 AM](https://user-images.githubusercontent.com/89855/125221107-f4fab980-e2f1-11eb-8bee-5b4bb0158d49.png)
