### PR TITLE
fix eslint warnings

### DIFF
--- a/lib/compile/index.ts
+++ b/lib/compile/index.ts
@@ -300,11 +300,12 @@ function getJsonPointer(
 ): SchemaEnv | undefined {
   if (parsedRef.fragment?.[0] !== "/") return
   for (const part of parsedRef.fragment.slice(1).split("/")) {
-    if (typeof schema == "boolean") return
-    schema = schema[unescapeFragment(part)]
-    if (schema === undefined) return
+    if (typeof schema === "boolean") return
+    const partSchema = schema[unescapeFragment(part)]
+    if (partSchema === undefined) return
+    schema = partSchema
     // TODO PREVENT_SCOPE_CHANGE could be defined in keyword def?
-    const schId = typeof schema == "object" && schema[this.opts.schemaId]
+    const schId = typeof schema === "object" && schema[this.opts.schemaId]
     if (!PREVENT_SCOPE_CHANGE.has(part) && schId) {
       baseId = resolveUrl(baseId, schId)
     }

--- a/lib/runtime/parseJson.ts
+++ b/lib/runtime/parseJson.ts
@@ -128,14 +128,16 @@ export function parseJsonString(s: string, pos: number): string | undefined {
         let code = 0
         while (count--) {
           code <<= 4
-          c = s[pos].toLowerCase()
+          c = s[pos]
+          if (c === undefined) {
+            errorMessage("unexpected end")
+            return undefined
+          }
+          c = c.toLowerCase()
           if (c >= "a" && c <= "f") {
             code += c.charCodeAt(0) - CODE_A + 10
           } else if (c >= "0" && c <= "9") {
             code += c.charCodeAt(0) - CODE_0
-          } else if (c === undefined) {
-            errorMessage("unexpected end")
-            return undefined
           } else {
             errorMessage(`unexpected token ${c}`)
             return undefined
@@ -147,6 +149,7 @@ export function parseJsonString(s: string, pos: number): string | undefined {
         errorMessage(`unexpected token ${c}`)
         return undefined
       }
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     } else if (c === undefined) {
       errorMessage("unexpected end")
       return undefined


### PR DESCRIPTION
**What issue does this pull request resolve?**

There were three eslint warnings, all about an unnecessary undefined check, this fixes them.

**What changes did you make?**

They were each slightly different:
1. One had a string index, which could be undefined, followed by a function call that would throw an exception if it was. Given that this wasn't causing crashes, I'm assuming that this branch was never hit, and can be safely remove for the time being.
2. Another has a valid check for an undefined string access, but typescript doesn't make accessing undefined by default. As of TS4.1 we could enable `"noUncheckedIndexedAccess": true` which will make index access also return undefined. That will fix the warning, but it introduces 29 typescript errors. The simplest mitigation would probably be to just ignore those with `!`, but I instead just ignored the warning so that when someone does add that check, they're more inclined to decide if we want to skip the check or enforce it at runtime.
3. Finally, one was a somewhat strange `any` bug. schemas have an index signature, potentially only containing other schemas? The access could be undefined, but schemas index value is any. The code is roughly
   ```
   schema: AnySchema
   schema = schema[key]
   ````
   if `schema[key]` returned undefined, typescript would error here, because you can't elide the undefined value when assigning to schema. typescript types hold for their whole scope, so the assignment doesn't widen the type. In this case, we need to first assign to a placeholder value, check that it's defined, and if so, then assign. This does do one extra variable assignment potentially slowing this down, although it doesn't look like a critical path, and this solution is future proofed for when the Schema index signature isn't any-typed.

**Is there anything that requires more attention while reviewing?**

This is pretty straightforward.