### PR TITLE
Ref fixes

### DIFF
--- a/spec/types/json-schema.spec.ts
+++ b/spec/types/json-schema.spec.ts
@@ -336,6 +336,25 @@ describe("JSONSchemaType type and validation as a type guard", () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       validate(null).should.be.true
     })
+
+    it("validates top level ref", () => {
+      const refSchema: JSONSchemaType<null> = {
+        $ref: "https://some_other_schema",
+      }
+
+      // eslint-disable-next-line no-void
+      void refSchema
+    })
+
+    it("requires toplevel null", () => {
+      // @ts-expect-error needs nullable
+      const nullNum: JSONSchemaType<number | null> = {
+        type: "number",
+      }
+
+      // eslint-disable-next-line no-void
+      void nullNum
+    })
   })
 
   describe("schema handles optional properties", () => {


### PR DESCRIPTION
**What issue does this pull request resolve?**

fixes #1718 1652

**What changes did you make?**

pulled `{ $ref: string }` from being defined on properties, to being a valid "top-level" type. Also pulled `Nullable` along with it. This is somewhat caused by the earlier diff that made nullable mean nullable not undefinable.

**Is there anything that requires more attention while reviewing?**

This is another commit in the stack, so only look at the last commit. The two tests that were added fail on the previous commit.
