### PR TITLE
docs: Fix code example

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -127,14 +127,15 @@ const schema = {
 }
 
 const serialize = ajv.compileSerializer(schema)
-console.log(serialize(data))
-
-const parse = ajv.compileParser(schema)
 
 const data = {
   foo: 1,
   bar: "abc"
 }
+
+console.log(serialize(data))
+
+const parse = ajv.compileParser(schema)
 
 const json = '{"foo": 1, "bar": "abc"}'
 const invalidJson = '{"unknown": "abc"}'


### PR DESCRIPTION
The `const data = {...}` is defined after `serialize(data)` that will throw error: `Reference Error: data is not defined`.

<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
None

**What changes did you make?**
Update docs code example

**Is there anything that requires more attention while reviewing?**
None