### PR TITLE
docs: clarification standalone requirements

### DIFF
--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -70,7 +70,9 @@ const requireFromString = require("require-from-string")
 const standaloneValidate = requireFromString(moduleCode) // for a single default export
 ```
 
-Ajv package should still be a run-time dependency for most schemas, but generated modules can only depend on code in [runtime](https://github.com/ajv-validator/ajv/tree/master/lib/runtime) folder, so the whole Ajv will not be included in the bundle (or executed) if you require the modules with standalone validation code from your application code.
+### Requirement at runtime
+
+To run the standalone generated functions, the Ajv package should still be a run-time dependency for most schemas, but generated modules can only depend on code in [runtime](https://github.com/ajv-validator/ajv/tree/master/lib/runtime) folder, so the whole Ajv will not be included in the bundle (or executed) if you require the modules with standalone validation code from your application code.
 
 ## Configuration and limitations
 


### PR DESCRIPTION
**What issue does this pull request resolve?**

I missed an important step for the standalone mode: the project requires the `ajv` module installation while I was assuming that

> that are pre-compiled and can be used without Ajv

**What changes did you make?**

I have added extra clarity to a very important step to use the standalone feature.

**Is there anything that requires more attention while reviewing?**

No