### PR TITLE
feat: add bigint as primitive type

### DIFF
--- a/lib/compile/jtd/parse.ts
+++ b/lib/compile/jtd/parse.ts
@@ -8,7 +8,7 @@ import N from "../names"
 import {hasPropFunc} from "../../vocabularies/code"
 import {hasRef} from "../../vocabularies/jtd/ref"
 import {intRange, IntType} from "../../vocabularies/jtd/type"
-import {parseJson, parseJsonNumber, parseJsonString} from "../../runtime/parseJson"
+import {parseJson, parseJsonBigInt, parseJsonNumber, parseJsonString} from "../../runtime/parseJson"
 import {useFunc} from "../util"
 import validTimestamp from "../../runtime/timestamp"
 
@@ -272,6 +272,9 @@ function parseType(cxt: ParseCxt): void {
       gen.if(fail, () => parsingError(cxt, str`invalid timestamp`))
       break
     }
+    case "bigint":
+      parseBigInt(cxt);
+      break
     case "float32":
     case "float64":
       parseNumber(cxt)
@@ -323,6 +326,16 @@ function parseNumber(cxt: ParseCxt, maxDigits?: number): void {
     _`"-0123456789".indexOf(${jsonSlice(1)}) < 0`,
     () => jsonSyntaxError(cxt),
     () => parseWith(cxt, parseJsonNumber, maxDigits)
+  )
+}
+
+function parseBigInt(cxt: ParseCxt, maxDigits?: number): void {
+  const {gen} = cxt
+  skipWhitespace(cxt)
+  gen.if(
+    _`"-0123456789".indexOf(${jsonSlice(1)}) < 0`,
+    () => jsonSyntaxError(cxt),
+    () => parseWith(cxt, parseJsonBigInt, maxDigits)
   )
 }
 

--- a/lib/compile/jtd/serialize.ts
+++ b/lib/compile/jtd/serialize.ts
@@ -218,7 +218,7 @@ function serializeType(cxt: SerializeCxt): void {
       )
       break
     default:
-      serializeNumber(cxt)
+      serializeNumber(cxt) // will seralize number, bigint and any other type
   }
 }
 

--- a/lib/compile/rules.ts
+++ b/lib/compile/rules.ts
@@ -1,6 +1,6 @@
 import type {AddedKeywordDefinition} from "../types"
 
-const _jsonTypes = ["string", "number", "integer", "boolean", "null", "object", "array"] as const
+const _jsonTypes = ["string", "number", "integer", "boolean", "null", "object", "array", "bigint"] as const
 
 export type JSONType = typeof _jsonTypes[number]
 
@@ -34,15 +34,16 @@ export interface Rule {
 }
 
 export function getRules(): ValidationRules {
-  const groups: Record<"number" | "string" | "array" | "object", RuleGroup> = {
+  const groups: Record<"number" | "string" | "array" | "object"| "bigint", RuleGroup> = {
     number: {type: "number", rules: []},
     string: {type: "string", rules: []},
     array: {type: "array", rules: []},
     object: {type: "object", rules: []},
+    bigint: {type: "bigint", rules: []}
   }
   return {
-    types: {...groups, integer: true, boolean: true, null: true},
-    rules: [{rules: []}, groups.number, groups.string, groups.array, groups.object],
+    types: {...groups, integer: true, boolean: true, null: true, bigint: true},
+    rules: [{rules: []}, groups.number, groups.string, groups.array, groups.object, groups.bigint],
     post: {rules: []},
     all: {},
     keywords: {},

--- a/lib/refs/json-schema-2019-09/meta/validation.json
+++ b/lib/refs/json-schema-2019-09/meta/validation.json
@@ -78,7 +78,7 @@
       "default": 0
     },
     "simpleTypes": {
-      "enum": ["array", "boolean", "integer", "null", "number", "object", "string"]
+      "enum": ["array", "boolean", "integer", "null", "number", "object", "string", "bigint"]
     },
     "stringArray": {
       "type": "array",

--- a/lib/refs/json-schema-2020-12/meta/validation.json
+++ b/lib/refs/json-schema-2020-12/meta/validation.json
@@ -78,7 +78,7 @@
       "default": 0
     },
     "simpleTypes": {
-      "enum": ["array", "boolean", "integer", "null", "number", "object", "string"]
+      "enum": ["array", "boolean", "integer", "null", "number", "object", "string","bigint"]
     },
     "stringArray": {
       "type": "array",

--- a/lib/refs/json-schema-draft-06.json
+++ b/lib/refs/json-schema-draft-06.json
@@ -16,7 +16,7 @@
       "allOf": [{"$ref": "#/definitions/nonNegativeInteger"}, {"default": 0}]
     },
     "simpleTypes": {
-      "enum": ["array", "boolean", "integer", "null", "number", "object", "string"]
+      "enum": ["array", "boolean", "integer", "null", "number", "object", "string", "bigint"]
     },
     "stringArray": {
       "type": "array",

--- a/lib/refs/json-schema-draft-07.json
+++ b/lib/refs/json-schema-draft-07.json
@@ -16,7 +16,7 @@
       "allOf": [{"$ref": "#/definitions/nonNegativeInteger"}, {"default": 0}]
     },
     "simpleTypes": {
-      "enum": ["array", "boolean", "integer", "null", "number", "object", "string"]
+      "enum": ["array", "boolean", "integer", "null", "number", "object", "string", "bigint"]
     },
     "stringArray": {
       "type": "array",

--- a/lib/refs/jtd-schema.ts
+++ b/lib/refs/jtd-schema.ts
@@ -42,6 +42,7 @@ const typeForm: MetaSchema = (root) => ({
         "uint16",
         "int32",
         "uint32",
+        "bigint"
       ],
     },
   },

--- a/lib/runtime/parseJson.ts
+++ b/lib/runtime/parseJson.ts
@@ -95,6 +95,70 @@ parseJsonNumber.message = undefined as string | undefined
 parseJsonNumber.position = 0 as number
 parseJsonNumber.code = 'require("ajv/dist/runtime/parseJson").parseJsonNumber'
 
+export function parseJsonBigInt(s: string, pos: number, maxDigits?: number): bigint | undefined {
+  let numStr = ""
+  let c: string
+  parseJsonNumber.message = undefined
+  if (s[pos] === "-") {
+    numStr += "-"
+    pos++
+  }
+  if (s[pos] === "0") {
+    numStr += "0"
+    pos++
+  } else {
+    if (!parseDigits(maxDigits)) {
+      errorMessage()
+      return undefined
+    }
+  }
+  if (maxDigits) {
+    parseJsonNumber.position = pos
+    return BigInt(numStr)
+  }
+  if (s[pos] === ".") {
+    numStr += "."
+    pos++
+    if (!parseDigits()) {
+      errorMessage()
+      return undefined
+    }
+  }
+  if (((c = s[pos]), c === "e" || c === "E")) {
+    numStr += "e"
+    pos++
+    if (((c = s[pos]), c === "+" || c === "-")) {
+      numStr += c
+      pos++
+    }
+    if (!parseDigits()) {
+      errorMessage()
+      return undefined
+    }
+  }
+  parseJsonBigInt.position = pos
+  return BigInt(numStr)
+
+  function parseDigits(maxLen?: number): boolean {
+    let digit = false
+    while (((c = s[pos]), c >= "0" && c <= "9" && (maxLen === undefined || maxLen-- > 0))) {
+      digit = true
+      numStr += c
+      pos++
+    }
+    return digit
+  }
+
+  function errorMessage(): void {
+    parseJsonBigInt.position = pos
+    parseJsonBigInt.message = pos < s.length ? `unexpected token ${s[pos]}` : "unexpected end"
+  }
+}
+
+parseJsonBigInt.message = undefined as string | undefined
+parseJsonBigInt.position = 0 as number
+parseJsonBigInt.code = 'require("ajv/dist/runtime/parseJson").parseJsonBigInt'
+
 const escapedChars: {[X in string]?: string} = {
   b: "\b",
   f: "\f",

--- a/lib/types/jtd-schema.ts
+++ b/lib/types/jtd-schema.ts
@@ -9,7 +9,7 @@ export type SomeJTDSchemaType = (
   | // ref
   {ref: string}
   // primitives
-  | {type: NumberType | StringType | "boolean"}
+  | {type: NumberType | StringType | "boolean" | "bigint"}
   // enum
   | {enum: string[]}
   // elements

--- a/lib/vocabularies/jtd/type.ts
+++ b/lib/vocabularies/jtd/type.ts
@@ -19,7 +19,7 @@ export const intRange: {[T in IntType]: [number, number, number]} = {
   uint32: [0, 4294967295, 10],
 }
 
-export type JTDType = "boolean" | "string" | "timestamp" | "float32" | "float64" | IntType
+export type JTDType = "boolean" | "string" | "timestamp" | "float32" | "float64" | IntType | "bigint"
 
 const error: KeywordErrorDefinition = {
   message: (cxt) => typeErrorMessage(cxt, cxt.schema),
@@ -53,6 +53,9 @@ const def: CodeKeywordDefinition = {
         cond = timestampCode(cxt)
         break
       }
+      case "bigint":
+        cond = _`typeof ${data} == "bigint" || typeof ${data} == "string"`
+        break
       case "float32":
       case "float64":
         cond = _`typeof ${data} == "number"`


### PR DESCRIPTION
**What issue does this pull request resolve?**
This PR adds ``bigint`` as a primitive type

**What changes did you make?**
- added ``bigint`` to ``JTDType``
- added ``bigint`` to the coercible types
- added ``bigint`` to the parser
- added ``bigint`` to the rules
- added ``bigint`` to the simpleTypes of ``jtd-schema.json``

**Is there anything that requires more attention while reviewing?**
I didn't implement tests for it, someone needs to help with that.
But I tested it manually with my schema.
