### PR TITLE
Adds comments to properties on Options

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -544,7 +544,7 @@ export interface CodeOptions {
    */
   formats?: Code
   /**
-   * add `source` property (see Source below) to validating function.
+   * add `source` property (seesSource) to validating function.
    */
   source?: boolean
   /**

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -83,63 +83,473 @@ export type Options = CurrentOptions & DeprecatedOptions
 
 export interface CurrentOptions {
   // strict mode options (NEW)
+
+  /**
+   * ### strict
+   *
+   * By default Ajv executes in strict mode, that is designed to prevent any
+   * unexpected behaviours or silently ignored mistakes in schemas (see [Strict
+   * Mode](./strict-mode.md) for more details). It does not change any
+   * validation results, but it makes some schemas invalid that would be
+   * otherwise valid according to JSON Schema specification.
+   *
+   * **Option values:**
+   *
+   * - `true` - throw an exception when any strict mode restriction is violated.
+   * - `"log"` - log warning when any strict mode restriction is violated.
+   * - `false` - ignore all strict mode violations.
+   * - `undefined` (default) - use defaults for options strictSchema,
+   *   strictNumbers, strictTypes, strictTuples and strictRequired.
+   */
   strict?: boolean | "log"
+  /**
+   * ### strictSchema
+   *
+   * Prevent unknown keywords, formats etc. (see [Strict
+   * schema](./strict-mode.md#strict-schema))
+   *
+   * **Option values:**
+   *
+   * - `true` (default) - throw an exception when any strict schema restriction
+   *   is violated.
+   * - `"log"` - log warning when any strict schema restriction is violated.
+   * - `false` - ignore all strict schema violations.
+   */
   strictSchema?: boolean | "log"
+  /**
+   * Whether to accept `NaN` and `Infinity` as number types during validation.
+   *
+   * **Option values:**
+   *
+   * - `true` (default) - fail validation if `NaN` or `Infinity` is passed where
+   *   number is expected.
+   * - `false` - allow `NaN` and `Infinity` as number.
+   */
   strictNumbers?: boolean | "log"
+  /**
+   * ### strictTypes
+   *
+   * See [Strict types](./strict-mode.md#strict-types)
+   *
+   * **Option values:**
+   * - `true` - throw an exception when any strict types restriction is
+   *   violated.
+   * - `"log"` (default) - log warning when any strict types restriction is
+   *   violated.
+   * - `false` - ignore all strict types violations.
+   */
   strictTypes?: boolean | "log"
+  /**
+   * ### strictTuples
+   *
+   * See [Unconstrained tuples](./strict-mode.md#unconstrained-tuples) Option
+   * values:
+   *
+   * - `true` - throw an exception when any strict tuples restriction is
+   *   violated.
+   * - `"log"` (default) - log warning when any strict tuples restriction is
+   *   violated.
+   * - `false` - ignore all strict tuples violations.
+   */
   strictTuples?: boolean | "log"
+  /**
+   * ### strictRequired
+   *
+   * See [Defined required
+   * properties](https://ajv.js.org/strict-mode#defined-required-properties)
+   *
+   * Option values:
+   *
+   * - `true` - throw an exception when strict required restriction is violated.
+   * - `"log"` - log warning when strict required restriction is violated.
+   * - `false` (default) - ignore strict required violations.
+   *
+   **/
   strictRequired?: boolean | "log"
+  /**
+   * ### allowMatchingProperties
+   *
+   * Pass true to allow overlap between "properties" and "patternProperties".
+   * Does not affect other strict mode restrictions.
+   *
+   * See [Strict Mode](https://ajv.js.org/strict-mode.html).
+   *
+   **/
   allowMatchingProperties?: boolean // disables a strict mode restriction
+  /**
+   * ### allowUnionTypes
+   *
+   * Pass true to allow using multiple non-null types in "type" keyword (one of
+   * `strictTypes` restrictions).
+   *
+   * see [Strict types](https://ajv.js.org/strict-mode#strict-types)
+   **/
   allowUnionTypes?: boolean
+  /**
+   * ### validateFormats
+   *
+   * Format validation.
+   *
+   * Option values:
+   *
+   * - `true` (default) - validate formats (see
+   *   [Formats](https://ajv.js.org/guide/formats.md)). In [strict
+   *   mode](https://ajv.js.org/strict-mode.html) unknown formats will throw
+   *   exception during schema compilation (and fail validation in case format
+   *   keyword value is [\$data
+   *   reference](./guide/combining-schemas#data-reference)).
+   * - `false` - do not validate any format keywords (TODO they will still
+   *   collect annotations once supported).
+   **/
   validateFormats?: boolean
+
   // validation and reporting options:
+
+  /**
+   * ### $data
+   *
+   * Support [\$data
+   * references](https://ajv.js.org/guide/combining-schemas#data-reference).
+   * Draft 6 meta-schema that is added by default will be extended to allow
+   * them. If you want to use another meta-schema you need to use
+   * $dataMetaSchema method to add support for $data reference. See
+   * [API](https://ajv.js.org/options.htmlajv-constructor-and-methods).
+   **/
   $data?: boolean
+  /**
+   * ### allErrors
+   *
+   * Check all rules collecting all errors. Default is to return after the first
+   * error.
+   **/
   allErrors?: boolean
+  /**
+   * ### verbose
+   *
+   * Include the reference to the part of the schema (`schema` and
+   * `parentSchema`) and validated data in errors (false by default).
+   **/
   verbose?: boolean
+  /**
+   * ### discriminator
+   *
+   * Support [discriminator
+   * keyword](https://ajv.js.org/json-schema#discriminator) from [OpenAPI
+   * specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md).
+   **/
   discriminator?: boolean
+  /**
+   * ### unicodeRegExp
+   *
+   * By default Ajv uses unicode flag "u" with "pattern" and
+   * "patternProperties", as per JSON Schema spec. See
+   * [RegExp.prototype.unicode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode).
+   *
+   * Option values:
+   *
+   * - `true` (default) - use unicode flag "u".
+   * - `false` - do not use flag "u".
+   **/
   unicodeRegExp?: boolean
-  timestamp?: "string" | "date" // JTD only
+  /**
+   * ### timestamp
+   *
+   * Defines which Javascript types will be accepted for the [JTD timestamp
+   * type](./json-type-definition#type-form).
+   *
+   * By default Ajv will accept both Date objects and
+   * [RFC3339](https://datatracker.ietf.org/doc/rfc3339/) strings. You can
+   * specify allowed values with the option `timestamp: "date"` or `timestamp:
+   * "string"`.
+   *
+   * *JTD only*
+   **/
+  timestamp?: "string" | "date"
+  /**
+   * ### parseDate
+   *
+   * Defines how date-time strings are parsed by [JTD
+   * parsers](https://ajv.js.org/api#jtd-parse). By default Ajv parses date-time
+   * strings as string. Use `parseDate: true` to parse them as Date objects.
+   *
+   * *JTD only*
+   **/
   parseDate?: boolean // JTD only
+  /**
+   * ### allowDate
+   *
+   * Defines how date-time strings are parsed and validated. By default Ajv only
+   * allows full date-time strings, as required by JTD specification. Use
+   * `allowDate: true` to allow date strings both for validation and for
+   * parsing.
+   *
+   * #### *warning*
+   * Option `allowDate` is not portable
+   *
+   * This option makes JTD validation and parsing more permissive and
+   * non-standard. The date strings without time part will be accepted by Ajv,
+   * but will be rejected by other JTD validators.
+   *
+   * *JTD only*
+   **/
   allowDate?: boolean // JTD only
+  /**
+   * ### $comment
+   *
+   * Log or pass the value of `$comment` keyword to a function.
+   *
+   * Option values:
+   *
+   * - `false` (default): ignore \$comment keyword.
+   * - `true`: log the keyword value to console.
+   * - function: pass the keyword value, its schema path and root schema to the
+   *   specified function
+   **/
   $comment?:
     | true
     | ((comment: string, schemaPath?: string, rootSchema?: AnySchemaObject) => unknown)
+  /**
+   * ### formats
+   *
+   * An object with format definitions. Keys and values will be passed to
+   * `addFormat` method. Pass `true` as format definition to ignore some
+   * formats.
+   **/
   formats?: {[Name in string]?: Format}
+  /**
+   * ### keywords
+   *
+   * An array of keyword definitions or strings. Values will be passed to
+   * `addKeyword` method.
+   **/
   keywords?: Vocabulary
+  /**
+   * ### schemas
+   *
+   * An array or object of schemas that will be added to the instance. In case you
+   * pass the array the schemas must have IDs in them. When the object is passed
+   * the method `addSchema(value, key)` will be called for each schema in this
+   * object.
+   **/
   schemas?: AnySchema[] | {[Key in string]?: AnySchema}
+  /**
+   * ### logger
+   *
+   * Sets the logging method. Default is the global `console` object that should
+   * have methods `log`, `warn` and `error`. See [Error
+   * logging](https://ajv.js.org/options.htmlerror-logging).
+   *
+   * Option values:
+   *
+   * - logger instance - it should have methods `log`, `warn` and `error`. If any
+   *   of these methods is missing an exception will be thrown.
+   * - `false` - logging is disabled.
+   **/
   logger?: Logger | false
+  /**
+   * ### loadSchema
+   *
+   * Asynchronous function that will be used to load remote schemas when
+   * `compileAsync` [method](https://ajv.js.org/options.htmlapi-compileAsync) is
+   * used and some reference is missing (option `missingRefs` should NOT be
+   * 'fail' or 'ignore'). This function should accept remote schema uri as a
+   * parameter and return a Promise that resolves to a schema. See example in
+   * [Asynchronous
+   * compilation](https://ajv.js.org/guide/managing-schemas#asynchronous-schema-compilation).
+   *
+   * ## Options to modify validated data
+   **/
   loadSchema?: (uri: string) => Promise<AnySchemaObject>
+
   // options to modify validated data:
+
+  /**
+   * ### removeAdditional
+   *
+   * Remove additional properties - see example in [Removing additional properties](https://ajv.js.org/guide/modifying-data#removing-additional-properties).
+   *
+   * This option is not used if schema is added with `addMetaSchema` method.
+   *
+   * Option values:
+   *
+   * - `false` (default) - not to remove additional properties
+   * - `"all"` - all additional properties are removed, regardless of `additionalProperties` keyword in schema (and no validation is made for them).
+   * - `true` - only additional properties with `additionalProperties` keyword equal to `false` are removed.
+   * - `"failing"` - additional properties that fail schema validation will be removed (where `additionalProperties` keyword is `false` or schema).
+   **/
   removeAdditional?: boolean | "all" | "failing"
+  /**
+   * ### useDefaults
+   *
+   * Replace missing or undefined properties and items with the values from corresponding `default` keywords. Default behaviour is to ignore `default` keywords. This option is not used if schema is added with `addMetaSchema` method.
+   *
+   * See examples in [Assigning defaults](https://ajv.js.org/guide/modifying-data#assigning-defaults).
+   *
+   * Option values:
+   *
+   * - `false` (default) - do not use defaults
+   * - `true` - insert defaults by value (object literal is used).
+   * - `"empty"` - in addition to missing or undefined, use defaults for properties and items that are equal to `null` or `""` (an empty string).
+   **/
   useDefaults?: boolean | "empty"
+  /**
+   * ### coerceTypes
+   *
+   * Change data type of data to match `type` keyword. See the example in [Coercing data types](https://ajv.js.org/guide/modifying-data#coercing-data-types) and [coercion rules](https://ajv.js.org/coercion.html).
+   *
+   * Option values:
+   *
+   * - `false` (default) - no type coercion.
+   * - `true` - coerce scalar data types.
+   * - `"array"` - in addition to coercions between scalar types, coerce scalar data to an array with one element and vice versa (as required by the schema).
+   **/
   coerceTypes?: boolean | "array"
+
   // advanced options:
+
   next?: boolean // NEW
   unevaluated?: boolean // NEW
   dynamicRef?: boolean // NEW
   schemaId?: "id" | "$id"
   jtd?: boolean // NEW
+  /**
+   * ### meta
+   *
+   * Add [meta-schema](http://json-schema.org/documentation.html) so it can be
+   * used by other schemas (true by default). If an object is passed, it will be
+   * used as the default meta-schema for schemas that have no `$schema` keyword.
+   * This default meta-schema MUST have `$schema` keyword.
+   **/
   meta?: SchemaObject | boolean
   defaultMeta?: string | AnySchemaObject
+  /**
+   * ### validateSchema
+   *
+   * Validate added/compiled schemas against meta-schema (true by default). `$schema` property in the schema can be http://json-schema.org/draft-07/schema or absent (draft-07 meta-schema will be used) or can be a reference to the schema previously added with `addMetaSchema` method.
+   *
+   * Option values:
+   *
+   * - `true` (default) - if the validation fails, throw the exception.
+   * - `"log"` - if the validation fails, log error.
+   * - `false` - skip schema validation.
+   **/
   validateSchema?: boolean | "log"
+  /**
+   * ### addUsedSchema
+   *
+   * By default methods `compile` and `validate` add schemas to the instance if they have `$id` (or `id`) property that doesn't start with "#". If `$id` is present and it is not unique the exception will be thrown. Set this option to `false` to skip adding schemas to the instance and the `$id` uniqueness check when these methods are used. This option does not affect `addSchema` method.
+   **/
   addUsedSchema?: boolean
+  /**
+   * ### inlineRefs
+   *
+   * Affects compilation of referenced schemas.
+   *
+   * Option values:
+   *
+   * - `true` (default) - the referenced schemas that don't have refs in them
+   *   are inlined, regardless of their size - it improves performance.
+   * - `false` - to not inline referenced schemas (they will always be compiled
+   *   as separate functions).
+   * - integer number - to limit the maximum number of keywords of the schema
+   *   that will be inlined (to balance the total size of compiled functions and
+   *   performance).
+   **/
   inlineRefs?: boolean | number
+  /**
+   * ### passContext
+   *
+   * Pass validation context to _compile_ and _validate_ keyword functions. If
+   * this option is `true` and you pass some context to the compiled validation
+   * function with `validate.call(context, data)`, the `context` will be
+   * available as `this` in your keywords. By default `this` is Ajv instance.
+   **/
   passContext?: boolean
+  /**
+   * ### loopRequired
+   *
+   * By default `required` keyword is compiled into a single expression (or a sequence of statements in `allErrors` mode) up to 200 required properties. Pass integer to set a different number of properties above which `required` keyword will be validated in a loop (with a smaller validation function size and worse performance).
+   **/
   loopRequired?: number
+  /**
+   * ### loopEnum
+   *
+   * By default `enum` keyword is compiled into a single expression with up to
+   * 200 allowed values. Pass integer to set the number of values above which
+   * `enum` keyword will be validated in a loop (with a smaller validation
+   * function size and worse performance).
+   *
+   **/
   loopEnum?: number // NEW
+  /**
+   * ### ownProperties
+   *
+   * By default Ajv iterates over all enumerable object properties; when this option is `true` only own enumerable object properties (i.e. found directly on the object rather than on its prototype) are iterated. Contributed by @mbroadst.
+   **/
   ownProperties?: boolean
+  /**
+   * ### multipleOfPrecision
+   *
+   * By default `multipleOf` keyword is validated by comparing the result of division with `parseInt()` of that result. It works for dividers that are bigger than 1. For small dividers such as 0.01 the result of the division is usually not integer (even when it should be integer, see issue [#84](https://github.com/ajv-validator/ajv/issues/84)). If you need to use fractional dividers set this option to some positive integer N to have `multipleOf` validated using this formula: `Math.abs(Math.round(division) - division) < 1e-N` (it is slower but allows for float arithmetic deviations).
+   **/
   multipleOfPrecision?: number
+  /**
+   * ### int32range <Badge text="JTD only">
+   *
+   * Can be used to disable range checking for `int32` and `uint32` types.
+   *
+   * By default Ajv limits the range of these types to `[-2**31, 2**31 - 1]` for `int32` and to `[0, 2**32-1]` for `uint32` when validating and parsing.
+   *
+   * With option `int32range: false` Ajv only requires that `uint32` is non-negative, otherwise does not check the range. Parser will limit the number size to 16 digits (approx. `2**53` - safe integer range).
+   *
+   * #### *warning*
+   * Option int32range is not portable
+   * This option makes JTD validation and parsing more permissive and non-standard. The integers within a wider range will be accepted by Ajv, but will be rejected by other JTD validators.
+   * :::
+   **/
   int32range?: boolean // JTD only
+  /**
+   * ### messages
+   *
+   * Include human-readable messages in errors. `true` by default. `false` can be
+   * passed when messages are generated outside of Ajv code (e.g. with
+   * [ajv-i18n](https://github.com/ajv-validator/ajv-i18n)).
+   **/
   messages?: boolean
+  /**
+   * ### code
+   *
+   * Code generation options
+   *
+   * see [CodeOptions](https://ajv.js.org/options.html#code)
+   */
   code?: CodeOptions // NEW
 }
 
 export interface CodeOptions {
+  /**
+   * to generate es5 code - by default code is es6, with "for-of" loops, "let" and "const"
+   */
   es5?: boolean
+  /**
+   * add line-breaks to code - to simplify debugging of generated functions
+   */
   lines?: boolean
+  /**
+   * code optimization flag or number of passes, 1 pass by default,
+   */
   optimize?: boolean | number
-  formats?: Code // code to require (or construct) map of available formats - for standalone code
+  /**
+   * code to require (or construct) map of available formats - for standalone code
+   */
+  formats?: Code
+  /**
+   * add `source` property (see Source below) to validating function.
+   */
   source?: boolean
+  /**
+   * an optional function to process generated code
+   */
   process?: (code: string, schema?: SchemaEnv) => string
 }
 

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -356,8 +356,6 @@ export interface CurrentOptions {
    * parameter and return a Promise that resolves to a schema. See example in
    * [Asynchronous
    * compilation](https://ajv.js.org/guide/managing-schemas#asynchronous-schema-compilation).
-   *
-   * ## Options to modify validated data
    **/
   loadSchema?: (uri: string) => Promise<AnySchemaObject>
 


### PR DESCRIPTION
**What issue does this pull request resolve?**
Improves user experience by inlining documentation of options in code editors like VSCode through intellisense.

<img width="788" alt="Screen Shot 2021-09-09 at 1 17 50 PM" src="https://user-images.githubusercontent.com/1073892/132732694-bf1f7705-051e-44d2-a0a3-8e526f6de2f4.png">


**What changes did you make?**
Adds comments to `Options` and `CodeGenOptions`.

**Is there anything that requires more attention while reviewing?**
Options missing comments:

-  `next`
-  `unevaluated`
- `dynamicRef`
- `schemaId`
- `defaultMeta`