### PR TITLE
Use npm 6-style peer dependency resolution with `npm link`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "test-karma": "karma start",
     "test-browser": "rm -rf .browser && npm run bundle && scripts/prepare-tests && karma start",
     "test-all": "npm run test-cov && if-node-version 12 npm run test-browser",
-    "test": "npm run json-tests && npm run prettier:check && npm run eslint && npm link && npm link ajv && npm run test-cov",
+    "test": "npm run json-tests && npm run prettier:check && npm run eslint && npm link && npm link --legacy-peer-deps ajv && npm run test-cov",
     "test-ci": "AJV_FULL_TEST=true npm test",
     "prepublish": "npm run build",
-    "benchmark": "npm i && npm run build && npm link && cd ./benchmark && npm link ajv && npm i && node ./jtd",
+    "benchmark": "npm i && npm run build && npm link && cd ./benchmark && npm link --legacy-peer-deps ajv && npm i && node ./jtd",
     "docs:dev": "./scripts/prepare-site && vuepress dev docs",
     "docs:build": "./scripts/prepare-site && vuepress build docs"
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
https://github.com/ajv-validator/ajv/issues/1758

FWIW, despite an `ERESOLVE` warning, `npm run test-ci` was able to run and finish successfully on npm 7 when I tried running the script as is.
<details>
  <summary>full warning</summary>
  
```
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: ajv-keywords@3.5.2
npm WARN Found: ajv@8.6.3
npm WARN node_modules/ajv
npm WARN   ajv@"file:" from the root project
npm WARN   3 more (ajv-errors, ajv-formats, table)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer ajv@"^6.9.1" from ajv-keywords@3.5.2
npm WARN node_modules/ajv-keywords
npm WARN   ajv-keywords@"^3.1.0" from schema-utils@1.0.0
npm WARN   node_modules/cache-loader/node_modules/schema-utils
npm WARN   11 more (schema-utils, schema-utils, schema-utils, schema-utils, ...)
npm WARN 
npm WARN Conflicting peer dependency: ajv@6.12.6
npm WARN node_modules/ajv
npm WARN   peer ajv@"^6.9.1" from ajv-keywords@3.5.2
npm WARN   node_modules/ajv-keywords
npm WARN     ajv-keywords@"^3.1.0" from schema-utils@1.0.0
npm WARN     node_modules/cache-loader/node_modules/schema-utils
npm WARN     11 more (schema-utils, schema-utils, schema-utils, schema-utils, ...)
```
</details>

**What changes did you make?**
Added the [`--legacy-peer-deps` option](https://docs.npmjs.com/cli/v7/commands/npm-link#strict-peer-deps) to `npm link ajv` (the option has no effect in npm < 7).

Tested with:
* node v16.10.0 and npm v7.24.0
* node v14.18.0 and npm v6.14.15
* node v12.22.6 and npm v6.14.15

**Is there anything that requires more attention while reviewing?**
No
