### PR TITLE
split union types

### DIFF
--- a/lib/types/jtd-schema.ts
+++ b/lib/types/jtd-schema.ts
@@ -228,23 +228,27 @@ type JTDDataDef<S, D extends Record<string, unknown>> =
           optionalProperties?: Record<string, unknown>
           additionalProperties?: boolean
         }
-      ? {-readonly [K in keyof S["properties"]]-?: JTDDataDef<S["properties"][K], D>} & {
-          -readonly [K in keyof S["optionalProperties"]]+?: JTDDataDef<
-            S["optionalProperties"][K],
-            D
-          >
-        } & ([S["additionalProperties"]] extends [true] ? Record<string, unknown> : unknown)
+      ? {-readonly [K in keyof S["properties"]]-?: JTDDataDef<S["properties"][K], D>} &
+          {
+            -readonly [K in keyof S["optionalProperties"]]+?: JTDDataDef<
+              S["optionalProperties"][K],
+              D
+            >
+          } &
+          ([S["additionalProperties"]] extends [true] ? Record<string, unknown> : unknown)
       : S extends {
           properties?: Record<string, unknown>
           optionalProperties: Record<string, unknown>
           additionalProperties?: boolean
         }
-      ? {-readonly [K in keyof S["properties"]]-?: JTDDataDef<S["properties"][K], D>} & {
-          -readonly [K in keyof S["optionalProperties"]]+?: JTDDataDef<
-            S["optionalProperties"][K],
-            D
-          >
-        } & ([S["additionalProperties"]] extends [true] ? Record<string, unknown> : unknown)
+      ? {-readonly [K in keyof S["properties"]]-?: JTDDataDef<S["properties"][K], D>} &
+          {
+            -readonly [K in keyof S["optionalProperties"]]+?: JTDDataDef<
+              S["optionalProperties"][K],
+              D
+            >
+          } &
+          ([S["additionalProperties"]] extends [true] ? Record<string, unknown> : unknown)
       : // values
       S extends {values: infer V}
       ? Record<string, JTDDataDef<V, D>>


### PR DESCRIPTION
**What issue does this pull request resolve?**

https://github.com/microsoft/TypeScript/pull/30639 introduced regressions for typescript checking of JSONSchemaType. It was suggested that https://gist.github.com/armanio123/95a33f9ad3286a7d78590eb11af293c4 might improve things. However, that diff removed the usage of `UnionToIntersection` which may be causing most of the regression.

After implementing this and cloning the [example](https://github.com/aarbmx6s/vscode-ajv-issue) I saw identical performance for running `tsc`, a little less than 2s on my machine. I'm posting so that the original so that the OP can try this branch out to see if it fixes anything for them.

More discussion [here](https://github.com/microsoft/TypeScript/issues/44851)

Meant to address #1667

**What changes did you make?**

Simply split out the types as in the gist.

**Is there anything that requires more attention while reviewing?**

You could double check I didn't make a mistake, but the tests pass, so this should be fine.
