### PR TITLE
Include schema in error object

### DIFF
--- a/lib/compile/validate/dataType.ts
+++ b/lib/compile/validate/dataType.ts
@@ -203,8 +203,10 @@ export type TypeError = ErrorObject<"type", {type: string}>
 
 const typeError: KeywordErrorDefinition = {
   message: ({schema}) => `must be ${schema}`,
-  params: ({schema, schemaValue}) =>
-    typeof schema == "string" ? _`{type: ${schema}}` : _`{type: ${schemaValue}}`,
+  params: ({schema, schemaValue, it}) =>
+    typeof schema == "string"
+      ? _`{type: ${schema}, schema: ${it.topSchemaRef}${it.schemaPath}}`
+      : _`{type: ${schemaValue}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 export function reportTypeError(it: SchemaObjCxt): void {

--- a/lib/vocabularies/applicator/additionalItems.ts
+++ b/lib/vocabularies/applicator/additionalItems.ts
@@ -12,7 +12,7 @@ export type AdditionalItemsError = ErrorObject<"additionalItems", {limit: number
 
 const error: KeywordErrorDefinition = {
   message: ({params: {len}}) => str`must NOT have more than ${len} items`,
-  params: ({params: {len}}) => _`{limit: ${len}}`,
+  params: ({params: {len}, it}) => _`{limit: ${len}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/applicator/additionalProperties.ts
+++ b/lib/vocabularies/applicator/additionalProperties.ts
@@ -19,7 +19,8 @@ export type AdditionalPropertiesError = ErrorObject<
 
 const error: KeywordErrorDefinition = {
   message: "must NOT have additional properties",
-  params: ({params}) => _`{additionalProperty: ${params.additionalProperty}}`,
+  params: ({params, it}) =>
+    _`{additionalProperty: ${params.additionalProperty}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition & AddedKeywordDefinition = {

--- a/lib/vocabularies/applicator/contains.ts
+++ b/lib/vocabularies/applicator/contains.ts
@@ -19,8 +19,10 @@ const error: KeywordErrorDefinition = {
     max === undefined
       ? str`must contain at least ${min} valid item(s)`
       : str`must contain at least ${min} and no more than ${max} valid item(s)`,
-  params: ({params: {min, max}}) =>
-    max === undefined ? _`{minContains: ${min}}` : _`{minContains: ${min}, maxContains: ${max}}`,
+  params: ({params: {min, max}, it}) =>
+    max === undefined
+      ? _`{minContains: ${min}, schema: ${it.topSchemaRef}${it.schemaPath}}`
+      : _`{minContains: ${min}, maxContains: ${max}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/applicator/dependencies.ts
+++ b/lib/vocabularies/applicator/dependencies.ts
@@ -32,11 +32,12 @@ export const error: KeywordErrorDefinition = {
     const property_ies = depsCount === 1 ? "property" : "properties"
     return str`must have ${property_ies} ${deps} when property ${property} is present`
   },
-  params: ({params: {property, depsCount, deps, missingProperty}}) =>
+  params: ({params: {property, depsCount, deps, missingProperty}, it}) =>
     _`{property: ${property},
     missingProperty: ${missingProperty},
     depsCount: ${depsCount},
-    deps: ${deps}}`, // TODO change to reference
+    deps: ${deps},
+    schema: ${it.topSchemaRef}${it.schemaPath}}`, // TODO change to reference
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/applicator/if.ts
+++ b/lib/vocabularies/applicator/if.ts
@@ -13,7 +13,8 @@ export type IfKeywordError = ErrorObject<"if", {failingKeyword: string}, AnySche
 
 const error: KeywordErrorDefinition = {
   message: ({params}) => str`must match "${params.ifClause}" schema`,
-  params: ({params}) => _`{failingKeyword: ${params.ifClause}}`,
+  params: ({params, it}) =>
+    _`{failingKeyword: ${params.ifClause}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/applicator/items2020.ts
+++ b/lib/vocabularies/applicator/items2020.ts
@@ -14,7 +14,7 @@ export type ItemsError = ErrorObject<"items", {limit: number}, AnySchema>
 
 const error: KeywordErrorDefinition = {
   message: ({params: {len}}) => str`must NOT have more than ${len} items`,
-  params: ({params: {len}}) => _`{limit: ${len}}`,
+  params: ({params: {len}, it}) => _`{limit: ${len}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/applicator/oneOf.ts
+++ b/lib/vocabularies/applicator/oneOf.ts
@@ -17,7 +17,8 @@ export type OneOfError = ErrorObject<
 
 const error: KeywordErrorDefinition = {
   message: "must match exactly one schema in oneOf",
-  params: ({params}) => _`{passingSchemas: ${params.passing}}`,
+  params: ({params, it}) =>
+    _`{passingSchemas: ${params.passing}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/applicator/propertyNames.ts
+++ b/lib/vocabularies/applicator/propertyNames.ts
@@ -12,7 +12,8 @@ export type PropertyNamesError = ErrorObject<"propertyNames", {propertyName: str
 
 const error: KeywordErrorDefinition = {
   message: "property name must be valid",
-  params: ({params}) => _`{propertyName: ${params.propertyName}}`,
+  params: ({params, it}) =>
+    _`{propertyName: ${params.propertyName}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/discriminator/index.ts
+++ b/lib/vocabularies/discriminator/index.ts
@@ -10,8 +10,8 @@ const error: KeywordErrorDefinition = {
     discrError === DiscrError.Tag
       ? `tag "${tagName}" must be string`
       : `value of tag "${tagName}" must be in oneOf`,
-  params: ({params: {discrError, tag, tagName}}) =>
-    _`{error: ${discrError}, tag: ${tagName}, tagValue: ${tag}}`,
+  params: ({params: {discrError, tag, tagName}, it}) =>
+    _`{error: ${discrError}, tag: ${tagName}, tagValue: ${tag}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/format/format.ts
+++ b/lib/vocabularies/format/format.ts
@@ -22,7 +22,8 @@ export type FormatError = ErrorObject<"format", {format: string}, string | {$dat
 
 const error: KeywordErrorDefinition = {
   message: ({schemaCode}) => str`must match format "${schemaCode}"`,
-  params: ({schemaCode}) => _`{format: ${schemaCode}}`,
+  params: ({schemaCode, it}) =>
+    _`{format: ${schemaCode}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/jtd/discriminator.ts
+++ b/lib/vocabularies/jtd/discriminator.ts
@@ -21,9 +21,9 @@ const error: KeywordErrorDefinition = {
       : typeErrorMessage(cxt, "object")
   },
   params: (cxt) => {
-    const {schema, params} = cxt
+    const {schema, params, it} = cxt
     return params.discrError
-      ? _`{error: ${params.discrError}, tag: ${schema}, tagValue: ${params.tag}}`
+      ? _`{error: ${params.discrError}, tag: ${schema}, tagValue: ${params.tag}, schema: ${it.topSchemaRef}${it.schemaPath}}`
       : typeErrorParams(cxt, "object")
   },
 }

--- a/lib/vocabularies/jtd/enum.ts
+++ b/lib/vocabularies/jtd/enum.ts
@@ -8,7 +8,8 @@ export type JTDEnumError = ErrorObject<"enum", {allowedValues: string[]}, string
 
 const error: KeywordErrorDefinition = {
   message: "must be equal to one of the allowed values",
-  params: ({schemaCode}) => _`{allowedValues: ${schemaCode}}`,
+  params: ({schemaCode, it}) =>
+    _`{allowedValues: ${schemaCode}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/jtd/error.ts
+++ b/lib/vocabularies/jtd/error.ts
@@ -18,6 +18,8 @@ export function typeErrorMessage({parentSchema}: KeywordErrorCxt, t: string): st
   return parentSchema?.nullable ? `must be ${t} or null` : `must be ${t}`
 }
 
-export function typeErrorParams({parentSchema}: KeywordErrorCxt, t: string): Code {
-  return _`{type: ${t}, nullable: ${!!parentSchema?.nullable}}`
+export function typeErrorParams({parentSchema, it}: KeywordErrorCxt, t: string): Code {
+  return _`{type: ${t}, nullable: ${!!parentSchema?.nullable}, schema: ${it.topSchemaRef}${
+    it.schemaPath
+  }}`
 }

--- a/lib/vocabularies/jtd/properties.ts
+++ b/lib/vocabularies/jtd/properties.ts
@@ -36,11 +36,11 @@ export const error: KeywordErrorDefinition = {
       : typeErrorMessage(cxt, "object")
   },
   params: (cxt) => {
-    const {params} = cxt
+    const {params, it} = cxt
     return params.propError
       ? params.propError === PropError.Additional
-        ? _`{error: ${params.propError}, additionalProperty: ${params.additionalProperty}}`
-        : _`{error: ${params.propError}, missingProperty: ${params.missingProperty}}`
+        ? _`{error: ${params.propError}, additionalProperty: ${params.additionalProperty}, schema: ${it.topSchemaRef}${it.schemaPath}}`
+        : _`{error: ${params.propError}, missingProperty: ${params.missingProperty}, schema: ${it.topSchemaRef}${it.schemaPath}}`
       : typeErrorParams(cxt, "object")
   },
 }

--- a/lib/vocabularies/unevaluated/unevaluatedItems.ts
+++ b/lib/vocabularies/unevaluated/unevaluatedItems.ts
@@ -12,7 +12,7 @@ export type UnevaluatedItemsError = ErrorObject<"unevaluatedItems", {limit: numb
 
 const error: KeywordErrorDefinition = {
   message: ({params: {len}}) => str`must NOT have more than ${len} items`,
-  params: ({params: {len}}) => _`{limit: ${len}}`,
+  params: ({params: {len}, it}) => _`{limit: ${len}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/unevaluated/unevaluatedProperties.ts
+++ b/lib/vocabularies/unevaluated/unevaluatedProperties.ts
@@ -16,7 +16,8 @@ export type UnevaluatedPropertiesError = ErrorObject<
 
 const error: KeywordErrorDefinition = {
   message: "must NOT have unevaluated properties",
-  params: ({params}) => _`{unevaluatedProperty: ${params.unevaluatedProperty}}`,
+  params: ({params, it}) =>
+    _`{unevaluatedProperty: ${params.unevaluatedProperty}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/validation/const.ts
+++ b/lib/vocabularies/validation/const.ts
@@ -8,7 +8,8 @@ export type ConstError = ErrorObject<"const", {allowedValue: any}>
 
 const error: KeywordErrorDefinition = {
   message: "must be equal to constant",
-  params: ({schemaCode}) => _`{allowedValue: ${schemaCode}}`,
+  params: ({schemaCode, it}) =>
+    _`{allowedValue: ${schemaCode}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/validation/enum.ts
+++ b/lib/vocabularies/validation/enum.ts
@@ -20,8 +20,8 @@ const def: CodeKeywordDefinition = {
     const {gen, data, $data, schema, schemaCode, it} = cxt
     if (!$data && schema.length === 0) throw new Error("enum must have non-empty array")
     const useLoop = schema.length >= it.opts.loopEnum
-    const needsEql = schema.some((x: unknown) => typeof x === "object")
-    const eql = (needsEql ? useFunc(gen, equal) : undefined)
+    const needsEql = schema.some((x: unknown) => x !== null && typeof x === "object")
+    const eql = needsEql ? useFunc(gen, equal) : undefined
     let valid: Code
     if (useLoop || $data) {
       valid = gen.let("valid")

--- a/lib/vocabularies/validation/enum.ts
+++ b/lib/vocabularies/validation/enum.ts
@@ -20,7 +20,8 @@ const def: CodeKeywordDefinition = {
     const {gen, data, $data, schema, schemaCode, it} = cxt
     if (!$data && schema.length === 0) throw new Error("enum must have non-empty array")
     const useLoop = schema.length >= it.opts.loopEnum
-    const eql = useFunc(gen, equal)
+    const needsEql = schema.some((x: unknown) => typeof x === "object")
+    const eql = (needsEql ? useFunc(gen, equal) : undefined)
     let valid: Code
     if (useLoop || $data) {
       valid = gen.let("valid")

--- a/lib/vocabularies/validation/enum.ts
+++ b/lib/vocabularies/validation/enum.ts
@@ -20,7 +20,7 @@ const def: CodeKeywordDefinition = {
     const {gen, data, $data, schema, schemaCode, it} = cxt
     if (!$data && schema.length === 0) throw new Error("enum must have non-empty array")
     const useLoop = schema.length >= it.opts.loopEnum
-    const needsEql = schema.some((x: unknown) => x !== null && typeof x === "object")
+    const needsEql = (schema as any[]).some((x: unknown) => x !== null && typeof x === "object")
     const eql = needsEql ? useFunc(gen, equal) : undefined
     let valid: Code
     if (useLoop || $data) {

--- a/lib/vocabularies/validation/enum.ts
+++ b/lib/vocabularies/validation/enum.ts
@@ -9,7 +9,8 @@ export type EnumError = ErrorObject<"enum", {allowedValues: any[]}, any[] | {$da
 
 const error: KeywordErrorDefinition = {
   message: "must be equal to one of the allowed values",
-  params: ({schemaCode}) => _`{allowedValues: ${schemaCode}}`,
+  params: ({schemaCode, it}) =>
+    _`{allowedValues: ${schemaCode}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/validation/enum.ts
+++ b/lib/vocabularies/validation/enum.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import type {CodeKeywordDefinition, ErrorObject, KeywordErrorDefinition} from "../../types"
 import type {KeywordCxt} from "../../compile/validate"
 import {_, or, Name, Code} from "../../compile/codegen"
@@ -20,7 +21,11 @@ const def: CodeKeywordDefinition = {
     const {gen, data, $data, schema, schemaCode, it} = cxt
     if (!$data && schema.length === 0) throw new Error("enum must have non-empty array")
     const useLoop = schema.length >= it.opts.loopEnum
-    const needsEql = (schema as any[]).some((x: unknown) => x !== null && typeof x === "object")
+    const needsEql =
+      useLoop ||
+      $data ||
+      !Array.isArray(schema) ||
+      schema.some((x: unknown) => x !== null && typeof x === "object")
     const eql = needsEql ? useFunc(gen, equal) : undefined
     let valid: Code
     if (useLoop || $data) {

--- a/lib/vocabularies/validation/limitItems.ts
+++ b/lib/vocabularies/validation/limitItems.ts
@@ -7,7 +7,8 @@ const error: KeywordErrorDefinition = {
     const comp = keyword === "maxItems" ? "more" : "fewer"
     return str`must NOT have ${comp} than ${schemaCode} items`
   },
-  params: ({schemaCode}) => _`{limit: ${schemaCode}}`,
+  params: ({schemaCode, it}) =>
+    _`{limit: ${schemaCode}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/validation/limitLength.ts
+++ b/lib/vocabularies/validation/limitLength.ts
@@ -9,7 +9,8 @@ const error: KeywordErrorDefinition = {
     const comp = keyword === "maxLength" ? "more" : "fewer"
     return str`must NOT have ${comp} than ${schemaCode} characters`
   },
-  params: ({schemaCode}) => _`{limit: ${schemaCode}}`,
+  params: ({schemaCode, it}) =>
+    _`{limit: ${schemaCode}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/validation/limitNumber.ts
+++ b/lib/vocabularies/validation/limitNumber.ts
@@ -23,8 +23,10 @@ export type LimitNumberError = ErrorObject<
 
 const error: KeywordErrorDefinition = {
   message: ({keyword, schemaCode}) => str`must be ${KWDs[keyword as Kwd].okStr} ${schemaCode}`,
-  params: ({keyword, schemaCode}) =>
-    _`{comparison: ${KWDs[keyword as Kwd].okStr}, limit: ${schemaCode}}`,
+  params: ({keyword, schemaCode, it}) =>
+    _`{comparison: ${KWDs[keyword as Kwd].okStr}, limit: ${schemaCode}, schema: ${it.topSchemaRef}${
+      it.schemaPath
+    }}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/validation/limitProperties.ts
+++ b/lib/vocabularies/validation/limitProperties.ts
@@ -7,7 +7,8 @@ const error: KeywordErrorDefinition = {
     const comp = keyword === "maxProperties" ? "more" : "fewer"
     return str`must NOT have ${comp} than ${schemaCode} items`
   },
-  params: ({schemaCode}) => _`{limit: ${schemaCode}}`,
+  params: ({schemaCode, it}) =>
+    _`{limit: ${schemaCode}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/validation/multipleOf.ts
+++ b/lib/vocabularies/validation/multipleOf.ts
@@ -10,7 +10,8 @@ export type MultipleOfError = ErrorObject<
 
 const error: KeywordErrorDefinition = {
   message: ({schemaCode}) => str`must be multiple of ${schemaCode}`,
-  params: ({schemaCode}) => _`{multipleOf: ${schemaCode}}`,
+  params: ({schemaCode, it}) =>
+    _`{multipleOf: ${schemaCode}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/validation/pattern.ts
+++ b/lib/vocabularies/validation/pattern.ts
@@ -7,7 +7,8 @@ export type PatternError = ErrorObject<"pattern", {pattern: string}, string | {$
 
 const error: KeywordErrorDefinition = {
   message: ({schemaCode}) => str`must match pattern "${schemaCode}"`,
-  params: ({schemaCode}) => _`{pattern: ${schemaCode}}`,
+  params: ({schemaCode, it}) =>
+    _`{pattern: ${schemaCode}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/validation/required.ts
+++ b/lib/vocabularies/validation/required.ts
@@ -18,7 +18,8 @@ export type RequiredError = ErrorObject<
 
 const error: KeywordErrorDefinition = {
   message: ({params: {missingProperty}}) => str`must have required property '${missingProperty}'`,
-  params: ({params: {missingProperty}}) => _`{missingProperty: ${missingProperty}}`,
+  params: ({params: {missingProperty}, it}) =>
+    _`{missingProperty: ${missingProperty}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {

--- a/lib/vocabularies/validation/uniqueItems.ts
+++ b/lib/vocabularies/validation/uniqueItems.ts
@@ -14,7 +14,8 @@ export type UniqueItemsError = ErrorObject<
 const error: KeywordErrorDefinition = {
   message: ({params: {i, j}}) =>
     str`must NOT have duplicate items (items ## ${j} and ${i} are identical)`,
-  params: ({params: {i, j}}) => _`{i: ${i}, j: ${j}}`,
+  params: ({params: {i, j}, it}) =>
+    _`{i: ${i}, j: ${j}, schema: ${it.topSchemaRef}${it.schemaPath}}`,
 }
 
 const def: CodeKeywordDefinition = {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
#1855

**What changes did you make?**
I added a `schema` field to the "params" object in error objects, which refers to the JSON schema that caused the validation to fail.

This was not particularly ugly, but I'm pulling fields from the context object that might not be desired.

**Is there anything that requires more attention while reviewing?**
Assuming the feature is deemed worthy of merging, I imagine some refactoring will be suggested given the amount of repetition in the code. I'll be happy to do that if you folks have suggestions/feedback.