### PR TITLE
Add option to generate ESM exports instead of CJS (#1523)

### DIFF
--- a/docs/guide/environments.md
+++ b/docs/guide/environments.md
@@ -100,7 +100,7 @@ The default configuration of AJV is to generate code in ES6 with Common JS (CJS)
 the ES Modules(ESM) flag.
 
 ```javascript
-const ajv = new Ajv({code: {exportEsm: true}})
+const ajv = new Ajv({code: {esm: true}})
 ```
 
 ## Other JavaScript environments

--- a/docs/guide/environments.md
+++ b/docs/guide/environments.md
@@ -94,6 +94,15 @@ const ajv = new Ajv({code: {es5: true}})
 
 See [Advanced options](https://github.com/ajv-validator/ajv/blob/master/docs/api.md#advanced-options).
 
+## CJS vs ESM exports
+
+The default configuration of AJV is to generate code in ES6 with Common JS (CJS) exports. This can be changed by setting 
+the ES Modules(ESM) flag.
+
+```javascript
+const ajv = new Ajv({code: {exportEsm: true}})
+```
+
 ## Other JavaScript environments
 
 Ajv is used in other JavaScript environments, including Electron apps, WeChat mini-apps and many others, where the same considerations apply as above:

--- a/docs/options.md
+++ b/docs/options.md
@@ -65,7 +65,7 @@ const defaultOptions = {
   code: {
     // NEW
     es5: false,
-    exportEsm: false,
+    esm: false,
     lines: false,
     source: false,
     process: undefined, // (code: string) => string
@@ -348,7 +348,7 @@ Code generation options:
 ```typescript
 type CodeOptions = {
   es5?: boolean // to generate es5 code - by default code is es6, with "for-of" loops, "let" and "const"
-  exportEsm?: boolean // how functions should be exported - by default CJS is used, so the validate function(s) 
+  esm?: boolean // how functions should be exported - by default CJS is used, so the validate function(s) 
   // file can be `required`. Set this value to true to export the validate function(s) as ES Modules, enabling 
   // bunlers to do their job.
   lines?: boolean // add line-breaks to code - to simplify debugging of generated functions

--- a/docs/options.md
+++ b/docs/options.md
@@ -65,6 +65,7 @@ const defaultOptions = {
   code: {
     // NEW
     es5: false,
+    exportEsm: false,
     lines: false,
     source: false,
     process: undefined, // (code: string) => string
@@ -347,6 +348,9 @@ Code generation options:
 ```typescript
 type CodeOptions = {
   es5?: boolean // to generate es5 code - by default code is es6, with "for-of" loops, "let" and "const"
+  exportEsm?: boolean // how functions should be exported - by default CJS is used, so the validate function(s) 
+  // file can be `required`. Set this value to true to export the validate function(s) as ES Modules, enabling 
+  // bunlers to do their job.
   lines?: boolean // add line-breaks to code - to simplify debugging of generated functions
   source?: boolean // add `source` property (see Source below) to validating function.
   process?: (code: string, schema?: SchemaEnv) => string // an optional function to process generated code

--- a/lib/compile/codegen/code.ts
+++ b/lib/compile/codegen/code.ts
@@ -155,6 +155,19 @@ export function getProperty(key: Code | string | number): Code {
   return typeof key == "string" && IDENTIFIER.test(key) ? new _Code(`.${key}`) : _`[${key}]`
 }
 
+//Does best effort to format the name properly
+export function getEsmExportName(key: Code | string | number): Code {
+  if (typeof key == "string" && IDENTIFIER.test(key)) {
+    return new _Code(`${key}`)
+  }
+  const name = key.toString()
+  let newName = name.replace(/[^\w$_]|[\s]/gi, "_")
+  if (/^[0-9]/.test(name)) {
+    newName = "_" + newName
+  }
+  return new _Code(`${newName}`)
+}
+
 export function regexpCode(rx: RegExp): Code {
   return new _Code(rx.toString())
 }

--- a/lib/compile/codegen/code.ts
+++ b/lib/compile/codegen/code.ts
@@ -160,12 +160,7 @@ export function getEsmExportName(key: Code | string | number): Code {
   if (typeof key == "string" && IDENTIFIER.test(key)) {
     return new _Code(`${key}`)
   }
-  const name = key.toString()
-  let newName = name.replace(/[^\w$_]|[\s]/gi, "_")
-  if (/^[0-9]/.test(name)) {
-    newName = "_" + newName
-  }
-  return new _Code(`${newName}`)
+  throw new Error(`CodeGen: invalid export name: ${key}, use explicit $id name mapping`)
 }
 
 export function regexpCode(rx: RegExp): Code {

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -140,7 +140,7 @@ export interface CurrentOptions {
 
 export interface CodeOptions {
   es5?: boolean
-  exportEsm?: boolean
+  esm?: boolean
   lines?: boolean
   optimize?: boolean | number
   formats?: Code // code to require (or construct) map of available formats - for standalone code

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -140,6 +140,7 @@ export interface CurrentOptions {
 
 export interface CodeOptions {
   es5?: boolean
+  exportEsm?: boolean
   lines?: boolean
   optimize?: boolean | number
   formats?: Code // code to require (or construct) map of available formats - for standalone code

--- a/lib/standalone/index.ts
+++ b/lib/standalone/index.ts
@@ -30,7 +30,7 @@ function standaloneCode(
     const usedValues: UsedScopeValues = {}
     const n = source?.validateName
     const vCode = validateCode(usedValues, source)
-    if (ajv.opts.code.exportEsm) {
+    if (ajv.opts.code.esm) {
       // Always do named export as `validate` rather than the variable `n` which is `validateXX` for known export value
       return `"use strict";${_n}export const validate = ${n};${_n}export default ${n};${_n}${vCode}`
     }
@@ -47,15 +47,10 @@ function standaloneCode(
       const v = getValidateFunc(schemas[name] as T)
       if (v) {
         const vCode = validateCode(usedValues, v.source)
-        if (ajv.opts.code.exportEsm) {
-          code = _`${code}${_n}export const ${getEsmExportName(name)} = ${
-            v.source?.validateName
-          };${_n}${vCode}`
-        } else {
-          code = _`${code}${_n}exports${getProperty(name)} = ${
-            v.source?.validateName
-          };${_n}${vCode}`
-        }
+        const exportSyntax = ajv.opts.code.esm
+          ? _`export const ${getEsmExportName(name)}`
+          : _`exports${getProperty(name)}`
+        code = _`${code}${_n}${exportSyntax} = ${v.source?.validateName};${_n}${vCode}`
       }
     }
     return `${code}`

--- a/lib/standalone/index.ts
+++ b/lib/standalone/index.ts
@@ -2,7 +2,7 @@ import type AjvCore from "../core"
 import type {AnyValidateFunction, SourceCode} from "../types"
 import type {SchemaEnv} from "../compile"
 import {UsedScopeValues, UsedValueState, ValueScopeName, varKinds} from "../compile/codegen/scope"
-import {_, nil, _Code, Code, getProperty} from "../compile/codegen/code"
+import {_, nil, _Code, Code, getProperty, getEsmExportName} from "../compile/codegen/code"
 
 function standaloneCode(
   ajv: AjvCore,
@@ -30,6 +30,10 @@ function standaloneCode(
     const usedValues: UsedScopeValues = {}
     const n = source?.validateName
     const vCode = validateCode(usedValues, source)
+    if (ajv.opts.code.exportEsm) {
+      // Always do named export as `validate` rather than the variable `n` which is `validateXX` for known export value
+      return `"use strict";${_n}export const validate = ${n};${_n}export default ${n};${_n}${vCode}`
+    }
     return `"use strict";${_n}module.exports = ${n};${_n}module.exports.default = ${n};${_n}${vCode}`
   }
 
@@ -43,7 +47,15 @@ function standaloneCode(
       const v = getValidateFunc(schemas[name] as T)
       if (v) {
         const vCode = validateCode(usedValues, v.source)
-        code = _`${code}${_n}exports${getProperty(name)} = ${v.source?.validateName};${_n}${vCode}`
+        if (ajv.opts.code.exportEsm) {
+          code = _`${code}${_n}export const ${getEsmExportName(name)} = ${
+            v.source?.validateName
+          };${_n}${vCode}`
+        } else {
+          code = _`${code}${_n}exports${getProperty(name)} = ${
+            v.source?.validateName
+          };${_n}${vCode}`
+        }
       }
     }
     return `${code}`

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "karma-mocha": "^2.0.0",
     "lint-staged": "^12.1.1",
     "mocha": "^9.0.2",
+    "module-from-string": "^3.1.3",
     "node-fetch": "^3.0.0",
     "nyc": "^15.0.0",
     "prettier": "^2.3.1",

--- a/spec/standalone.spec.ts
+++ b/spec/standalone.spec.ts
@@ -57,7 +57,7 @@ describe("standalone code generation", () => {
       })
 
       it("should generate module code with named export - ESM", () => {
-        ajv = new _Ajv({code: {source: true, exportEsm: true}})
+        ajv = new _Ajv({code: {source: true, esm: true}})
         ajv.addSchema(numSchema)
         ajv.addSchema(strSchema)
         const moduleCode = standaloneCode(ajv, {
@@ -85,17 +85,24 @@ describe("standalone code generation", () => {
       })
 
       it("should generate module code with all exports - ESM", () => {
-        ajv = new _Ajv({code: {source: true, exportEsm: true}})
+        ajv = new _Ajv({code: {source: true, esm: true}})
         ajv.addSchema(numSchema)
         ajv.addSchema(strSchema)
-        const moduleCode = standaloneCode(ajv)
-        testExportTypeEsm(moduleCode, false)
-        const m = importFromStringSync(moduleCode)
-        assert.strictEqual(Object.keys(m).length, 2)
-        testExports({
-          validateNumber: m.https___example_com_number_json,
-          validateString: m.https___example_com_string_json,
-        })
+
+        try {
+          standaloneCode(ajv)
+        } catch (err) {
+          if (err instanceof Error) {
+            const isMappingErr =
+              `CodeGen: invalid export name: ${numSchema.$id}, use explicit $id name mapping` ===
+                err.message ||
+              `CodeGen: invalid export name: ${strSchema.$id}, use explicit $id name mapping` ===
+                err.message
+            assert.strictEqual(isMappingErr, true)
+          } else {
+            throw err
+          }
+        }
       })
     })
 
@@ -295,7 +302,7 @@ describe("standalone code generation", () => {
   })
 
   it("should generate module code with a single export - ESM", () => {
-    const ajv = new _Ajv({code: {source: true, exportEsm: true}})
+    const ajv = new _Ajv({code: {source: true, esm: true}})
     const v = ajv.compile({
       type: "number",
       minimum: 0,

--- a/spec/standalone.spec.ts
+++ b/spec/standalone.spec.ts
@@ -4,7 +4,28 @@ import _Ajv from "./ajv"
 import standaloneCode from "../dist/standalone"
 import ajvFormats from "ajv-formats"
 import requireFromString = require("require-from-string")
+import {importFromStringSync} from "module-from-string"
 import assert = require("assert")
+
+function testExportTypeEsm(moduleCode: string, singleExport: boolean) {
+  //Must have
+  assert.strictEqual(moduleCode.includes("export const"), true)
+  if (singleExport) {
+    assert.strictEqual(moduleCode.includes("export default"), true)
+  }
+  //Must not have
+  assert.strictEqual(moduleCode.includes("module.exports"), false)
+}
+function testExportTypeCjs(moduleCode: string, singleExport: boolean) {
+  //Must have
+  if (singleExport) {
+    assert.strictEqual(moduleCode.includes("module.exports"), true)
+  } else {
+    assert.strictEqual(moduleCode.includes("exports.") || moduleCode.includes("exports["), true)
+  }
+  //Must not have
+  assert.strictEqual(moduleCode.includes("export const"), false)
+}
 
 describe("standalone code generation", () => {
   describe("multiple exports", () => {
@@ -21,29 +42,59 @@ describe("standalone code generation", () => {
     }
 
     describe("without schema keys", () => {
-      beforeEach(() => {
+      it("should generate module code with named export - CJS", () => {
         ajv = new _Ajv({code: {source: true}})
         ajv.addSchema(numSchema)
         ajv.addSchema(strSchema)
-      })
-
-      it("should generate module code with named exports", () => {
         const moduleCode = standaloneCode(ajv, {
           validateNumber: "https://example.com/number.json",
           validateString: "https://example.com/string.json",
         })
+        testExportTypeCjs(moduleCode, false)
         const m = requireFromString(moduleCode)
         assert.strictEqual(Object.keys(m).length, 2)
         testExports(m)
       })
 
-      it("should generate module code with all exports", () => {
+      it("should generate module code with named export - ESM", () => {
+        ajv = new _Ajv({code: {source: true, exportEsm: true}})
+        ajv.addSchema(numSchema)
+        ajv.addSchema(strSchema)
+        const moduleCode = standaloneCode(ajv, {
+          validateNumber: "https://example.com/number.json",
+          validateString: "https://example.com/string.json",
+        })
+        testExportTypeEsm(moduleCode, false)
+        const m = importFromStringSync(moduleCode)
+        assert.strictEqual(Object.keys(m).length, 2)
+        testExports(m)
+      })
+
+      it("should generate module code with all exports - CJS", () => {
+        ajv = new _Ajv({code: {source: true}})
+        ajv.addSchema(numSchema)
+        ajv.addSchema(strSchema)
         const moduleCode = standaloneCode(ajv)
+        testExportTypeCjs(moduleCode, false)
         const m = requireFromString(moduleCode)
         assert.strictEqual(Object.keys(m).length, 2)
         testExports({
           validateNumber: m["https://example.com/number.json"],
           validateString: m["https://example.com/string.json"],
+        })
+      })
+
+      it("should generate module code with all exports - ESM", () => {
+        ajv = new _Ajv({code: {source: true, exportEsm: true}})
+        ajv.addSchema(numSchema)
+        ajv.addSchema(strSchema)
+        const moduleCode = standaloneCode(ajv)
+        testExportTypeEsm(moduleCode, false)
+        const m = importFromStringSync(moduleCode)
+        assert.strictEqual(Object.keys(m).length, 2)
+        testExports({
+          validateNumber: m.https___example_com_number_json,
+          validateString: m.https___example_com_string_json,
         })
       })
     })
@@ -223,15 +274,36 @@ describe("standalone code generation", () => {
     }
   })
 
-  it("should generate module code with a single export (ESM compatible)", () => {
+  it("should generate module code with a single export - CJS", () => {
     const ajv = new _Ajv({code: {source: true}})
     const v = ajv.compile({
       type: "number",
       minimum: 0,
     })
     const moduleCode = standaloneCode(ajv, v)
+    testExportTypeCjs(moduleCode, true)
     const m = requireFromString(moduleCode)
     testExport(m)
+    testExport(m.default)
+
+    function testExport(validate: AnyValidateFunction<unknown>) {
+      assert.strictEqual(validate(1), true)
+      assert.strictEqual(validate(0), true)
+      assert.strictEqual(validate(-1), false)
+      assert.strictEqual(validate("1"), false)
+    }
+  })
+
+  it("should generate module code with a single export - ESM", () => {
+    const ajv = new _Ajv({code: {source: true, exportEsm: true}})
+    const v = ajv.compile({
+      type: "number",
+      minimum: 0,
+    })
+    const moduleCode = standaloneCode(ajv, v)
+    testExportTypeEsm(moduleCode, true)
+    const m = importFromStringSync(moduleCode)
+    testExport(m.validate)
     testExport(m.default)
 
     function testExport(validate: AnyValidateFunction<unknown>) {


### PR DESCRIPTION
**What issue does this pull request resolve?**
Adds an option so that the generated code can do both CJS and ESM exports. https://github.com/ajv-validator/ajv/issues/1523

**What changes did you make?**
Adde an extra flag  `code.exportEsm` to generate code with ESM exports instead of CJS.

**Is there anything that requires more attention while reviewing?**
I wanted to use the `code.es5` flag and then make the assumption that ES5 code uses CJS and ES6 uses ESM. But this would have been a breaking change because by default the code is exporting as ES6. So I thought it best to add an additional flag called `code.exportEsm`. It defaults to false so it introduces no breaking changes.

CJS (default) creates exports as `module.exports = ` for single exports and `exports.` or `exports[` for multiple exports. ESM creates exports as `export const` and  `export default` for single exports, where the `export const` has been given a fixed name of `validate`. This is just to cater for both import methods. Then for the multiple exports, the `export default` option is not available(or has not been implemented) and must be done with named exports as in `export const`.

I tested both scenarios for when the code has a single and multiple exports. Note that ESM can not export with special characters in the name, CJS can because it then uses the array syntax like `exports[https://example.com/string.json]`. I didn't just want it to fail the ESM version when the CJS passed so instead I used some regex to replace special characters and then the ESM export would look like `export const https___example_com_string_json`

I also needed to add a new devDependencies called `module-from-string` to be able to test the generated code. It is similar to `require-from-string`. The [package](https://www.npmjs.com/package/module-from-string) is almost a year old with not a lot of stars or downloads but looks stable and was good enough for the tests. I am not sure how else to test ESM modules, open to suggestions if you do not like this method.
 