### PR TITLE
Fix broken named anchor link

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -185,17 +185,17 @@ Option values:
 - `true` (default) - use unicode flag "u".
 - `false` - do not use flag "u".
 
-### timestamp <Badge text="JTD only">
+### timestamp <Badge text="JTD only" />
 
 Defines which Javascript types will be accepted for the [JTD timestamp type](./json-type-definition#type-form).
 
 By default Ajv will accept both Date objects and [RFC3339](https://datatracker.ietf.org/doc/rfc3339/) strings. You can specify allowed values with the option `timestamp: "date"` or `timestamp: "string"`.
 
-### parseDate <Badge text="JTD only">
+### parseDate <Badge text="JTD only" />
 
 Defines how date-time strings are parsed by [JTD parsers](./api.md#jtd-parse). By default Ajv parses date-time strings as string. Use `parseDate: true` to parse them as Date objects.
 
-### allowDate <Badge text="JTD only">
+### allowDate <Badge text="JTD only" />
 
 Defines how date-time strings are parsed and validated. By default Ajv only allows full date-time strings, as required by JTD specification. Use `allowDate: true` to allow date strings both for validation and for parsing.
 
@@ -203,7 +203,7 @@ Defines how date-time strings are parsed and validated. By default Ajv only allo
 This option makes JTD validation and parsing more permissive and non-standard. The date strings without time part will be accepted by Ajv, but will be rejected by other JTD validators.
 :::
 
-### int32range <Badge text="JTD only">
+### int32range <Badge text="JTD only" />
 
 Can be used to disable range checking for `int32` and `uint32` types.
 


### PR DESCRIPTION
Prefix the closing angle bracket with a forward slash so that a correct stub is generated for table of contents.

<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

Fixes broken TOC internal anchor links to JTD-only items.

**What changes did you make?**

Prefix tag-closing bracket with forward slash since TOC stub generator expects the slash in order to match and replace.

**Is there anything that requires more attention while reviewing?**

Perhaps the [relevant regex-match](https://github.com/ajv-validator/ajv/blob/418cd0f4308c07c627071b4d03544e7cc57f235c/docs/.vuepress/config.js#L24) should be more permissive and allow for tags with or without a closing forward slash. I can make that quick change if desired, just comment.