### PR TITLE
Fix some relative links

### DIFF
--- a/docs/guide/formats.md
+++ b/docs/guide/formats.md
@@ -30,7 +30,7 @@ addFormats(ajv)
 
 See [ajv-formats](https://github.com/ajv-validator/ajv-formats) documentation for further details.
 
-It is recommended NOT to use "format" keyword implementations with untrusted data, as they may use potentially unsafe regular expressions (even though known issues are fixed) - see [ReDoS attack](./security.md#redos-attack).
+It is recommended NOT to use "format" keyword implementations with untrusted data, as they may use potentially unsafe regular expressions (even though known issues are fixed) - see [ReDoS attack](../security.md#redos-attack).
 
 ::: danger Format validation of untrusted data
 If you need to use "format" keyword to validate untrusted data, you MUST assess their suitability and safety for your validation scenarios.
@@ -61,7 +61,7 @@ JSON Schema draft-07 also defines formats `iri`, `iri-reference`, `idn-hostname`
 
 ## User-defined formats
 
-You can add and replace any formats using [addFormat](./api.md#api-addformat) method:
+You can add and replace any formats using [addFormat](../api.md#ajv-addformat-name-string-format-format-ajv) method:
 
 ```javascript
 ajv.addFormat("identifier", /^a-z\$_[a-zA-Z$_0-9]*$/)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

A couple broken links: `addFormat` API link and a link to the ReDOS security consideration

**What changes did you make?**

* Fix relative path for both links
* Fix anchor for `addFormat` API link to match the API reference link

**Is there anything that requires more attention while reviewing?**

No. Though the `addFormat` anchor doesn't work in GitHub's docs rendering -- I'm sure this is due to the way the different Markdown engines generate anchors.