### PR TITLE
Use root schemaEnv when resolving references in oneOf

### DIFF
--- a/lib/vocabularies/discriminator/index.ts
+++ b/lib/vocabularies/discriminator/index.ts
@@ -66,7 +66,7 @@ const def: CodeKeywordDefinition = {
       for (let i = 0; i < oneOf.length; i++) {
         let sch = oneOf[i]
         if (sch?.$ref && !schemaHasRulesButRef(sch, it.self.RULES)) {
-          sch = resolveRef.call(it.self, it.schemaEnv, it.baseId, sch?.$ref)
+          sch = resolveRef.call(it.self, it.schemaEnv.root, it.baseId, sch?.$ref)
           if (sch instanceof SchemaEnv) sch = sch.schema
         }
         const propSch = sch?.properties?.[tagName]

--- a/spec/discriminator.spec.ts
+++ b/spec/discriminator.spec.ts
@@ -159,7 +159,7 @@ describe("discriminator keyword", function () {
     })
   })
 
-  describe("validation with referenced schemas", () => {
+  describe("validation with deeply referenced schemas", () => {
     const schema = [
       {
         type: "object",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

Fixes #1899

**What changes did you make?**

[Use root schemaEnv when resolving references in oneOf](https://github.com/ajv-validator/ajv/commit/d7f91f6569b55bc241057f37fa1910c6998eb1ec)

**Is there anything that requires more attention while reviewing?**

No this should be a simple fix