### PR TITLE
docs: update example in security.md, ReDoS attack section

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -72,7 +72,7 @@ To use a third-party regex engine in Ajv, set the ajv.opts.code.regExp property 
 ``` 
 const Ajv = require("ajv") 
 const RE2 = require("re2") 
-const ajv = new Ajv({regExp: RE2}) 
+const ajv = new Ajv({code: {regExp: RE2}}) 
 ``` 
 
 For details about the interface of the `regexp` option, see options.md under the docs folder. 


### PR DESCRIPTION
I made a mistake with one of the code snippets in the documentation. The 'regExp' attribute belongs to the code options, not the ajv options directly.
