### PR TITLE
docs: fix link for useDefaults

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -329,7 +329,7 @@ Options can have properties `separator` (string used to separate errors, ", " by
 
 In case of validation failure, Ajv assigns the array of errors to `errors` property of validation function (or to `errors` property of Ajv instance when `validate` or `validateSchema` methods were called). In case of [asynchronous validation](./guide/async-validation.md), the returned promise is rejected with exception `Ajv.ValidationError` that has `errors` property.
 
-Note, the `errors` property may not be set if validation fails due to a missing property, even if it is not required in the schema. In these cases, consider using [option `useDefaults`](./options.md#options).
+Note, the `errors` value may not be set if validation fails due to a missing property, even if it is not required in the schema. In these cases, consider using [option `useDefaults`](./options.md#options).
 
 ### Error objects
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -329,8 +329,6 @@ Options can have properties `separator` (string used to separate errors, ", " by
 
 In case of validation failure, Ajv assigns the array of errors to `errors` property of validation function (or to `errors` property of Ajv instance when `validate` or `validateSchema` methods were called). In case of [asynchronous validation](./guide/async-validation.md), the returned promise is rejected with exception `Ajv.ValidationError` that has `errors` property.
 
-Note, the `errors` value may not be set if validation fails due to a missing property, even if it is not required in the schema. In these cases, consider using [option `useDefaults`](./options.md#options).
-
 ### Error objects
 
 Each reported error is an object with the following properties:

--- a/docs/api.md
+++ b/docs/api.md
@@ -329,6 +329,8 @@ Options can have properties `separator` (string used to separate errors, ", " by
 
 In case of validation failure, Ajv assigns the array of errors to `errors` property of validation function (or to `errors` property of Ajv instance when `validate` or `validateSchema` methods were called). In case of [asynchronous validation](./guide/async-validation.md), the returned promise is rejected with exception `Ajv.ValidationError` that has `errors` property.
 
+Note, the `errors` property may not be set if validation fails due to a missing property, even if it is not required in the schema. In these cases, consider using [option `useDefaults`](./options.md#options).
+
 ### Error objects
 
 Each reported error is an object with the following properties:

--- a/docs/guide/modifying-data.md
+++ b/docs/guide/modifying-data.md
@@ -154,7 +154,7 @@ See [discriminator](../json-schema.md#discriminator) keyword.
 
 ## Assigning defaults
 
-With [option `useDefaults`](./api.md#options) Ajv will assign values from `default` keyword in the schemas of `properties` and `items` (when it is the array of schemas) to the missing properties and items.
+With [option `useDefaults`](./options.md#options) Ajv will assign values from `default` keyword in the schemas of `properties` and `items` (when it is the array of schemas) to the missing properties and items.
 
 With the option value `"empty"` properties and items equal to `null` or `""` (empty string) will be considered missing and assigned defaults.
 


### PR DESCRIPTION
**What issue does this pull request resolve?**

I ran into what is essentially https://github.com/ajv-validator/ajv/issues/1790, where I was confused that validation failed but the `errors` property on the validation function was not set. I have tested this and it appears this is due to a missing, but not required, property in the validated object.

**What changes did you make?**

Fixes a broken link to the option and adds a clarifying note regarding the `errors` property in this case.

**Is there anything that requires more attention while reviewing?**

Ensure I'm correct about this behavior :-)