### PR TITLE
fix: added support for asynchronous keywords in JTD schemas (#2029)

### DIFF
--- a/lib/compile/index.ts
+++ b/lib/compile/index.ts
@@ -99,7 +99,7 @@ export class SchemaEnv implements SchemaEnvArgs {
     this.schemaPath = env.schemaPath
     this.localRefs = env.localRefs
     this.meta = env.meta
-    this.$async = schema?.$async
+    this.$async = schema?.$async ?? schema?.["metadata"]?.async
     this.refs = {}
   }
 }

--- a/lib/compile/validate/boolSchema.ts
+++ b/lib/compile/validate/boolSchema.ts
@@ -12,7 +12,10 @@ export function topBoolOrEmptySchema(it: SchemaCxt): void {
   const {gen, schema, validateName} = it
   if (schema === false) {
     falseSchemaError(it, false)
-  } else if (typeof schema == "object" && schema.$async === true) {
+  } else if (
+    typeof schema == "object" &&
+    (schema.$async === true || schema.metadata?.async === true)
+  ) {
     gen.return(N.data)
   } else {
     gen.assign(_`${validateName}.errors`, null)

--- a/lib/compile/validate/index.ts
+++ b/lib/compile/validate/index.ts
@@ -181,7 +181,9 @@ function updateContext(it: SchemaObjCxt): void {
 }
 
 function checkAsyncSchema(it: SchemaObjCxt): void {
-  if (it.schema.$async && !it.schemaEnv.$async) throw new Error("async schema in sync schema")
+  if ((it.schema.$async || it.schema.metadata?.async) && !it.schemaEnv.$async) {
+    throw new Error("async schema in sync schema")
+  }
 }
 
 function commentKeyword({gen, schemaEnv, schema, errSchemaPath, opts}: SchemaObjCxt): void {

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -314,7 +314,7 @@ export default class Ajv {
   }
 
   _addVocabularies(): void {
-    this.addKeyword("$async")
+    this.addKeyword(this.opts.jtd ? "async" : "$async")
   }
 
   _addDefaultMetaSchema(): void {
@@ -369,6 +369,8 @@ export default class Ajv {
   // Create validation function for passed schema
   // _meta: true if schema is a meta-schema. Used internally to compile meta schemas of user-defined keywords.
   compile<T = unknown>(schema: Schema | JSONSchemaType<T>, _meta?: boolean): ValidateFunction<T>
+  // Async validation
+  compile<T = unknown>(schema: AsyncSchema, _meta?: boolean): AsyncValidateFunction<T>
   // Separated for type inference to work
   // eslint-disable-next-line @typescript-eslint/unified-signatures
   compile<T = unknown>(schema: JTDSchemaType<T>, _meta?: boolean): ValidateFunction<T>
@@ -378,7 +380,6 @@ export default class Ajv {
     schema: T,
     _meta?: boolean
   ): ValidateFunction<JTDDataType<T>>
-  compile<T = unknown>(schema: AsyncSchema, _meta?: boolean): AsyncValidateFunction<T>
   compile<T = unknown>(schema: AnySchema, _meta?: boolean): AnyValidateFunction<T>
   compile<T = unknown>(schema: AnySchema, _meta?: boolean): AnyValidateFunction<T> {
     const sch = this._addSchema(schema, _meta)

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -12,17 +12,20 @@ interface _SchemaObject {
   [x: string]: any // TODO
 }
 
-export interface SchemaObject extends _SchemaObject {
+export type SchemaObject = _SchemaObject & {
   id?: string
   $id?: string
   $schema?: string
   $async?: false
+  metadata?: {
+    async?: false
+    [x: string]: any
+  }
   [x: string]: any // TODO
 }
 
-export interface AsyncSchema extends _SchemaObject {
-  $async: true
-}
+export type AsyncSchema = _SchemaObject &
+  ({$async: true} | {metadata: {async: boolean} & {[x: string]: any}})
 
 export type AnySchemaObject = SchemaObject | AsyncSchema
 

--- a/spec/ajv.ts
+++ b/spec/ajv.ts
@@ -1,6 +1,12 @@
 import type Ajv from "../dist/core"
+import type AjvJtd from "../dist/jtd"
+
 const AjvClass: typeof Ajv = typeof window == "object" ? (window as any).ajv7 : require("" + "..")
 
 export default AjvClass
 module.exports = AjvClass
 module.exports.default = AjvClass
+
+export const AjvJtdClass: typeof AjvJtd =
+  typeof window == "object" ? (window as any).ajvJTD : require("../dist/jtd")
+module.exports.AjvJtdClass = AjvJtdClass

--- a/spec/ajv_async_instances.ts
+++ b/spec/ajv_async_instances.ts
@@ -1,11 +1,23 @@
 import getAjvInstances from "./ajv_instances"
-import _Ajv from "./ajv"
+import {default as _Ajv, AjvJtdClass as _AjvJtd} from "./ajv"
 import type AjvCore from "../dist/core"
 import type {Options} from ".."
 
 export default function getAjvSyncInstances(extraOpts?: Options): AjvCore[] {
   return getAjvInstances(
     _Ajv,
+    {
+      strict: false,
+      allErrors: true,
+      code: {lines: true, optimize: false},
+    },
+    extraOpts
+  )
+}
+
+export function getAjvJtdAsyncInstances(extraOpts?: Options): AjvCore[] {
+  return getAjvInstances(
+    _AjvJtd,
     {
       strict: false,
       allErrors: true,

--- a/spec/async_validate.spec.ts
+++ b/spec/async_validate.spec.ts
@@ -1,394 +1,559 @@
-import getAjvAsyncInstances from "./ajv_async_instances"
+import getAjvAsyncInstances, {getAjvJtdAsyncInstances} from "./ajv_async_instances"
 import _Ajv from "./ajv"
 import chai from "./chai"
+
 const should = chai.should()
 
 describe("async schemas, formats and keywords", function () {
   this.timeout(30000)
   let ajv, instances
 
-  beforeEach(() => {
-    instances = getAjvAsyncInstances()
-    ajv = instances[0]
-  })
-
-  describe("async schemas without async elements", () => {
-    it("should return result as promise", () => {
-      const schema = {
-        $async: true,
-        type: "string",
-        maxLength: 3,
-      }
-
-      return repeat(() => {
-        return Promise.all(instances.map(test))
-      })
-
-      function test(_ajv) {
-        const validate = _ajv.compile(schema)
-
-        return Promise.all([
-          shouldBeValid(validate("abc"), "abc"),
-          shouldBeInvalid(validate("abcd")),
-          shouldBeInvalid(validate(1)),
-        ])
-      }
+  describe("async JSON schemas", () => {
+    beforeEach(() => {
+      instances = getAjvAsyncInstances()
+      ajv = instances[0]
     })
 
-    it("should fail compilation if async schema is inside sync schema", () => {
-      const schema: any = {
-        type: "object",
-        properties: {
-          foo: {
-            $async: true,
-            type: "string",
-            maxLength: 3,
-          },
-        },
-      }
-
-      should.throw(() => {
-        ajv.compile(schema)
-      }, "async schema in sync schema")
-
-      ajv.compile({...schema, $async: true})
-    })
-  })
-
-  describe("async formats", () => {
-    beforeEach(addFormatEnglishWord)
-
-    it("should fail compilation if async format is inside sync schema", () => {
-      instances.forEach((_ajv) => {
-        let schema: any = {
+    describe("async schemas without async elements", () => {
+      it("should return result as promise", () => {
+        const schema = {
+          $async: true,
           type: "string",
-          format: "english_word",
+          maxLength: 3,
         }
 
-        should.throw(() => {
-          _ajv.compile(schema)
-        }, "async format in sync schema")
-        schema = {...schema, $async: true}
-        _ajv.compile(schema)
-      })
-    })
-  })
-
-  describe("async user-defined keywords", () => {
-    beforeEach(() => {
-      instances.forEach((_ajv) => {
-        _ajv.addKeyword({
-          keyword: "idExists",
-          async: true,
-          type: "number",
-          validate: checkIdExists,
-          errors: false,
+        return repeat(() => {
+          return Promise.all(instances.map(test))
         })
 
-        _ajv.addKeyword({
-          keyword: "idExistsWithError",
-          async: true,
-          type: "number",
-          validate: checkIdExistsWithError,
-          errors: true,
-        })
-      })
-    })
+        function test(_ajv) {
+          const validate = _ajv.compile(schema)
 
-    it("should fail compilation if async keyword is inside sync schema", () => {
-      instances.forEach((_ajv) => {
-        let schema: any = {
+          return Promise.all([
+            shouldBeValid(validate("abc"), "abc"),
+            shouldBeInvalid(validate("abcd")),
+            shouldBeInvalid(validate(1)),
+          ])
+        }
+      })
+
+      it("should fail compilation if async schema is inside sync schema", () => {
+        const schema: any = {
           type: "object",
           properties: {
-            userId: {
-              type: "integer",
-              idExists: {table: "users"},
+            foo: {
+              $async: true,
+              type: "string",
+              maxLength: 3,
             },
           },
         }
 
         should.throw(() => {
-          _ajv.compile(schema)
-        }, "async keyword in sync schema")
+          ajv.compile(schema)
+        }, "async schema in sync schema")
 
-        schema = {...schema, $async: true}
-        _ajv.compile(schema)
+        ajv.compile({...schema, $async: true})
       })
     })
 
-    it("should return user-defined error", () => {
-      return Promise.all(
-        instances.map((_ajv) => {
-          const schema = {
-            $async: true,
+    describe("async formats", () => {
+      beforeEach(() => {
+        addFormatEnglishWord(instances)
+      })
+
+      it("should fail compilation if async format is inside sync schema", () => {
+        instances.forEach((_ajv) => {
+          let schema: any = {
+            type: "string",
+            format: "english_word",
+          }
+
+          should.throw(() => {
+            _ajv.compile(schema)
+          }, "async format in sync schema")
+          schema = {...schema, $async: true}
+          _ajv.compile(schema)
+        })
+      })
+    })
+
+    describe("async user-defined keywords", () => {
+      beforeEach(() => {
+        instances.forEach((_ajv) => {
+          _ajv.addKeyword({
+            keyword: "idExists",
+            async: true,
+            type: "number",
+            validate: checkIdExists,
+            errors: false,
+          })
+
+          _ajv.addKeyword({
+            keyword: "idExistsWithError",
+            async: true,
+            type: "number",
+            validate: checkIdExistsWithError,
+            errors: true,
+          })
+        })
+      })
+
+      it("should fail compilation if async keyword is inside sync schema", () => {
+        instances.forEach((_ajv) => {
+          let schema: any = {
             type: "object",
             properties: {
               userId: {
                 type: "integer",
-                idExistsWithError: {table: "users"},
-              },
-              postId: {
-                type: "integer",
-                idExistsWithError: {table: "posts"},
+                idExists: {table: "users"},
               },
             },
           }
 
+          should.throw(() => {
+            _ajv.compile(schema)
+          }, "async keyword in sync schema")
+
+          schema = {...schema, $async: true}
+          _ajv.compile(schema)
+        })
+      })
+
+      it("should return user-defined error", () => {
+        return Promise.all(
+          instances.map((_ajv) => {
+            const schema = {
+              $async: true,
+              type: "object",
+              properties: {
+                userId: {
+                  type: "integer",
+                  idExistsWithError: {table: "users"},
+                },
+                postId: {
+                  type: "integer",
+                  idExistsWithError: {table: "posts"},
+                },
+              },
+            }
+
+            const validate = _ajv.compile(schema)
+
+            return Promise.all([
+              shouldBeInvalid(validate({userId: 5, postId: 10}), ["id not found in table posts"]),
+              shouldBeInvalid(validate({userId: 9, postId: 25}), ["id not found in table users"]),
+            ])
+          })
+        )
+      })
+    })
+
+    describe("async referenced schemas", () => {
+      beforeEach(() => {
+        instances = getAjvAsyncInstances({inlineRefs: false, ignoreKeywordsWithRef: true})
+        addFormatEnglishWord(instances)
+      })
+
+      it("should validate referenced async schema", () => {
+        const schema = {
+          $async: true,
+          definitions: {
+            english_word: {
+              $async: true,
+              type: "string",
+              format: "english_word",
+            },
+          },
+          type: "object",
+          properties: {
+            word: {$ref: "#/definitions/english_word"},
+          },
+        }
+
+        return repeat(() => {
+          return Promise.all(
+            instances.map((_ajv) => {
+              const validate = _ajv.compile(schema)
+              const validData = {word: "tomorrow"}
+
+              return Promise.all([
+                shouldBeValid(validate(validData), validData),
+                shouldBeInvalid(validate({word: "manana"})),
+                shouldBeInvalid(validate({word: 1})),
+                shouldThrow(validate({word: "today"}), "unknown word"),
+              ])
+            })
+          )
+        })
+      })
+
+      it("should validate recursive async schema", () => {
+        const schema = {
+          $async: true,
+          definitions: {
+            english_word: {
+              $async: true,
+              type: "string",
+              format: "english_word",
+            },
+          },
+          type: "object",
+          properties: {
+            foo: {
+              anyOf: [{$ref: "#/definitions/english_word"}, {$ref: "#"}],
+            },
+          },
+        }
+
+        return recursiveTest(schema)
+      })
+
+      it("should validate recursive ref to async sub-schema, issue #612", () => {
+        const schema = {
+          $async: true,
+          type: "object",
+          properties: {
+            foo: {
+              $async: true,
+              anyOf: [
+                {
+                  type: "string",
+                  format: "english_word",
+                },
+                {
+                  type: "object",
+                  properties: {
+                    foo: {$ref: "#/properties/foo"},
+                  },
+                },
+              ],
+            },
+          },
+        }
+
+        return recursiveTest(schema)
+      })
+
+      it("should validate ref from referenced async schema to root schema", () => {
+        const schema = {
+          $async: true,
+          definitions: {
+            wordOrRoot: {
+              $async: true,
+              anyOf: [
+                {
+                  type: "string",
+                  format: "english_word",
+                },
+                {$ref: "#"},
+              ],
+            },
+          },
+          type: "object",
+          properties: {
+            foo: {$ref: "#/definitions/wordOrRoot"},
+          },
+        }
+
+        return recursiveTest(schema)
+      })
+
+      it("should validate refs between two async schemas", () => {
+        const schemaObj = {
+          $id: "http://e.com/obj.json#",
+          $async: true,
+          type: "object",
+          properties: {
+            foo: {$ref: "http://e.com/word.json#"},
+          },
+        }
+
+        const schemaWord = {
+          $id: "http://e.com/word.json#",
+          $async: true,
+          anyOf: [
+            {
+              type: "string",
+              format: "english_word",
+            },
+            {$ref: "http://e.com/obj.json#"},
+          ],
+        }
+
+        return recursiveTest(schemaObj, schemaWord)
+      })
+
+      it("should fail compilation if sync schema references async schema", () => {
+        let schema: any = {
+          $id: "http://e.com/obj.json#",
+          type: "object",
+          properties: {
+            foo: {$ref: "http://e.com/word.json#"},
+          },
+        }
+
+        const schemaWord = {
+          $id: "http://e.com/word.json#",
+          $async: true,
+          anyOf: [
+            {
+              type: "string",
+              format: "english_word",
+            },
+            {$ref: "http://e.com/obj.json#"},
+          ],
+        }
+
+        ajv.addSchema(schemaWord)
+        ajv.addFormat("english_word", {
+          async: true,
+          validate: checkWordOnServer,
+        })
+
+        should.throw(() => {
+          ajv.compile(schema)
+        }, "async schema referenced by sync schema")
+
+        schema = {...schema, $id: "http://e.com/obj2.json#", $async: true}
+
+        ajv.compile(schema)
+      })
+
+      function recursiveTest(schema, refSchema?) {
+        return repeat(() => {
+          return Promise.all(
+            instances.map((_ajv) => {
+              if (refSchema) _ajv.addSchema(refSchema)
+              const validate = _ajv.compile(schema)
+              let data
+
+              return Promise.all([
+                shouldBeValid(validate((data = {foo: "tomorrow"})), data),
+                shouldBeInvalid(validate({foo: "manana"})),
+                shouldBeInvalid(validate({foo: 1})),
+                shouldThrow(validate({foo: "today"}), "unknown word"),
+                shouldBeValid(validate((data = {foo: {foo: "tomorrow"}})), data),
+                shouldBeInvalid(validate({foo: {foo: "manana"}})),
+                shouldBeInvalid(validate({foo: {foo: 1}})),
+                shouldThrow(validate({foo: {foo: "today"}}), "unknown word"),
+                shouldBeValid(validate((data = {foo: {foo: {foo: "tomorrow"}}})), data),
+                shouldBeInvalid(validate({foo: {foo: {foo: "manana"}}})),
+                shouldBeInvalid(validate({foo: {foo: {foo: 1}}})),
+                shouldThrow(validate({foo: {foo: {foo: "today"}}}), "unknown word"),
+              ])
+            })
+          )
+        })
+      }
+    })
+  })
+
+  describe("async JTD schemas", () => {
+    beforeEach(() => {
+      instances = getAjvJtdAsyncInstances()
+      ajv = instances[0]
+    })
+
+    describe("async schemas without async elements", () => {
+      it("should return result as promise", () => {
+        instances = getAjvJtdAsyncInstances()
+
+        const schema = {
+          type: "string",
+          metadata: {async: true},
+        }
+
+        return repeat(() => {
+          return Promise.all(instances.map(test))
+        })
+
+        function test(_ajv) {
           const validate = _ajv.compile(schema)
 
           return Promise.all([
-            shouldBeInvalid(validate({userId: 5, postId: 10}), ["id not found in table posts"]),
-            shouldBeInvalid(validate({userId: 9, postId: 25}), ["id not found in table users"]),
+            shouldBeValid(validate("abc"), "abc"),
+            shouldBeInvalid(validate(true)),
+            shouldBeInvalid(validate(1)),
           ])
-        })
-      )
-    })
-
-    function checkIdExists(schema, data) {
-      switch (schema.table) {
-        case "users":
-          return check([1, 5, 8])
-        case "posts":
-          return check([21, 25, 28])
-        default:
-          throw new Error("no such table")
-      }
-
-      function check(IDs) {
-        return Promise.resolve(IDs.indexOf(data) >= 0)
-      }
-    }
-
-    function checkIdExistsWithError(schema, data) {
-      const {table} = schema
-      switch (table) {
-        case "users":
-          return check(table, [1, 5, 8])
-        case "posts":
-          return check(table, [21, 25, 28])
-        default:
-          throw new Error("no such table")
-      }
-
-      function check(_table, IDs) {
-        if (IDs.indexOf(data) >= 0) return Promise.resolve(true)
-        const error = {
-          keyword: "idExistsWithError",
-          message: "id not found in table " + _table,
         }
-        return Promise.reject(new _Ajv.ValidationError([error]))
-      }
-    }
-  })
+      })
 
-  describe("async referenced schemas", () => {
-    beforeEach(() => {
-      instances = getAjvAsyncInstances({inlineRefs: false, ignoreKeywordsWithRef: true})
-      addFormatEnglishWord()
-    })
-
-    it("should validate referenced async schema", () => {
-      const schema = {
-        $async: true,
-        definitions: {
-          english_word: {
-            $async: true,
-            type: "string",
-            format: "english_word",
+      it("should fail compilation if async schema is inside sync schema", () => {
+        const schema: any = {
+          properties: {
+            foo: {
+              type: "string",
+              metadata: {async: true},
+            },
           },
-        },
-        type: "object",
-        properties: {
-          word: {$ref: "#/definitions/english_word"},
-        },
-      }
+        }
 
-      return repeat(() => {
-        return Promise.all(
-          instances.map((_ajv) => {
-            const validate = _ajv.compile(schema)
-            const validData = {word: "tomorrow"}
+        should.throw(() => {
+          ajv.compile(schema)
+        }, "async schema in sync schema")
 
-            return Promise.all([
-              shouldBeValid(validate(validData), validData),
-              shouldBeInvalid(validate({word: "manana"})),
-              shouldBeInvalid(validate({word: 1})),
-              shouldThrow(validate({word: "today"}), "unknown word"),
-            ])
-          })
-        )
+        ajv.compile({...schema, metadata: {async: true}})
       })
     })
 
-    it("should validate recursive async schema", () => {
-      const schema = {
-        $async: true,
-        definitions: {
-          english_word: {
-            $async: true,
-            type: "string",
-            format: "english_word",
-          },
-        },
-        type: "object",
-        properties: {
-          foo: {
-            anyOf: [{$ref: "#/definitions/english_word"}, {$ref: "#"}],
-          },
-        },
-      }
+    describe("async user-defined keywords", () => {
+      beforeEach(() => {
+        instances.forEach((_ajv) => {
+          _ajv.addKeyword({
+            keyword: "idExists",
+            async: true,
+            type: "number",
+            validate: checkIdExists,
+            errors: false,
+          })
 
-      return recursiveTest(schema)
-    })
+          _ajv.addKeyword({
+            keyword: "idExistsWithError",
+            async: true,
+            type: "number",
+            validate: checkIdExistsWithError,
+            errors: true,
+          })
+        })
+      })
 
-    it("should validate recursive ref to async sub-schema, issue #612", () => {
-      const schema = {
-        $async: true,
-        type: "object",
-        properties: {
-          foo: {
-            $async: true,
-            anyOf: [
-              {
-                type: "string",
-                format: "english_word",
-              },
-              {
-                type: "object",
-                properties: {
-                  foo: {$ref: "#/properties/foo"},
+      it("should fail compilation if async keyword is inside sync schema", () => {
+        instances.forEach((_ajv) => {
+          let schema: any = {
+            properties: {userId: {type: "int32", metadata: {idExists: {table: "users"}}}},
+          }
+
+          should.throw(() => {
+            _ajv.compile(schema)
+          }, "async keyword in sync schema")
+
+          schema = {...schema, metadata: {async: true}}
+          _ajv.compile(schema)
+        })
+      })
+
+      it("should return user-defined error", () => {
+        return Promise.all(
+          instances.map((_ajv) => {
+            const schema = {
+              properties: {
+                userId: {
+                  type: "int32",
+                  metadata: {idExistsWithError: {table: "users"}},
                 },
+                postId: {type: "int32", metadata: {idExistsWithError: {table: "posts"}}},
               },
-            ],
-          },
-        },
-      }
+              metadata: {async: true},
+            }
 
-      return recursiveTest(schema)
-    })
-
-    it("should validate ref from referenced async schema to root schema", () => {
-      const schema = {
-        $async: true,
-        definitions: {
-          wordOrRoot: {
-            $async: true,
-            anyOf: [
-              {
-                type: "string",
-                format: "english_word",
-              },
-              {$ref: "#"},
-            ],
-          },
-        },
-        type: "object",
-        properties: {
-          foo: {$ref: "#/definitions/wordOrRoot"},
-        },
-      }
-
-      return recursiveTest(schema)
-    })
-
-    it("should validate refs between two async schemas", () => {
-      const schemaObj = {
-        $id: "http://e.com/obj.json#",
-        $async: true,
-        type: "object",
-        properties: {
-          foo: {$ref: "http://e.com/word.json#"},
-        },
-      }
-
-      const schemaWord = {
-        $id: "http://e.com/word.json#",
-        $async: true,
-        anyOf: [
-          {
-            type: "string",
-            format: "english_word",
-          },
-          {$ref: "http://e.com/obj.json#"},
-        ],
-      }
-
-      return recursiveTest(schemaObj, schemaWord)
-    })
-
-    it("should fail compilation if sync schema references async schema", () => {
-      let schema: any = {
-        $id: "http://e.com/obj.json#",
-        type: "object",
-        properties: {
-          foo: {$ref: "http://e.com/word.json#"},
-        },
-      }
-
-      const schemaWord = {
-        $id: "http://e.com/word.json#",
-        $async: true,
-        anyOf: [
-          {
-            type: "string",
-            format: "english_word",
-          },
-          {$ref: "http://e.com/obj.json#"},
-        ],
-      }
-
-      ajv.addSchema(schemaWord)
-      ajv.addFormat("english_word", {
-        async: true,
-        validate: checkWordOnServer,
-      })
-
-      should.throw(() => {
-        ajv.compile(schema)
-      }, "async schema referenced by sync schema")
-
-      schema = {...schema, $id: "http://e.com/obj2.json#", $async: true}
-
-      ajv.compile(schema)
-    })
-
-    function recursiveTest(schema, refSchema?) {
-      return repeat(() => {
-        return Promise.all(
-          instances.map((_ajv) => {
-            if (refSchema) _ajv.addSchema(refSchema)
             const validate = _ajv.compile(schema)
-            let data
 
             return Promise.all([
-              shouldBeValid(validate((data = {foo: "tomorrow"})), data),
-              shouldBeInvalid(validate({foo: "manana"})),
-              shouldBeInvalid(validate({foo: 1})),
-              shouldThrow(validate({foo: "today"}), "unknown word"),
-              shouldBeValid(validate((data = {foo: {foo: "tomorrow"}})), data),
-              shouldBeInvalid(validate({foo: {foo: "manana"}})),
-              shouldBeInvalid(validate({foo: {foo: 1}})),
-              shouldThrow(validate({foo: {foo: "today"}}), "unknown word"),
-              shouldBeValid(validate((data = {foo: {foo: {foo: "tomorrow"}}})), data),
-              shouldBeInvalid(validate({foo: {foo: {foo: "manana"}}})),
-              shouldBeInvalid(validate({foo: {foo: {foo: 1}}})),
-              shouldThrow(validate({foo: {foo: {foo: "today"}}}), "unknown word"),
+              shouldBeInvalid(validate({userId: 5, postId: 10}), ["id not found in table posts"]),
+              shouldBeInvalid(validate({userId: 9, postId: 25}), ["id not found in table users"]),
             ])
           })
         )
       })
-    }
-  })
+    })
 
-  function addFormatEnglishWord() {
-    instances.forEach((_ajv) => {
-      _ajv.addFormat("english_word", {
-        async: true,
-        validate: checkWordOnServer,
+    describe("async referenced schemas", () => {
+      beforeEach(() => {
+        instances = getAjvJtdAsyncInstances({inlineRefs: false, ignoreKeywordsWithRef: true})
+        instances.forEach((instance) => {
+          instance.addKeyword({
+            keyword: "englishWord",
+            async: true,
+            validate: (schema, data) =>
+              !!schema &&
+              checkWordOnServer(data).catch((error) => {
+                throw new _Ajv.ValidationError([{message: error.message}])
+              }),
+          })
+        })
+      })
+
+      it("should validate referenced async schema", () => {
+        const schema = {
+          metadata: {
+            async: true,
+          },
+          definitions: {
+            english_word: {
+              type: "string",
+              metadata: {englishWord: true, async: true},
+            },
+          },
+          properties: {
+            word: {ref: "english_word"},
+          },
+        }
+
+        return repeat(() => {
+          return Promise.all(
+            instances.map((_ajv) => {
+              const validate = _ajv.compile(schema)
+              const validData = {word: "tomorrow"}
+
+              return Promise.all([
+                shouldBeValid(validate(validData), validData),
+                shouldBeInvalid(validate({word: "manana"})),
+                shouldBeInvalid(validate({word: 1})),
+                shouldThrow(validate({word: "today"}), "unknown word"),
+              ])
+            })
+          )
+        })
       })
     })
-  }
+  })
 })
+
+function addFormatEnglishWord(instances) {
+  instances.forEach((_ajv) => {
+    _ajv.addFormat("english_word", {
+      async: true,
+      validate: checkWordOnServer,
+    })
+  })
+}
+
+function checkIdExists(schema, data) {
+  switch (schema.table) {
+    case "users":
+      return check([1, 5, 8])
+    case "posts":
+      return check([21, 25, 28])
+    default:
+      throw new Error("no such table")
+  }
+
+  function check(IDs) {
+    return Promise.resolve(IDs.indexOf(data) >= 0)
+  }
+}
+
+function checkIdExistsWithError(schema, data) {
+  const {table} = schema
+  switch (table) {
+    case "users":
+      return check(table, [1, 5, 8])
+    case "posts":
+      return check(table, [21, 25, 28])
+    default:
+      throw new Error("no such table")
+  }
+
+  function check(_table, IDs) {
+    if (IDs.indexOf(data) >= 0) return Promise.resolve(true)
+    const error = {
+      keyword: "idExistsWithError",
+      message: "id not found in table " + _table,
+    }
+    return Promise.reject(new _Ajv.ValidationError([error]))
+  }
+}
 
 function checkWordOnServer(str) {
   return str === "tomorrow"
@@ -403,6 +568,7 @@ function shouldBeValid(p, data) {
 }
 
 const SHOULD_BE_INVALID = "test: should be invalid"
+
 function shouldBeInvalid(p, expectedMessages?: string[]) {
   return checkNotValid(p).then((err) => {
     err.should.be.instanceof(_Ajv.ValidationError)
@@ -416,7 +582,12 @@ function shouldBeInvalid(p, expectedMessages?: string[]) {
 }
 
 function shouldThrow(p, exception) {
-  return checkNotValid(p).then((err) => err.message.should.equal(exception))
+  return checkNotValid(p).then((err) => {
+    if (err.errors?.length) {
+      return err.errors[0]?.message?.should?.equal(exception)
+    }
+    return err.message.should.equal(exception)
+  })
 }
 
 function checkNotValid(p) {

--- a/spec/types/async-validate.spec.ts
+++ b/spec/types/async-validate.spec.ts
@@ -1,6 +1,7 @@
 import type {AnySchemaObject, SchemaObject, AsyncSchema} from "../.."
-import _Ajv from "../ajv"
+import {default as _Ajv, AjvJtdClass as _AjvJtd} from "../ajv"
 import chai from "../chai"
+
 const should = chai.should()
 
 interface Foo {
@@ -135,6 +136,133 @@ describe("$async validation and type guards", () => {
     const schema: Record<string, unknown> = {
       type: "object",
       properties: {foo: {type: "number"}},
+    }
+    const validate = ajv.compile<Foo>(schema)
+
+    it("should have result type boolean", () => {
+      const data = {foo: 1}
+      let result: boolean
+      if ((result = validate(data))) {
+        data.foo.should.equal(1)
+      }
+      result.should.equal(true)
+    })
+  })
+
+  describe("schema: any", () => {
+    const schema: any = {}
+    const validate = ajv.compile(schema)
+    it("should have result type boolean | promise", () => {
+      const result: boolean = validate({})
+      result.should.equal(true)
+    })
+  })
+})
+
+describe("metadata.async validation and type guards", () => {
+  const ajv = new _AjvJtd({strictTypes: false})
+
+  describe("async: undefined", () => {
+    it("should have result type boolean 1", () => {
+      const validate = ajv.compile({metadata: {async: false}})
+      const result: boolean = validate({})
+      should.exist(result)
+    })
+
+    it("should have result type boolean 2", () => {
+      const schema: SchemaObject = {metadata: {async: false}}
+      const validate = ajv.compile(schema)
+      const result: boolean = validate({})
+      should.exist(result)
+    })
+
+    it("should have result type boolean 3", () => {
+      const schema: AnySchemaObject = {metadata: {async: false}}
+      const validate = ajv.compile(schema)
+      const result: boolean = validate({})
+      should.exist(result)
+    })
+  })
+
+  describe("async: false", () => {
+    it("should have result type boolean 1", () => {
+      const validate = ajv.compile({metadata: {async: false}})
+      const result: boolean = validate({})
+      should.exist(result)
+    })
+
+    it("should have result type boolean 2", () => {
+      const schema: SchemaObject = {metadata: {async: false}}
+      const validate = ajv.compile(schema)
+      const result: boolean = validate({})
+      should.exist(result)
+    })
+
+    it("should have result type boolean 3", () => {
+      const schema: AnySchemaObject = {metadata: {async: false}}
+      const validate = ajv.compile(schema)
+      const result: boolean = validate({})
+      should.exist(result)
+    })
+  })
+
+  describe("async: true", () => {
+    it("should have result type promise 1", async () => {
+      const validate = ajv.compile<Foo>({
+        properties: {foo: {type: "int32"}},
+        metadata: {async: true},
+      })
+      const result: Promise<Foo> = validate({foo: 1})
+      await result.then((data) => data.should.exist)
+    })
+
+    it("should have result type promise 2", async () => {
+      const schema: AsyncSchema = {
+        properties: {foo: {type: "int32"}},
+        metadata: {async: true},
+      }
+      const validate = ajv.compile<Foo>(schema)
+      const result: Promise<Foo> = validate({foo: 1})
+      await result.then((data) => data.foo.should.equal(1))
+    })
+  })
+
+  describe("async: boolean", () => {
+    it("should have result type boolean | promise 1", async () => {
+      const schema = {
+        properties: {foo: {type: "int32"}},
+        metadata: {async: true},
+      }
+      const validate = ajv.compile<Foo>(schema)
+      const data = {foo: 1}
+      const result: boolean | Promise<Foo> = validate(data)
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises, @typescript-eslint/no-unnecessary-condition
+      if (result) {
+        if (typeof result == "boolean") {
+          data.foo.should.equal(1)
+        } else {
+          await result.then((_data) => _data.foo.should.equal(1))
+        }
+      } else {
+        should.fail()
+      }
+    })
+
+    it("should have result type boolean | promise 2", async () => {
+      const schema = {metadata: {async: false}}
+      const validate = ajv.compile<any>(schema)
+      const result = validate({})
+      if (typeof result === "boolean") {
+        should.exist(result)
+      } else {
+        await result.then((data) => data.should.exist)
+      }
+    })
+  })
+
+  describe("async: unknown", () => {
+    const schema: Record<string, unknown> = {
+      properties: {foo: {type: "int32"}},
     }
     const validate = ajv.compile<Foo>(schema)
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?** #2029

**What changes did you make?** 

The main changes are:

- The `$async` keyword is now added only if the JTD option is not present, otherwise a new `async` keyword is added.
- The `SchemaEnv.$async` property is now set with the value of `$async` or `metadata.async` properties.
- The `SchemaObject` and `AsyncSchema` types now includes the `metadata.async` property.

**Is there anything that requires more attention while reviewing?**

Maybe the changes I added to the `AsyncSchema` type where I had some problems.

I first tried to add the `metadata.async` property with the type `true` but this caused errors in the compile function behavior (the schemas had errors saying that [type `boolean` is not assignable to type `true`](https://github.com/microsoft/TypeScript/issues/24413) for the `metadata.async` property ).

I finally assigned the type `boolean` to the `metadata.async` property and it works perfectly for the `compile` and `validate` functions. However, this is not really correct because it implies that a schema with the property `metadata.async = false` is an `AsyncSchema`.
