### PR TITLE
ensure that nullable is not set for required parameters

### DIFF
--- a/lib/types/json-schema.ts
+++ b/lib/types/json-schema.ts
@@ -180,6 +180,7 @@ type Nullable<T> = undefined extends T
       default?: T | null
     }
   : {
+      nullable?: false
       const?: T
       enum?: Readonly<T[]>
       default?: T

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-node": "^10.0.0",
     "tsify": "^5.0.2",
-    "typescript": "^4.2.0"
+    "typescript": ">=4.2 <4.8"
   },
   "collective": {
     "type": "opencollective",

--- a/spec/types/json-schema.spec.ts
+++ b/spec/types/json-schema.spec.ts
@@ -306,6 +306,23 @@ describe("JSONSchemaType type and validation as a type guard", () => {
       // eslint-disable-next-line no-void
       void optionalSchema
     })
+
+    it("won't accept nullable for non-null types", () => {
+      // @ts-expect-error can't set nullable
+      const nonNullSchema: JSONSchemaType<{a: number}> = {
+        type: "object",
+        properties: {
+          a: {
+            type: "number",
+            nullable: true,
+          },
+        },
+        required: [],
+      }
+
+      // eslint-disable-next-line no-void
+      void nonNullSchema
+    })
   })
 
   describe("schema works for primitives", () => {


### PR DESCRIPTION
nullable was enforced for optional parameters, but not forbidden for
required parameters. This tests and enforces the latter case.

**What issue does this pull request resolve?**

fixes #2030

at least partially

**What changes did you make?**

add `nullable?: false` and tests

**Is there anything that requires more attention while reviewing?**

nope