### PR TITLE
Remove unnecessary console.log

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -140,8 +140,8 @@ const parse = ajv.compileParser(schema)
 const json = '{"foo": 1, "bar": "abc"}'
 const invalidJson = '{"unknown": "abc"}'
 
-console.log(parseAndLog(json)) // logs {foo: 1, bar: "abc"}
-console.log(parseAndLog(invalidJson)) // logs error and position
+parseAndLog(json) // logs {foo: 1, bar: "abc"}
+parseAndLog(invalidJson) // logs error and position
 
 function parseAndLog(json) {
   const data = parse(json)


### PR DESCRIPTION
There are already console logs in the parseAndLog function itself. parseAndLog(json) and parseAndLog(invalidJson) will just print 2 undefined in plus.

**What issue does this pull request resolve?**
Remove 2 unnecessary console logs in the documentation.

**What changes did you make?**
Removed 2 unnecessary console logs in the documentation.

**Is there anything that requires more attention while reviewing?**
No.
