### PR TITLE
Export Ajv as a named export

### DIFF
--- a/lib/ajv.ts
+++ b/lib/ajv.ts
@@ -36,6 +36,8 @@ Object.defineProperty(exports, "__esModule", {value: true})
 
 export default Ajv
 
+export {Ajv}
+
 export {
   Format,
   FormatDefinition,


### PR DESCRIPTION
This is solving an issue where it's impossible for me to import Ajv in a typescript project.  This solves #2047 for me

import { Ajv } from 'ajv';

**What issue does this pull request resolve?**

#2047 

**What changes did you make?**

Added a single line exporting `Ajv` in a slightly different way.  I'm not sure if there are any tests on the exported interface.

**Is there anything that requires more attention while reviewing?**

I don't think so -- this should be a no-op for those who don't use it, and the test suite (`yarn test`) passes.  