### PR TITLE
chore: provide an esm distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ node_modules
 
 # compiled typescript
 dist/
+dist-esm/
 
 # browser bundles
 bundle/

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@ spec/json-typedef-spec
 .browser
 coverage
 dist
+dist-esm
 bundle
 .nyc_output
 spec/_json

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "8.11.2",
   "description": "Another JSON Schema Validator",
   "main": "dist/ajv.js",
+  "module": "dist-esm/ajv.js",
   "types": "dist/ajv.d.ts",
   "files": [
     "lib/",
@@ -19,7 +20,9 @@
     "test-cov": "nyc npm run test-spec",
     "rollup": "rm -rf bundle && rollup -c",
     "bundle": "rm -rf bundle && node ./scripts/bundle.js ajv ajv7 ajv7 && node ./scripts/bundle.js 2019 ajv2019 ajv2019 && node ./scripts/bundle.js 2020 ajv2020 ajv2020 && node ./scripts/bundle.js jtd ajvJTD ajvJTD",
-    "build": "rm -rf dist && tsc && cp -r lib/refs dist && rm dist/refs/json-schema-2019-09/index.ts && rm dist/refs/json-schema-2020-12/index.ts && rm dist/refs/jtd-schema.ts",
+    "build:cjs": "rm -rf dist && tsc && cp -r lib/refs dist && rm dist/refs/json-schema-2019-09/index.ts && rm dist/refs/json-schema-2020-12/index.ts && rm dist/refs/jtd-schema.ts",
+    "build:esm": "rm -rf dist-esm && tsc --outDir dist-esm --module es2020 && cp -r lib/refs dist-esm && rm dist-esm/refs/json-schema-2019-09/index.ts && rm dist-esm/refs/json-schema-2020-12/index.ts && rm dist-esm/refs/jtd-schema.ts",
+    "build": "npm run build:cjs && npm run build:esm",
     "json-tests": "rm -rf spec/_json/*.js && node scripts/jsontests",
     "test-karma": "karma start",
     "test-browser": "rm -rf .browser && npm run bundle && scripts/prepare-tests && karma start",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?** 

https://github.com/ajv-validator/ajv/issues/2015

**What changes did you make?** 

I setup the build script to create a second distribution folder containing esm. This is done by running tsc with two flags passed to it, that alter the output directory, and the module format. The rest uses the existing tsconfig.

I passed the `module` entrypoint of the package json to this distribution, which allows anything that supports ESM to consume a native ESM version. This allows better tree shaking and scope hoisting for supported environments.

This makes no alterations to existing distributions, and the bundles are left unchanged. This only affects the package when consumed via the package.json file in an environment supporting ESM.

**Is there anything that requires more attention while reviewing?**

I'm a bit confused about why files in the runtime folder assign a `code` property that contains a require statement in a string. Currently this continues to point to the CJS variants of the files in case this is required