### PR TITLE
Check for first property in generated code

### DIFF
--- a/lib/compile/jtd/serialize.ts
+++ b/lib/compile/jtd/serialize.ts
@@ -155,7 +155,7 @@ function serializeSchemaProperties(cxt: SerializeCxt, discriminator?: string): v
   const props = keys(properties)
   const optProps = keys(optionalProperties)
   const allProps = allProperties(props.concat(optProps))
-  let first = !discriminator
+  const first = gen.let("first", !discriminator)
   for (const key of props) {
     serializeProperty(key, properties[key], keyValue(key))
   }
@@ -167,9 +167,7 @@ function serializeSchemaProperties(cxt: SerializeCxt, discriminator?: string): v
   }
   if (schema.additionalProperties) {
     gen.forIn("key", data, (key) =>
-      gen.if(isAdditional(key, allProps), () =>
-        serializeKeyValue(cxt, key, {}, gen.let("first", first))
-      )
+      gen.if(isAdditional(key, allProps), () => serializeKeyValue(cxt, key, {}, first))
     )
   }
 
@@ -190,8 +188,7 @@ function serializeSchemaProperties(cxt: SerializeCxt, discriminator?: string): v
   }
 
   function serializeProperty(key: string, propSchema: SchemaObject, value: Name): void {
-    if (first) first = false
-    else gen.add(N.json, str`,`)
+    addComma(cxt, first)
     gen.add(N.json, str`${JSON.stringify(key)}:`)
     serializeCode({...cxt, schema: propSchema, data: value})
   }

--- a/spec/jtd-schema.spec.ts
+++ b/spec/jtd-schema.spec.ts
@@ -144,6 +144,20 @@ describe("JSON Type Definition", () => {
         })
       )
     }
+
+    it("serializes missing first optionalProperty", () => {
+      const schema = {
+        optionalProperties: {
+          foo: {type: "string"},
+          bar: {type: "string"},
+        },
+      }
+      const instance = {
+        bar: "bar",
+      }
+      const serialize = ajv.compileSerializer(schema)
+      assert.deepStrictEqual(JSON.parse(serialize(instance)), instance)
+    })
   })
 
   describe("parse", () => {


### PR DESCRIPTION
**What issue does this pull request resolve?**
#2181 - `compileSerializer` fails with optional properties only

**What changes did you make?**
Added a failing test to demonstrate the bug.

**Is there anything that requires more attention while reviewing?**
No.

fixes #2171
fixes #2181
fixes #2001
