### PR TITLE
`satisfies` does not properly enforce enum on `SomeJTDSchemaType`

### DIFF
--- a/lib/types/jtd-schema.ts
+++ b/lib/types/jtd-schema.ts
@@ -11,7 +11,7 @@ export type SomeJTDSchemaType = (
   // primitives
   | {type: NumberType | StringType | "boolean"}
   // enum
-  | {enum: string[]}
+  | {enum: readonly string[]}
   // elements
   | {elements: SomeJTDSchemaType}
   // values


### PR DESCRIPTION
**What issue does this pull request resolve?**

Closes #2205 

**What changes did you make?**

Made the type of string enums readonly in `SomeJTDSchemaType`

Also documented the use of `JTDDataType` to extract types from schema, and the use of `SomeJTDSchemaType` to ensure a schema is properly formed before sending it to `JTDDataType`

**Is there anything that requires more attention while reviewing?**

This only impacts the typescript typings used in a way that was not documented before ; no impact on the result of the unit tests ; so I don't think so