### PR TITLE
Replace `fast-deep-equal` to `fast-equals`

### DIFF
--- a/lib/compile/resolve.ts
+++ b/lib/compile/resolve.ts
@@ -2,7 +2,7 @@ import type {AnySchema, AnySchemaObject, UriResolver} from "../types"
 import type Ajv from "../ajv"
 import type {URIComponents} from "uri-js"
 import {eachItem} from "./util"
-import * as equal from "fast-deep-equal"
+import {deepEqual} from "fast-equals"
 import * as traverse from "json-schema-traverse"
 
 // the hash of local references inside the schema (created by getSchemaRefs), used for inline resolution
@@ -140,7 +140,7 @@ export function getSchemaRefs(this: Ajv, schema: AnySchema, baseId: string): Loc
   return localRefs
 
   function checkAmbiguosRef(sch1: AnySchema, sch2: AnySchema | undefined, ref: string): void {
-    if (sch2 !== undefined && !equal(sch1, sch2)) throw ambiguos(ref)
+    if (sch2 !== undefined && !deepEqual(sch1, sch2)) throw ambiguos(ref)
   }
 
   function ambiguos(ref: string): Error {

--- a/lib/runtime/equal.ts
+++ b/lib/runtime/equal.ts
@@ -1,7 +1,7 @@
 // https://github.com/ajv-validator/ajv/issues/889
-import * as equal from "fast-deep-equal"
+import {deepEqual} from "fast-equals"
 
-type Equal = typeof equal & {code: string}
-;(equal as Equal).code = 'require("ajv/dist/runtime/equal").default'
+type Equal = typeof deepEqual & {code: string}
+;(deepEqual as Equal).code = 'require("ajv/dist/runtime/equal").default'
 
-export default equal as Equal
+export default deepEqual as Equal

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "homepage": "https://ajv.js.org",
   "runkitExampleFilename": ".runkit_example.js",
   "dependencies": {
-    "fast-deep-equal": "^3.1.1",
+    "fast-equals": "^5.0.0",
     "json-schema-traverse": "^1.0.0",
     "require-from-string": "^2.0.2",
     "uri-js": "^4.2.2"


### PR DESCRIPTION
Suggestion to replace `fast-deep-equal` to well-maintained faster implementation.