### PR TITLE
docs: Clarify keyword name constraints for `addKeyword`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -251,7 +251,7 @@ Add validation keyword to Ajv instance.
 
 Keyword should be different from all standard JSON Schema keywords and different from previously defined keywords. There is no way to redefine keywords or to remove keyword definition from the instance.
 
-Keyword must start with a letter, `_` or `$`, and may continue with letters, numbers, `_`, `$`, `-`, or `:`.
+Keyword must start with an ASCII letter, `_` or `$`, and may continue with ASCII letters, numbers, `_`, `$`, `-`, or `:`.
 It is recommended to use an application-specific prefix for keywords to avoid current and future name collisions.
 
 Example Keywords:

--- a/docs/api.md
+++ b/docs/api.md
@@ -251,7 +251,7 @@ Add validation keyword to Ajv instance.
 
 Keyword should be different from all standard JSON Schema keywords and different from previously defined keywords. There is no way to redefine keywords or to remove keyword definition from the instance.
 
-Keyword must start with a letter, `_` or `$`, and may continue with letters, numbers, `_`, `$`, or `-`.
+Keyword must start with a letter, `_` or `$`, and may continue with letters, numbers, `_`, `$`, `-`, or `:`.
 It is recommended to use an application-specific prefix for keywords to avoid current and future name collisions.
 
 Example Keywords:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
Closes #2217.

**What changes did you make?**
Based on the [`KEYWORD_NAME` regex](https://github.com/ajv-validator/ajv/blob/b3e0cb17d0e095b5c883042b2306571be5ec86b7/lib/core.ts#L819):
- Mentioned `:` as a valid character
- Specified that "letters" refers to the ASCII character set

**Is there anything that requires more attention while reviewing?**
No.