### PR TITLE
add refs variable for jtd validation

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -340,7 +340,10 @@ export default class Ajv {
   validate<T>(schema: Schema | JSONSchemaType<T> | string, data: unknown): data is T
   // Separated for type inference to work
   // eslint-disable-next-line @typescript-eslint/unified-signatures
-  validate<T>(schema: JTDSchemaType<T>, data: unknown): data is T
+  validate<T, R extends Record<string, unknown>>(
+    schema: JTDSchemaType<T, R>,
+    data: unknown
+  ): data is T
   // This overload is only intended for typescript inference, the first
   // argument prevents manual type annotation from matching this overload
   validate<N extends never, T extends SomeJTDSchemaType>(
@@ -371,7 +374,10 @@ export default class Ajv {
   compile<T = unknown>(schema: Schema | JSONSchemaType<T>, _meta?: boolean): ValidateFunction<T>
   // Separated for type inference to work
   // eslint-disable-next-line @typescript-eslint/unified-signatures
-  compile<T = unknown>(schema: JTDSchemaType<T>, _meta?: boolean): ValidateFunction<T>
+  compile<T = unknown, R extends Record<string, unknown> = Record<string, unknown>>(
+    schema: JTDSchemaType<T, R>,
+    _meta?: boolean
+  ): ValidateFunction<T>
   // This overload is only intended for typescript inference, the first
   // argument prevents manual type annotation from matching this overload
   compile<N extends never, T extends SomeJTDSchemaType>(

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "eslint": "eslint \"lib/**/*.ts\" \"spec/**/*.*s\" --ignore-pattern spec/JSON-Schema-Test-Suite",
-    "prettier:write": "prettier --write \"./**/*.{json,yaml,js,ts}\"",
+    "prettier:write": "prettier --write --cache \"./**/*.{json,yaml,js,ts}\"",
     "prettier:check": "prettier --list-different \"./**/*.{json,yaml,js,ts}\"",
     "test-spec": "cross-env TS_NODE_PROJECT=spec/tsconfig.json mocha -r ts-node/register \"spec/**/*.spec.{ts,js}\" -R dot",
     "test-codegen": "nyc cross-env TS_NODE_PROJECT=spec/tsconfig.json mocha -r ts-node/register 'spec/codegen.spec.ts' -R spec",


### PR DESCRIPTION
There seems to be some weird behavior with typescript when refs was left to default. By specifying it manually the behavior was fixed.

**What issue does this pull request resolve?**

fixes #2167

**What changes did you make?**

- Add `R extends Record<string, unknown>` to compile and validate for JTD schemas that resolves the referenced issue.
- Add tests that failed prior to the change
- Added `--cache` to prettier invocation. This is not related to the diff, but a nice quality of life change. I'll remove if requested

**Is there anything that requires more attention while reviewing?**

1. If you're cool with adding `--cache` to prettier
2. `compile` and `validate` have really complicated types. This change only resolved the existing tests, but we know coverage is not 100%, so if anything comes to mind that this might hurt.

with or without cache, prettier was tweaking files that broke typescript. I reverted the changes here to get the pull request in, but it's worth calling out