### PR TITLE
docs: modify the link of `Error logging` to the right address

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -240,7 +240,7 @@ An array or object of schemas that will be added to the instance. In case you pa
 
 ### logger
 
-Sets the logging method. Default is the global `console` object that should have methods `log`, `warn` and `error`. See [Error logging](#error-logging).
+Sets the logging method. Default is the global `console` object that should have methods `log`, `warn` and `error`. See [Error logging](./api.md#error-logging).
 
 Option values:
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

A link in the dossier doesn't point to the right address. 

**What changes did you make?**

I modified the link to point to the correct address.

**Is there anything that requires more attention while reviewing?**

N/A
