### PR TITLE
fix(#1558): Discrepancy in `addUsedSchema` between v6 and v8

### DIFF
--- a/lib/compile/resolve.ts
+++ b/lib/compile/resolve.ts
@@ -112,6 +112,7 @@ export function getSchemaRefs(this: Ajv, schema: AnySchema, baseId: string): Loc
       // eslint-disable-next-line @typescript-eslint/unbound-method
       const _resolve = this.opts.uriResolver.resolve
       ref = normalizeId(baseId ? _resolve(baseId, ref) : ref)
+      if (this.opts.addUsedSchema === false) return ref // skip adding schema reference
       if (schemaRefs.has(ref)) throw ambiguos(ref)
       schemaRefs.add(ref)
       let schOrRef = this.refs[ref]

--- a/spec/resolve.spec.ts
+++ b/spec/resolve.spec.ts
@@ -134,6 +134,37 @@ uriResolvers.forEach((resolver) => {
             }, /resolves to more than one schema/)
           })
         })
+        it("should not throw if the same id resolves to two different schemas when addUsedSchema is false", () => {
+          const ajvInstance = new _Ajv({
+            allErrors: true,
+            verbose: true,
+            inlineRefs: false,
+            allowUnionTypes: true,
+            uriResolver: resolver,
+            addUsedSchema: false,
+          })
+
+          ajvInstance.compile({
+            $id: "http://example.com/1.json",
+            type: "integer",
+          })
+
+          let errorOccurred = false
+          try {
+            ajvInstance.compile({
+              type: "object",
+              additionalProperties: {
+                $id: "http://example.com/1.json",
+                type: "string",
+              },
+            })
+          } catch (error) {
+            errorOccurred = true
+          }
+
+          // Assert that no error occurred
+          errorOccurred.should.equal(false)
+        })
 
         it("should resolve ids defined as urn's (issue #423)", () => {
           const schema = {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
Fixes #1558 

**What changes did you make?**
I have added changes to check for `addUsedSchema` option, if it's false then skip the adding schema reference otherwise continue the flow.

**Is there anything that requires more attention while reviewing?**

NA
