### PR TITLE
fix: Provide named exports alongside default exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ In JavaScript:
 
 ```javascript
 // or ESM/TypeScript import
-import Ajv from "ajv"
+import { Ajv } from "ajv"
 // Node.js require:
-const Ajv = require("ajv")
+const { Ajv } = require("ajv")
 
 const ajv = new Ajv() // options can be passed, e.g. {allErrors: true}
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -61,7 +61,7 @@ Properties not defined in the schema will not be included in serialized JSON, un
 If you use JTD with typescript, the type for the schema can be derived from the data type, and generated serializer would only accept correct data type in this case:
 
 ```typescript
-import Ajv, {JTDSchemaType} from "ajv/dist/jtd"
+import {Ajv, JTDSchemaType} from "ajv/dist/jtd"
 const ajv = new Ajv()
 
 interface MyData {

--- a/docs/guide/combining-schemas.md
+++ b/docs/guide/combining-schemas.md
@@ -104,8 +104,8 @@ const strictTreeSchema = {
   unevaluatedProperties: false,
 }
 
-import Ajv2019 from "ajv/dist/2019"
-// const Ajv2019 = require("ajv/dist/2019")
+import {Ajv2019} from "ajv/dist/2019"
+// const {Ajv2019} = require("ajv/dist/2019")
 const ajv = new Ajv2019({
   schemas: [treeSchema, strictTreeSchema],
 })

--- a/docs/guide/formats.md
+++ b/docs/guide/formats.md
@@ -9,7 +9,7 @@ To add all formats from this plugin:
 <code-group>
 <code-block title="JavaScript">
 ```javascript
-const Ajv = require("ajv")
+const {Ajv} = require("ajv")
 const addFormats = require("ajv-formats")
 
 const ajv = new Ajv()
@@ -19,7 +19,7 @@ addFormats(ajv)
 
 <code-block title="TypeScript">
 ```typescript
-import Ajv from "ajv"
+import {Ajv} from "ajv"
 import addFormats from "ajv-formats"
 
 const ajv = new Ajv()
@@ -91,14 +91,14 @@ If you define your own formats, for standalone code generation to work you need 
 <code-group>
 <code-block title="JavaScript">
 ```javascript
-const {default: Ajv, _} = require("ajv")
+const {Ajv, _} = require("ajv")
 const ajv = new Ajv({code: {formats: _`require("./my_formats")`}})
 ```
 </code-block>
 
 <code-block title="TypeScript">
 ```typescript
-import Ajv, {_} from "ajv"
+import {Ajv, _} from "ajv"
 const ajv = new Ajv({code: {formats: _`require("./my_formats")`}})
 ```
 </code-block>

--- a/docs/guide/managing-schemas.md
+++ b/docs/guide/managing-schemas.md
@@ -42,7 +42,7 @@ The simplest approach is to compile all your schemas when the application starts
 <code-group>
 <code-block title="JavaScript">
 ```javascript
-const Ajv = require("ajv").default
+const {Ajv} = require("ajv").default
 const schema_user = require("./schema_user.json")
 const ajv = new Ajv()
 const validate_user = ajv.compile(schema_user)
@@ -65,7 +65,7 @@ app.post("/user", async (cxt) => {
 
 <code-block title="TypeScript">
 ```javascript
-import Ajv from "ajv"
+import {Ajv} from "ajv"
 import * as schema_user from "./schema_user.json"
 const ajv = new Ajv()
 const validate_user = ajv.compile<User>(schema_user)
@@ -106,7 +106,7 @@ You can load all schemas and add them to Ajv instance in a single `validation` m
 <code-group>
 <code-block title="validation.js">
 ```javascript
-const Ajv = require("ajv")
+const {Ajv} = require("ajv")
 const schema_user = require("./schema_user.json")
 const schema_document = require("./schema_document.json")
 const ajv = exports.ajv = new Ajv()
@@ -117,7 +117,7 @@ ajv.addSchema(schema_document, "document")
 
 <code-block title="validation.ts">
 ```typescript
-import Ajv from "ajv"
+import {Ajv} from "ajv"
 import * as schema_user from "./schema_user.json"
 import * as schema_document from "./schema_document.json"
 export const ajv = new Ajv()

--- a/docs/guide/schema-language.md
+++ b/docs/guide/schema-language.md
@@ -37,7 +37,7 @@ You can migrate schemas from draft-04 to draft-07 using [ajv-cli](https://github
 These are the most widely used versions of JSON Schema specification, and they are supported with the main ajv export.
 
 ```javascript
-import Ajv from "ajv"
+import {Ajv} from "ajv"
 const ajv = new Ajv()
 ```
 
@@ -55,7 +55,7 @@ The main advantage of this JSON Schema version over draft-07 is the ability to s
 To use Ajv with the support of all JSON Schema draft-2019-09/2020-12 features you need to use a different export:
 
 ```javascript
-import Ajv2019 from "ajv/dist/2019"
+import {Ajv2019} from "ajv/dist/2019"
 const ajv = new Ajv2019()
 ```
 

--- a/docs/guide/typescript.md
+++ b/docs/guide/typescript.md
@@ -20,7 +20,7 @@ For the same example as in [Getting started](./getting-started):
 <code-group>
 <code-block title="JSON Schema">
 ```typescript
-import Ajv, {JSONSchemaType} from "ajv"
+import {Ajv, JSONSchemaType} from "ajv"
 const ajv = new Ajv()
 
 interface MyData {
@@ -61,7 +61,7 @@ if (validate(data)) {
 
 <code-block title="JSON Type Definition">
 ```typescript
-import Ajv, {JTDSchemaType} from "ajv/dist/jtd"
+import {Ajv, JTDSchemaType} from "ajv/dist/jtd"
 const ajv = new Ajv()
 
 interface MyData {
@@ -110,7 +110,7 @@ You can use JTD schema to construct the type of data using utility type `JTDData
 <code-group>
 <code-block title="JSON Type Definition">
 ```typescript
-import Ajv, {JTDDataType} from "ajv/dist/jtd"
+import {Ajv, JTDDataType} from "ajv/dist/jtd"
 const ajv = new Ajv()
 
 const schema = {
@@ -214,7 +214,7 @@ This example uses the same data and schema types as above:
 <code-group>
 <code-block title="JSON Type Definition">
 ```typescript
-import Ajv, {JTDSchemaType} from "ajv/dist/jtd"
+import {Ajv, JTDSchemaType} from "ajv/dist/jtd"
 const ajv = new Ajv()
 
 interface MyData {
@@ -290,7 +290,7 @@ Here's a more detailed example showing several union types:
 <code-group>
 <code-block title="JSON Schema">
 ```typescript
-import Ajv, {JSONSchemaType} from "ajv"
+import {Ajv, JSONSchemaType} from "ajv"
 const ajv = new Ajv()
 
 type MyUnion = {prop: boolean} | string | number

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -15,14 +15,14 @@ This version is provided as default export:
 <code-group>
 <code-block title="JavaScript">
 ```javascript
-const Ajv = require("ajv")
+const {Ajv} = require("ajv")
 const ajv = new Ajv()
 ```
 </code-block>
 
 <code-block title="TypeScript">
 ```typescript
-import Ajv from "ajv"
+import {Ajv} from "ajv"
 const ajv = new Ajv()
 ```
 </code-block>
@@ -48,14 +48,14 @@ To use draft-2019-09 schemas you need to import a different Ajv class:
 <code-group>
 <code-block title="JavaScript">
 ```javascript
-const Ajv2019 = require("ajv/dist/2019")
+const {Ajv2019} = require("ajv/dist/2019")
 const ajv = new Ajv2019()
 ```
 </code-block>
 
 <code-block title="TypeScript">
 ```typescript
-import Ajv2019 from "ajv/dist/2019"
+import {Ajv2019} from "ajv/dist/2019"
 const ajv = new Ajv2019()
 ```
 </code-block>
@@ -96,14 +96,14 @@ To use draft-2020-12 schemas you need to import a different Ajv class:
 <code-group>
 <code-block title="JavaScript">
 ```javascript
-const Ajv2020 = require("ajv/dist/2020")
+const {Ajv2020} = require("ajv/dist/2020")
 const ajv = new Ajv2020()
 ```
 </code-block>
 
 <code-block title="TypeScript">
 ```typescript
-import Ajv2020 from "ajv/dist/2020"
+import {Ajv2020} from "ajv/dist/2020"
 const ajv = new Ajv2020()
 ```
 </code-block>
@@ -116,7 +116,7 @@ You can use JSON Schema draft-06 schemas with Ajv v7/8. If your schemas use `$sc
 <code-group>
 <code-block title="JavaScript">
 ```javascript
-const Ajv = require("ajv")
+const {Ajv} = require("ajv")
 const draft6MetaSchema = require("ajv/dist/refs/json-schema-draft-06.json")
 
 const ajv = new Ajv()
@@ -126,7 +126,7 @@ ajv.addMetaSchema(draft6MetaSchema)
 
 <code-block title="TypeScript">
 ```typescript
-import Ajv from "ajv"
+import {Ajv} from "ajv"
 import * as draft6MetaSchema from "ajv/dist/refs/json-schema-draft-06.json"
 
 const ajv = new Ajv()
@@ -142,14 +142,14 @@ You can use JSON Schema draft-04 schemas with Ajv from v8.5.0 and the additional
 <code-group>
 <code-block title="JavaScript">
 ```javascript
-const Ajv = require("ajv-draft-04")
+const {Ajv} = require("ajv-draft-04")
 const ajv = new Ajv()
 ```
 </code-block>
 
 <code-block title="TypeScript">
 ```typescript
-import Ajv from "ajv-draft-04"
+import {Ajv} from "ajv-draft-04"
 const ajv = new Ajv()
 ```
 </code-block>

--- a/docs/json-type-definition.md
+++ b/docs/json-type-definition.md
@@ -7,14 +7,14 @@ To use JTD schemas you need to import a different Ajv class:
 <code-group>
 <code-block title="JavaScript">
 ```javascript
-const Ajv = require("ajv/dist/jtd")
+const {Ajv} = require("ajv/dist/jtd")
 const ajv = new Ajv()
 ```
 </code-block>
 
 <code-block title="TypeScript">
 ```typescript
-import Ajv from "ajv/dist/jtd"
+import {Ajv} from "ajv/dist/jtd"
 const ajv = new Ajv()
 ```
 </code-block>

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -44,7 +44,7 @@ npm install ajv
 ```javascript
 const fs = require("fs")
 const path = require("path")
-const Ajv = require("ajv")
+const {Ajv} = require("ajv")
 const standaloneCode = require("ajv/dist/standalone").default
 
 const schema = {
@@ -72,7 +72,7 @@ fs.writeFileSync(path.join(__dirname, "../consume/validate-cjs.js"), moduleCode)
 ```javascript
 const fs = require("fs")
 const path = require("path")
-const Ajv = require("ajv")
+const {Ajv} = require("ajv")
 const standaloneCode = require("ajv/dist/standalone").default
 
 const schemaFoo = {
@@ -107,7 +107,7 @@ fs.writeFileSync(path.join(__dirname, "../consume/validate-cjs.js"), moduleCode)
 ```javascript
 const fs = require("fs")
 const path = require("path")
-const Ajv = require("ajv")
+const {Ajv} = require("ajv")
 const standaloneCode = require("ajv/dist/standalone").default
 
 const schemaFoo = {
@@ -243,7 +243,7 @@ To support standalone code generation:
 
 ```javascript
 import myFormats from "./my-formats"
-import Ajv, {_} from "ajv"
+import {Ajv, _} from "ajv"
 const ajv = new Ajv({
   formats: myFormats,
   code: {

--- a/lib/2019.ts
+++ b/lib/2019.ts
@@ -10,7 +10,7 @@ import addMetaSchema2019 from "./refs/json-schema-2019-09"
 
 const META_SCHEMA_ID = "https://json-schema.org/draft/2019-09/schema"
 
-class Ajv2019 extends AjvCore {
+export class Ajv2019 extends AjvCore {
   constructor(opts: Options = {}) {
     super({
       ...opts,

--- a/lib/2020.ts
+++ b/lib/2020.ts
@@ -7,7 +7,7 @@ import addMetaSchema2020 from "./refs/json-schema-2020-12"
 
 const META_SCHEMA_ID = "https://json-schema.org/draft/2020-12/schema"
 
-class Ajv2020 extends AjvCore {
+export class Ajv2020 extends AjvCore {
   constructor(opts: Options = {}) {
     super({
       ...opts,

--- a/lib/ajv.ts
+++ b/lib/ajv.ts
@@ -8,7 +8,7 @@ const META_SUPPORT_DATA = ["/properties"]
 
 const META_SCHEMA_ID = "http://json-schema.org/draft-07/schema"
 
-class Ajv extends AjvCore {
+export class Ajv extends AjvCore {
   _addVocabularies(): void {
     super._addVocabularies()
     draft7Vocabularies.forEach((v) => this.addVocabulary(v))

--- a/lib/jtd.ts
+++ b/lib/jtd.ts
@@ -35,7 +35,7 @@ type JTDOptions = CurrentOptions & {
   multipleOfPrecision?: never
 }
 
-class Ajv extends AjvCore {
+export class Ajv extends AjvCore {
   constructor(opts: JTDOptions = {}) {
     super({
       ...opts,

--- a/lib/standalone/index.ts
+++ b/lib/standalone/index.ts
@@ -4,7 +4,7 @@ import type {SchemaEnv} from "../compile"
 import {UsedScopeValues, UsedValueState, ValueScopeName, varKinds} from "../compile/codegen/scope"
 import {_, nil, _Code, Code, getProperty, getEsmExportName} from "../compile/codegen/code"
 
-function standaloneCode(
+export function standaloneCode(
   ajv: AjvCore,
   refsOrFunc?: {[K in string]?: string} | AnyValidateFunction
 ): string {


### PR DESCRIPTION
**What issue does this pull request resolve?**

Fixes #2132 

**What changes did you make?**

- https://github.com/ajv-validator/ajv/commit/88bae6ee26f2205e76ba4708e58c92400ed42468: Created additional named exports to the default exported `Ajv`, `Ajv2019`, `Ajv2020` and `standaloneCode`.
- https://github.com/ajv-validator/ajv/commit/fb6f379d5f425e5f8fcc021a4a6f82ab22053e23: Updated the documentation to use the named exports consistently.

**Is there anything that requires more attention while reviewing?**

The existing default exports are untouched, so backwards compatibility is guaranteed.