### PR TITLE
fix: Update parseJson() for v8 11.7.72 and newer

### DIFF
--- a/lib/runtime/parseJson.ts
+++ b/lib/runtime/parseJson.ts
@@ -1,4 +1,4 @@
-const rxParseJson = /position\s(\d+)$/
+const rxParseJson = /position\s(\d+)(?: \(line \d+ column \d+\))?$/
 
 export function parseJson(s: string, pos: number): unknown {
   let endPos: number | undefined


### PR DESCRIPTION
**What issue does this pull request resolve?**
Fixes #2355

**What changes did you make?**
Update regex to extract end position from error in `parseJson()` - the updated regex works both for the previous and the new v8 error messages

**Is there anything that requires more attention while reviewing?**
https://chromium-review.googlesource.com/c/v8/v8/+/3513684 also added some changes to the messages with some of the new message templates not mentioning a position at all. I'm not sure if this would affect ajv, but since `npm test` completes successfully with my patch I assume it does not.