### PR TITLE
build(deps): update Node.js versions for CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x]
+        node-version: [18.x, 20.x, 21.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
**What issue does this pull request resolve?**
Fixes #2330

re2 no longer works for NodeJS v14 and thus the CI fails for all new PRs

NodeJS v16 has also dropped out of support

Please note that NodeJS v21 will only work after #2356 has been merged (and the CI in #2356 will fail for NodeJS v14 without this PR). So either merge both regardless of CI or we have to make a commit without v21 first, then merge #2356, then add another PR for v21.