### PR TITLE
Add named exports for main classes to improve types for NodeNext

### DIFF
--- a/lib/2019.ts
+++ b/lib/2019.ts
@@ -10,7 +10,7 @@ import addMetaSchema2019 from "./refs/json-schema-2019-09"
 
 const META_SCHEMA_ID = "https://json-schema.org/draft/2019-09/schema"
 
-class Ajv2019 extends AjvCore {
+export class Ajv2019 extends AjvCore {
   constructor(opts: Options = {}) {
     super({
       ...opts,
@@ -44,6 +44,7 @@ class Ajv2019 extends AjvCore {
 }
 
 module.exports = exports = Ajv2019
+module.exports.Ajv2019 = Ajv2019
 Object.defineProperty(exports, "__esModule", {value: true})
 
 export default Ajv2019

--- a/lib/2020.ts
+++ b/lib/2020.ts
@@ -7,7 +7,7 @@ import addMetaSchema2020 from "./refs/json-schema-2020-12"
 
 const META_SCHEMA_ID = "https://json-schema.org/draft/2020-12/schema"
 
-class Ajv2020 extends AjvCore {
+export class Ajv2020 extends AjvCore {
   constructor(opts: Options = {}) {
     super({
       ...opts,
@@ -38,6 +38,7 @@ class Ajv2020 extends AjvCore {
 }
 
 module.exports = exports = Ajv2020
+module.exports.Ajv2020 = Ajv2020
 Object.defineProperty(exports, "__esModule", {value: true})
 
 export default Ajv2020

--- a/lib/ajv.ts
+++ b/lib/ajv.ts
@@ -8,7 +8,7 @@ const META_SUPPORT_DATA = ["/properties"]
 
 const META_SCHEMA_ID = "http://json-schema.org/draft-07/schema"
 
-class Ajv extends AjvCore {
+export class Ajv extends AjvCore {
   _addVocabularies(): void {
     super._addVocabularies()
     draft7Vocabularies.forEach((v) => this.addVocabulary(v))
@@ -32,6 +32,7 @@ class Ajv extends AjvCore {
 }
 
 module.exports = exports = Ajv
+module.exports.Ajv = Ajv
 Object.defineProperty(exports, "__esModule", {value: true})
 
 export default Ajv

--- a/lib/jtd.ts
+++ b/lib/jtd.ts
@@ -35,7 +35,7 @@ type JTDOptions = CurrentOptions & {
   multipleOfPrecision?: never
 }
 
-class Ajv extends AjvCore {
+export class Ajv extends AjvCore {
   constructor(opts: JTDOptions = {}) {
     super({
       ...opts,
@@ -93,6 +93,7 @@ class Ajv extends AjvCore {
 }
 
 module.exports = exports = Ajv
+module.exports.Ajv = Ajv
 Object.defineProperty(exports, "__esModule", {value: true})
 
 export default Ajv


### PR DESCRIPTION
**What issue does this pull request resolve?**

Users of TypeScript + ESM + NodeNext have difficulty using the default exported classes, which is the only way to consume them (#2132).

**What changes did you make?**

This additionally adds a named export, which side-steps this issues around default imports in that environment. This is a very lightweight alternative to #2365 to improve things for these users, even if it won't make this package pass [attw](https://arethetypeswrong.github.io/).

**Is there anything that requires more attention while reviewing?**

I don't think so.