### PR TITLE
chore: bump ajv-formats to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@types/require-from-string": "^1.2.3",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
-    "ajv-formats": "^3.0.0-rc.0",
+    "ajv-formats": "^3.0.0",
     "browserify": "^17.0.0",
     "chai": "^4.4.1",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@types/require-from-string": "^1.2.3",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
-    "ajv-formats": "^3.0.0",
+    "ajv-formats": "^3.0.1",
     "browserify": "^17.0.0",
     "chai": "^4.4.1",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
**What issue does this pull request resolve?**
Stop using rc version now that ajv-formats 3.0.0 has been released.

**What changes did you make?**
Bumps ajv-formats to 3.0.1

**Is there anything that requires more attention while reviewing?**
No
