### PR TITLE
chore: update typescript to 5.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-node": "^10.9.2",
     "tsify": "^5.0.4",
-    "typescript": "^4.9.5"
+    "typescript": "5.3.3"
   },
   "collective": {
     "type": "opencollective",

--- a/spec/types/async-validate.spec.ts
+++ b/spec/types/async-validate.spec.ts
@@ -110,7 +110,7 @@ describe("$async validation and type guards", () => {
       let result: boolean | Promise<Foo>
       if ((result = validate(data))) {
         if (typeof result == "boolean") {
-          data.foo.should.equal(1)
+          ;(data as any).foo.should.equal(1)
         } else {
           await result.then((_data) => _data.foo.should.equal(1))
         }

--- a/spec/types/async-validate.spec.ts
+++ b/spec/types/async-validate.spec.ts
@@ -109,10 +109,10 @@ describe("$async validation and type guards", () => {
       const data: unknown = {foo: 1}
       let result: boolean | Promise<Foo>
       if ((result = validate(data))) {
-        if (typeof result == "boolean") {
-          ;(data as any).foo.should.equal(1)
-        } else {
+        if (result instanceof Promise) {
           await result.then((_data) => _data.foo.should.equal(1))
+        } else {
+          should.fail()
         }
       } else {
         should.fail()


### PR DESCRIPTION
**What issue does this pull request resolve?**

- Updates TypeScript to 5.3.3

**What changes did you make?**

- Set a specific version of 5.3.3 and had to cast one test data to any

**Is there anything that requires more attention while reviewing?**

- The cast to any needs attention, but even when I revert to master, my VSCode IDE shows that type as unknown anyway. Not sure why it only starts to cause the tests to fail in updated versions of TS, but it's type hasn't changed so the cast seems safe.
- This is the last version that doesn't have trouble with the Nullable type.