### PR TITLE
Replace `uri-js` with `fast-uri`

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -344,7 +344,7 @@ Include human-readable messages in errors. `true` by default. `false` can be pas
 
 ### uriResolver
 
-By default `uriResolver` is undefined and relies on the embedded uriResolver [uri-js](https://github.com/garycourt/uri-js). Pass an object that satisfies the interface [UriResolver](https://github.com/ajv-validator/ajv/blob/master/lib/types/index.ts) to be used in replacement. One alternative is [fast-uri](https://github.com/fastify/fast-uri).
+By default `uriResolver` is undefined and relies on the embedded uriResolver [fast-uri](https://github.com/fastify/fast-uri). Pass an object that satisfies the interface [UriResolver](https://github.com/ajv-validator/ajv/blob/master/lib/types/index.ts) to be used in replacement. One alternative is [uri-js](https://github.com/garycourt/uri-js).
 
 ### code <Badge text="v7" />
 

--- a/lib/compile/index.ts
+++ b/lib/compile/index.ts
@@ -14,7 +14,7 @@ import N from "./names"
 import {LocalRefs, getFullPath, _getFullPath, inlineRef, normalizeId, resolveUrl} from "./resolve"
 import {schemaHasRulesButRef, unescapeFragment} from "./util"
 import {validateFunctionCode} from "./validate"
-import * as URI from "uri-js"
+import * as URI from "fast-uri"
 import {JSONType} from "./rules"
 
 export type SchemaRefs = {

--- a/lib/compile/resolve.ts
+++ b/lib/compile/resolve.ts
@@ -1,6 +1,6 @@
 import type {AnySchema, AnySchemaObject, UriResolver} from "../types"
 import type Ajv from "../ajv"
-import type {URIComponents} from "uri-js"
+import type {URIComponents} from "fast-uri"
 import {eachItem} from "./util"
 import * as equal from "fast-deep-equal"
 import * as traverse from "json-schema-traverse"

--- a/lib/runtime/uri.ts
+++ b/lib/runtime/uri.ts
@@ -1,4 +1,4 @@
-import * as uri from "uri-js"
+import * as uri from "fast-uri"
 
 type URI = typeof uri & {code: string}
 ;(uri as URI).code = 'require("ajv/dist/runtime/uri").default'

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,4 +1,4 @@
-import * as URI from "uri-js"
+import * as URI from "fast-uri"
 import type {CodeGen, Code, Name, ScopeValueSets, ValueScopeName} from "../compile/codegen"
 import type {SchemaEnv, SchemaCxt, SchemaObjCxt} from "../compile"
 import type {JSONType} from "../compile/rules"

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   "runkitExampleFilename": ".runkit_example.js",
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
+    "fast-uri": "^2.3.0",
     "json-schema-traverse": "^1.0.0",
-    "require-from-string": "^2.0.2",
-    "uri-js": "^4.4.1"
+    "require-from-string": "^2.0.2"
   },
   "devDependencies": {
     "@ajv-validator/config": "^0.5.0",
@@ -83,7 +83,6 @@
     "dayjs-plugin-utc": "^0.1.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
-    "fast-uri": "^2.3.0",
     "glob": "^10.3.10",
     "husky": "^9.0.11",
     "if-node-version": "^1.1.1",
@@ -104,7 +103,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-node": "^10.9.2",
     "tsify": "^5.0.4",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "uri-js": "^4.4.1"
   },
   "collective": {
     "type": "opencollective",

--- a/spec/resolve.spec.ts
+++ b/spec/resolve.spec.ts
@@ -4,7 +4,7 @@ import _Ajv from "./ajv"
 import type {AnyValidateFunction} from "../dist/types"
 import type MissingRefError from "../dist/compile/ref_error"
 import chai from "./chai"
-import * as uriJs from "fast-uri"
+import * as uriJs from "uri-js"
 const should = chai.should()
 
 const uriResolvers = [undefined, uriJs]
@@ -12,7 +12,7 @@ const uriResolvers = [undefined, uriJs]
 uriResolvers.forEach((resolver) => {
   let describeTitle: string
   if (resolver !== undefined) {
-    describeTitle = "fast-uri resolver"
+    describeTitle = "uri-js resolver"
   } else {
     describeTitle = "fast-uri resolver"
   }

--- a/spec/resolve.spec.ts
+++ b/spec/resolve.spec.ts
@@ -4,17 +4,17 @@ import _Ajv from "./ajv"
 import type {AnyValidateFunction} from "../dist/types"
 import type MissingRefError from "../dist/compile/ref_error"
 import chai from "./chai"
-import * as fastUri from "fast-uri"
+import * as uriJs from "fast-uri"
 const should = chai.should()
 
-const uriResolvers = [undefined, fastUri]
+const uriResolvers = [undefined, uriJs]
 
 uriResolvers.forEach((resolver) => {
   let describeTitle: string
   if (resolver !== undefined) {
     describeTitle = "fast-uri resolver"
   } else {
-    describeTitle = "uri-js resolver"
+    describeTitle = "fast-uri resolver"
   }
   describe(describeTitle, () => {
     describe("resolve", () => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

This PR fixes issues #2350 and #2343. It removes the (deep) dependency on `punycode`, a deprecated module.

**What changes did you make?**

I replaced the default uriResolver to [fast-uri](https://github.com/fastify/fast-uri) instead of [uri-js](https://github.com/garycourt/uri-js).

**Is there anything that requires more attention while reviewing?**

This PR supersedes #2377.

It is also worth considering using the web API `URL` which is defined in [URL Living Standard](https://url.spec.whatwg.org/) instead of `URI` which is defined in [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and is less prevalent and can resolve the issue raised by @jasoniangreen in the above linked PR:

> ...I have been speaking to @epoberezkin and he wants me to explore removing uri-js. [..] there is just an open question around browser support. I will update you when I have more.

We can use the native `URL` API as it is supported with node 10+ and all major browsers and it has [97.68% caniuse score](https://caniuse.com/url) while `URI` is not standardized afaict.

Thanks!

TODO:

- [ ] rebase
- [ ] fix [spec/resolve.spec.ts](https://github.com/ajv-validator/ajv/pull/2415/files#diff-8eaec48b707b9d12a6c79d05a2bc004c400d48d307c05f3bc86b752f9848a37c)