### PR TITLE
docs: add warning to maxLength / minLength

### DIFF
--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -280,6 +280,10 @@ The value of the keyword should be a number. The data to be valid should be a mu
 
 ### `maxLength` / `minLength`
 
+::: warning [Grapheme clusters](https://www.unicode.org/reports/tr29/tr29-17.html#Grapheme_Cluster_Boundaries) will count as multiple characters
+Certain charsets have characters that are made up of multiple unicode characters. These "grapheme clusters" are counted as multiple characters.
+:::
+
 The value of the keywords should be a number. The data to be valid should have length satisfying this rule. Unicode pairs are counted as a single character.
 
 **Examples**


### PR DESCRIPTION
**What issue does this pull request resolve?**

Adds warning about grapheme clusters to maxLength / minLength docs.

**What changes did you make?**

Only docs

**Is there anything that requires more attention while reviewing?**

Just the precise wording.
