### PR TITLE
fix #2427 compileAsync a schema with discriminator and $ref

### DIFF
--- a/spec/discriminator.spec.ts
+++ b/spec/discriminator.spec.ts
@@ -192,10 +192,10 @@ describe("discriminator keyword", function () {
     const badData = {foo: "w"}
 
     it("compile should resolve each $ref to a schema that was added with addSchema", () => {
-      const options = {
+      const opts = {
         discriminator: true,
       }
-      const ajv = new _Ajv(options)
+      const ajv = new _Ajv(opts)
       ajv.addSchema(schemas.main, "https://host/main")
       ajv.addSchema(schemas.schema1, "https://host/schema1")
       ajv.addSchema(schemas.schema2, "https://host/schema2")
@@ -205,15 +205,15 @@ describe("discriminator keyword", function () {
       assert.strictEqual(validate(badData), false)
     })
     it("compileAsync should loadSchema each $ref", async () => {
-      const options = {
+      const opts = {
         discriminator: true,
-        async loadSchema(url) {
+        loadSchema(url) {
           if (!url.startsWith("https://host/")) return undefined
           const name = url.substring("https://host/".length)
           return schemas[name]
         },
       }
-      const ajv = new _Ajv(options)
+      const ajv = new _Ajv(opts)
       const validate = await ajv.compileAsync({$ref: "https://host/main"})
       assert.strictEqual(validate(data), true)
       assert.strictEqual(validate(badData), false)

--- a/spec/discriminator.spec.ts
+++ b/spec/discriminator.spec.ts
@@ -159,6 +159,67 @@ describe("discriminator keyword", function () {
     })
   })
 
+  describe("schema with external $refs", () => {
+    const schemas = {
+      main: {
+        type: "object",
+        discriminator: {propertyName: "foo"},
+        required: ["foo"],
+        oneOf: [
+          {
+            $ref: "schema1",
+          },
+          {
+            $ref: "schema2",
+          },
+        ],
+      },
+      schema1: {
+        type: "object",
+        properties: {
+          foo: {const: "x"},
+        },
+      },
+      schema2: {
+        type: "object",
+        properties: {
+          foo: {enum: ["y", "z"]},
+        },
+      },
+    }
+
+    const data = {foo: "x"}
+    const badData = {foo: "w"}
+
+    it("compile should resolve each $ref to a schema that was added with addSchema", () => {
+      const options = {
+        discriminator: true,
+      }
+      const ajv = new _Ajv(options)
+      ajv.addSchema(schemas.main, "https://host/main")
+      ajv.addSchema(schemas.schema1, "https://host/schema1")
+      ajv.addSchema(schemas.schema2, "https://host/schema2")
+
+      const validate = ajv.compile({$ref: "https://host/main"})
+      assert.strictEqual(validate(data), true)
+      assert.strictEqual(validate(badData), false)
+    })
+    it("compileAsync should loadSchema each $ref", async () => {
+      const options = {
+        discriminator: true,
+        async loadSchema(url) {
+          if (!url.startsWith("https://host/")) return undefined
+          const name = url.substring("https://host/".length)
+          return schemas[name]
+        },
+      }
+      const ajv = new _Ajv(options)
+      const validate = await ajv.compileAsync({$ref: "https://host/main"})
+      assert.strictEqual(validate(data), true)
+      assert.strictEqual(validate(badData), false)
+    })
+  })
+
   describe("validation with deeply referenced schemas", () => {
     const schema = [
       {


### PR DESCRIPTION
Make the discriminator code generation throw MissingRefError when the $ref does not synchronously resolve so that compileAsync can loadSchema and retry.

<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
#2427 

**What changes did you make?**
Make the discriminator code generation throw MissingRefError when the $ref does not synchronously resolve so that compileAsync can loadSchema and retry.


**Is there anything that requires more attention while reviewing?**
The existing tests create separate test `Ajv` instances by calling `withStandalone(getAjvInstances(AjvClass, …))` (https://github.com/ajv-validator/ajv/blob/v8.13.0/spec/discriminator.spec.ts#L22). I could not directly reuse those `Ajv` instances because I need to add the `loadSchema` option and I can’t call compileAsync on an `Ajv` after `withStandalone`. For now I only called `new _Ajv`. To what extent should I try creating separate ajv, ajv2019, standalone instances in the test?