### PR TITLE
fix: broken link in docs warning

### DIFF
--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -280,8 +280,8 @@ The value of the keyword should be a number. The data to be valid should be a mu
 
 ### `maxLength` / `minLength`
 
-::: warning [Grapheme clusters](https://www.unicode.org/reports/tr29/tr29-17.html#Grapheme_Cluster_Boundaries) will count as multiple characters
-Certain charsets have characters that are made up of multiple unicode characters. These "grapheme clusters" are counted as multiple characters.
+::: warning Grapheme clusters will count as multiple characters
+Certain charsets have characters that are made up of multiple Unicode code points. These [grapheme clusters](https://www.unicode.org/reports/tr29/tr29-17.html#Grapheme_Cluster_Boundaries) are counted as multiple in length calculations.
 :::
 
 The value of the keywords should be a number. The data to be valid should have length satisfying this rule. Unicode pairs are counted as a single character.


### PR DESCRIPTION
**Screenshot**
<img width="767" alt="Screenshot 2024-05-11 at 11 11 57" src="https://github.com/ajv-validator/ajv/assets/3481367/3beab565-f2e7-4c2c-87e5-9dbc85e9dc23">
