### PR TITLE
docs: refactor to improve legibility

### DIFF
--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -478,11 +478,11 @@ To create and equivalent schema in draft-2020-12 use keywords [prefixItems](#pre
 
 The value of the keyword should be a boolean or an object.
 
-If `items` keyword is not present or it is an object, `additionalItems` keyword should be ignored regardless of its value. By default Ajv will throw exception in this case - see [Strict mode](./strict-mode.md)
+`additionalItems` keyword is ignored if `items` keyword is not present or is an object. By default Ajv will throw exception in this case - see [Strict mode](./strict-mode.md)
 
-If `items` keyword is an array and data array has not more items than the length of `items` keyword value, `additionalItems` keyword is also ignored.
+`additionalItems` keyword is ignored if `items` keyword has more elements than data array.
 
-If the length of data array is bigger than the length of "items" keyword value than the result of the validation depends on the value of `additionalItems` keyword:
+If the data array has more elements than the `items` keyword value then the result of the validation depends on the value of `additionalItems` keyword:
 
 - `false`: data is invalid
 - `true`: data is valid


### PR DESCRIPTION
The use of "not more" with the reverse ordering of the sentence made this difficult to parse. After reversing the order and removing negation, the surrounding paragraphs were updated to match the style.


**What issue does this pull request resolve?**
None

**What changes did you make?**
Restructured some paragraphs in the docs

**Is there anything that requires more attention while reviewing?**
Please validate that this new reordering aligns with the functionality as I have only just begun using this tool.