### PR TITLE
Revert fast-uri change

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -344,7 +344,7 @@ Include human-readable messages in errors. `true` by default. `false` can be pas
 
 ### uriResolver
 
-By default `uriResolver` is undefined and relies on the embedded uriResolver [fast-uri](https://github.com/fastify/fast-uri). Pass an object that satisfies the interface [UriResolver](https://github.com/ajv-validator/ajv/blob/master/lib/types/index.ts) to be used in replacement. One alternative is [uri-js](https://github.com/garycourt/uri-js).
+By default `uriResolver` is undefined and relies on the embedded uriResolver [uri-js](https://github.com/garycourt/uri-js). Pass an object that satisfies the interface [UriResolver](https://github.com/ajv-validator/ajv/blob/master/lib/types/index.ts) to be used in replacement. One alternative is [fast-uri](https://github.com/fastify/fast-uri).
 
 ### code <Badge text="v7" />
 

--- a/lib/compile/index.ts
+++ b/lib/compile/index.ts
@@ -14,7 +14,7 @@ import N from "./names"
 import {LocalRefs, getFullPath, _getFullPath, inlineRef, normalizeId, resolveUrl} from "./resolve"
 import {schemaHasRulesButRef, unescapeFragment} from "./util"
 import {validateFunctionCode} from "./validate"
-import * as URI from "fast-uri"
+import * as URI from "uri-js"
 import {JSONType} from "./rules"
 
 export type SchemaRefs = {

--- a/lib/compile/resolve.ts
+++ b/lib/compile/resolve.ts
@@ -1,6 +1,6 @@
 import type {AnySchema, AnySchemaObject, UriResolver} from "../types"
 import type Ajv from "../ajv"
-import type {URIComponents} from "fast-uri"
+import type {URIComponents} from "uri-js"
 import {eachItem} from "./util"
 import * as equal from "fast-deep-equal"
 import * as traverse from "json-schema-traverse"

--- a/lib/runtime/uri.ts
+++ b/lib/runtime/uri.ts
@@ -1,4 +1,4 @@
-import * as uri from "fast-uri"
+import * as uri from "uri-js"
 
 type URI = typeof uri & {code: string}
 ;(uri as URI).code = 'require("ajv/dist/runtime/uri").default'

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,4 +1,4 @@
-import * as URI from "fast-uri"
+import * as URI from "uri-js"
 import type {CodeGen, Code, Name, ScopeValueSets, ValueScopeName} from "../compile/codegen"
 import type {SchemaEnv, SchemaCxt, SchemaObjCxt} from "../compile"
 import type {JSONType} from "../compile/rules"

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   "runkitExampleFilename": ".runkit_example.js",
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
-    "fast-uri": "^2.3.0",
     "json-schema-traverse": "^1.0.0",
-    "require-from-string": "^2.0.2"
+    "require-from-string": "^2.0.2",
+    "uri-js": "^4.4.1"
   },
   "devDependencies": {
     "@ajv-validator/config": "^0.5.0",
@@ -83,6 +83,7 @@
     "dayjs-plugin-utc": "^0.1.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
+    "fast-uri": "^2.3.0",
     "glob": "^10.3.10",
     "husky": "^9.0.11",
     "if-node-version": "^1.1.1",
@@ -103,7 +104,6 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-node": "^10.9.2",
     "tsify": "^5.0.4",
-    "uri-js": "^4.4.1",
     "typescript": "5.3.3"
   },
   "collective": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ajv",
-  "version": "8.15.0",
+  "version": "8.16.0",
   "description": "Another JSON Schema Validator",
   "main": "dist/ajv.js",
   "types": "dist/ajv.d.ts",

--- a/spec/resolve.spec.ts
+++ b/spec/resolve.spec.ts
@@ -4,17 +4,17 @@ import _Ajv from "./ajv"
 import type {AnyValidateFunction} from "../dist/types"
 import type MissingRefError from "../dist/compile/ref_error"
 import chai from "./chai"
-import * as uriJs from "uri-js"
+import * as fastUri from "fast-uri"
 const should = chai.should()
 
-const uriResolvers = [undefined, uriJs]
+const uriResolvers = [undefined, fastUri]
 
 uriResolvers.forEach((resolver) => {
   let describeTitle: string
   if (resolver !== undefined) {
-    describeTitle = "uri-js resolver"
-  } else {
     describeTitle = "fast-uri resolver"
+  } else {
+    describeTitle = "uri-js resolver"
   }
   describe(describeTitle, () => {
     describe("resolve", () => {


### PR DESCRIPTION
**What issue does this pull request resolve?**

Fast URI breaks browser builds

**What changes did you make?**

Revert the change to switch uri-js with fast-js. Also bumped the version to 8.16.0.

**Is there anything that requires more attention while reviewing?**

No
