### PR TITLE
Revert "Revert fast-uri change (#2444)"

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -344,7 +344,7 @@ Include human-readable messages in errors. `true` by default. `false` can be pas
 
 ### uriResolver
 
-By default `uriResolver` is undefined and relies on the embedded uriResolver [uri-js](https://github.com/garycourt/uri-js). Pass an object that satisfies the interface [UriResolver](https://github.com/ajv-validator/ajv/blob/master/lib/types/index.ts) to be used in replacement. One alternative is [fast-uri](https://github.com/fastify/fast-uri).
+By default `uriResolver` is undefined and relies on the embedded uriResolver [fast-uri](https://github.com/fastify/fast-uri). Pass an object that satisfies the interface [UriResolver](https://github.com/ajv-validator/ajv/blob/master/lib/types/index.ts) to be used in replacement. One alternative is [uri-js](https://github.com/garycourt/uri-js).
 
 ### code <Badge text="v7" />
 

--- a/lib/compile/index.ts
+++ b/lib/compile/index.ts
@@ -14,7 +14,7 @@ import N from "./names"
 import {LocalRefs, getFullPath, _getFullPath, inlineRef, normalizeId, resolveUrl} from "./resolve"
 import {schemaHasRulesButRef, unescapeFragment} from "./util"
 import {validateFunctionCode} from "./validate"
-import * as URI from "uri-js"
+import {URIComponent} from "fast-uri"
 import {JSONType} from "./rules"
 
 export type SchemaRefs = {
@@ -295,7 +295,7 @@ const PREVENT_SCOPE_CHANGE = new Set([
 
 function getJsonPointer(
   this: Ajv,
-  parsedRef: URI.URIComponents,
+  parsedRef: URIComponent,
   {baseId, schema, root}: SchemaEnv
 ): SchemaEnv | undefined {
   if (parsedRef.fragment?.[0] !== "/") return

--- a/lib/compile/resolve.ts
+++ b/lib/compile/resolve.ts
@@ -1,6 +1,6 @@
 import type {AnySchema, AnySchemaObject, UriResolver} from "../types"
 import type Ajv from "../ajv"
-import type {URIComponents} from "uri-js"
+import type {URIComponent} from "fast-uri"
 import {eachItem} from "./util"
 import * as equal from "fast-deep-equal"
 import * as traverse from "json-schema-traverse"
@@ -73,7 +73,7 @@ export function getFullPath(resolver: UriResolver, id = "", normalize?: boolean)
   return _getFullPath(resolver, p)
 }
 
-export function _getFullPath(resolver: UriResolver, p: URIComponents): string {
+export function _getFullPath(resolver: UriResolver, p: URIComponent): string {
   const serialized = resolver.serialize(p)
   return serialized.split("#")[0] + "#"
 }

--- a/lib/runtime/uri.ts
+++ b/lib/runtime/uri.ts
@@ -1,4 +1,4 @@
-import * as uri from "uri-js"
+import * as uri from "fast-uri"
 
 type URI = typeof uri & {code: string}
 ;(uri as URI).code = 'require("ajv/dist/runtime/uri").default'

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,4 +1,4 @@
-import * as URI from "uri-js"
+import {URIComponent} from "fast-uri"
 import type {CodeGen, Code, Name, ScopeValueSets, ValueScopeName} from "../compile/codegen"
 import type {SchemaEnv, SchemaCxt, SchemaObjCxt} from "../compile"
 import type {JSONType} from "../compile/rules"
@@ -238,7 +238,7 @@ export interface RegExpLike {
 }
 
 export interface UriResolver {
-  parse(uri: string): URI.URIComponents
+  parse(uri: string): URIComponent
   resolve(base: string, path: string): string
-  serialize(component: URI.URIComponents): string
+  serialize(component: URIComponent): string
 }

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   "runkitExampleFilename": ".runkit_example.js",
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
+    "fast-uri": "^2.3.1",
     "json-schema-traverse": "^1.0.0",
-    "require-from-string": "^2.0.2",
-    "uri-js": "^4.4.1"
+    "require-from-string": "^2.0.2"
   },
   "devDependencies": {
     "@ajv-validator/config": "^0.5.0",
@@ -83,7 +83,6 @@
     "dayjs-plugin-utc": "^0.1.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
-    "fast-uri": "^2.3.0",
     "glob": "^10.3.10",
     "husky": "^9.0.11",
     "if-node-version": "^1.1.1",
@@ -104,7 +103,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-node": "^10.9.2",
     "tsify": "^5.0.4",
-    "typescript": "5.3.3"
+    "typescript": "5.3.3",
+    "uri-js": "^4.4.1"
   },
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "runkitExampleFilename": ".runkit_example.js",
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
-    "fast-uri": "^2.3.1",
+    "fast-uri": "^2.4.0",
     "json-schema-traverse": "^1.0.0",
     "require-from-string": "^2.0.2"
   },

--- a/spec/resolve.spec.ts
+++ b/spec/resolve.spec.ts
@@ -4,17 +4,17 @@ import _Ajv from "./ajv"
 import type {AnyValidateFunction} from "../dist/types"
 import type MissingRefError from "../dist/compile/ref_error"
 import chai from "./chai"
-import * as fastUri from "fast-uri"
+import * as uriJs from "uri-js"
 const should = chai.should()
 
-const uriResolvers = [undefined, fastUri]
+const uriResolvers = [undefined, uriJs]
 
 uriResolvers.forEach((resolver) => {
   let describeTitle: string
   if (resolver !== undefined) {
-    describeTitle = "fast-uri resolver"
-  } else {
     describeTitle = "uri-js resolver"
+  } else {
+    describeTitle = "fast-uri resolver"
   }
   describe(describeTitle, () => {
     describe("resolve", () => {


### PR DESCRIPTION
Hey!

So we removed the node-specific URL module and replaced it with the Web version

`fast-uri` can now be bundled for the web, as can be seen from: https://cdn.jsdelivr.net/npm/fast-uri/+esm

Not sure how I can test if AJV will bundle as well

https://github.com/ajv-validator/ajv/issues/2447 is fixed as well - https://github.com/fastify/fast-uri/pull/84