### PR TITLE
docs: clarify behaviour of addVocabulary

### DIFF
--- a/docs/strict-mode.md
+++ b/docs/strict-mode.md
@@ -42,10 +42,10 @@ By default Ajv fails schema compilation when unknown keywords are used. Users ca
 ajv.addKeyword("allowedKeyword")
 ```
 
-or
+or use the convenience method `addVocabulary` for multiple keywords
 
 ```javascript
-ajv.addVocabulary(["allowed1", "allowed2"])
+ajv.addVocabulary(["allowed1", "allowed2"]) // simply calls addKeyword multiple times
 ```
 
 #### Ignored "additionalItems" keyword


### PR DESCRIPTION
As it's name is so different and not just `addKeywords`, there has been some confusion as to it's behaviour.

Fixes #2386
