### PR TITLE
fix: ignore new eslint error for @typescript-eslint/no-extraneous-class

### DIFF
--- a/lib/compile/codegen/code.ts
+++ b/lib/compile/codegen/code.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export abstract class _CodeOrName {
   abstract readonly str: string
   abstract readonly names: UsedNames


### PR DESCRIPTION
**What issue does this pull request resolve?**

Since we don't use lock files small changes to default eslint rules can break our build from time to time. This time it is `@typescript-eslint/no-extraneous-class`.

**What changes did you make?**

This new error wasn't appearing before but since there is only once instance I think it's fine to ignore this one line and accept this new default for any new code.

**Is there anything that requires more attention while reviewing?**

No.