### PR TITLE
Fix fast-uri incompatibility with uri-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "runkitExampleFilename": ".runkit_example.js",
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
-    "fast-uri": "^2.4.0",
+    "fast-uri": "^3.0.1",
     "json-schema-traverse": "^1.0.0",
     "require-from-string": "^2.0.2"
   },


### PR DESCRIPTION
With https://github.com/fastify/fast-uri/pull/93 and v3.0.1, we've hopefully remedied the different handling of URI fragments in fast-uri, [the test that was linked](https://github.com/fastify/fast-uri/issues/85#issue-2352152308) [now passes](https://github.com/gurgunday/fast-uri/blob/63509a8303adda41fa69a563e428d68bd66e65c8/test/ajv.test.js)

I think it's good to go

Cc @jasoniangreen