### PR TITLE
perf: replace fast-deep-equal with dequal

### DIFF
--- a/lib/compile/resolve.ts
+++ b/lib/compile/resolve.ts
@@ -2,7 +2,7 @@ import type {AnySchema, AnySchemaObject, UriResolver} from "../types"
 import type Ajv from "../ajv"
 import type {URIComponent} from "fast-uri"
 import {eachItem} from "./util"
-import { dequal as equal } from "dequal"
+import {dequal as equal} from "dequal"
 import * as traverse from "json-schema-traverse"
 
 // the hash of local references inside the schema (created by getSchemaRefs), used for inline resolution

--- a/lib/compile/resolve.ts
+++ b/lib/compile/resolve.ts
@@ -2,7 +2,7 @@ import type {AnySchema, AnySchemaObject, UriResolver} from "../types"
 import type Ajv from "../ajv"
 import type {URIComponent} from "fast-uri"
 import {eachItem} from "./util"
-import * as equal from "fast-deep-equal"
+import { dequal as equal } from "dequal"
 import * as traverse from "json-schema-traverse"
 
 // the hash of local references inside the schema (created by getSchemaRefs), used for inline resolution

--- a/lib/runtime/equal.ts
+++ b/lib/runtime/equal.ts
@@ -1,5 +1,5 @@
 // https://github.com/ajv-validator/ajv/issues/889
-import * as equal from "fast-deep-equal"
+import { dequal as equal } from "dequal"
 
 type Equal = typeof equal & {code: string}
 ;(equal as Equal).code = 'require("ajv/dist/runtime/equal").default'

--- a/lib/runtime/equal.ts
+++ b/lib/runtime/equal.ts
@@ -1,5 +1,5 @@
 // https://github.com/ajv-validator/ajv/issues/889
-import { dequal as equal } from "dequal"
+import {dequal as equal} from "dequal"
 
 type Equal = typeof equal & {code: string}
 ;(equal as Equal).code = 'require("ajv/dist/runtime/equal").default'

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "runkitExampleFilename": ".runkit_example.js",
   "dependencies": {
     "dequal": "^2.0.3",
-    "fast-uri": "^2.4.0",
+    "fast-uri": "^3.0.1",
     "json-schema-traverse": "^1.0.0",
     "require-from-string": "^2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "homepage": "https://ajv.js.org",
   "runkitExampleFilename": ".runkit_example.js",
   "dependencies": {
-    "fast-deep-equal": "^3.1.3",
+    "dequal": "^2.0.3",
     "fast-uri": "^2.4.0",
     "json-schema-traverse": "^1.0.0",
     "require-from-string": "^2.0.2"


### PR DESCRIPTION
lukeed's `dequal` is amazing, both smaller and [faster](https://github.com/lukeed/dequal?tab=readme-ov-file#benchmarks) than `fast-deep-equal` while being compatible

closes #2466