### PR TITLE
perf: stop `.split` early at `getFullPath`

### DIFF
--- a/lib/compile/resolve.ts
+++ b/lib/compile/resolve.ts
@@ -75,7 +75,7 @@ export function getFullPath(resolver: UriResolver, id = "", normalize?: boolean)
 
 export function _getFullPath(resolver: UriResolver, p: URIComponent): string {
   const serialized = resolver.serialize(p)
-  return serialized.split("#")[0] + "#"
+  return serialized.split("#", 1)[0] + "#"
 }
 
 const TRAILING_SLASH_HASH = /#\/?$/


### PR DESCRIPTION
`String.prototype.split()` supports a [second parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split#limit) that stops the search as soon as the number of elements in the resulting list are hit

In this case, we are always getting the first element after splitting with `#`, therefore it doesn't make sense to continue searching the string for more separators and end up with a larger-than-necessary array