### PR TITLE
feat: allow tree-shaking by adding `"sideEffects": false` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dist/",
     ".runkit_example.js"
   ],
+  "sideEffects": false,
   "scripts": {
     "eslint": "eslint \"lib/**/*.ts\" \"spec/**/*.*s\" --ignore-pattern spec/JSON-Schema-Test-Suite",
     "prettier:write": "prettier --write \"./**/*.{json,yaml,js,ts}\"",


### PR DESCRIPTION
Fixes #2479