### PR TITLE
feat: add pattern and path to regexp create errors #2477

### DIFF
--- a/lib/vocabularies/code.ts
+++ b/lib/vocabularies/code.ts
@@ -100,7 +100,7 @@ export function usePattern({gen, it: {opts, errSchemaPath}}: KeywordCxt, pattern
   try {
     rx = new RegExp(pattern, u)
   } catch (e) {
-    throw new Error(`Invalid regular expression: ${pattern} at ${errSchemaPath}`)
+    throw new Error(`${(e as Error).message} | pattern ${pattern} at ${errSchemaPath}`)
   }
   rx = regExp(pattern, u)
 

--- a/lib/vocabularies/code.ts
+++ b/lib/vocabularies/code.ts
@@ -1,4 +1,4 @@
-import type {AnySchema, SchemaMap} from "../types"
+import type {AnySchema, RegExpLike, SchemaMap} from "../types"
 import type {SchemaCxt} from "../compile"
 import type {KeywordCxt} from "../compile/validate"
 import {CodeGen, _, and, or, not, nil, strConcat, getProperty, Code, Name} from "../compile/codegen"
@@ -92,10 +92,17 @@ export function callValidateCode(
 
 const newRegExp = _`new RegExp`
 
-export function usePattern({gen, it: {opts}}: KeywordCxt, pattern: string): Name {
+export function usePattern({gen, it: {opts, errSchemaPath}}: KeywordCxt, pattern: string): Name {
   const u = opts.unicodeRegExp ? "u" : ""
   const {regExp} = opts.code
-  const rx = regExp(pattern, u)
+
+  let rx: RegExpLike
+  try {
+    rx = new RegExp(pattern, u)
+  } catch (e) {
+    throw new Error(`Invalid regular expression: ${pattern} at ${errSchemaPath}`)
+  }
+  rx = regExp(pattern, u)
 
   return gen.scopeValue("pattern", {
     key: rx.toString(),

--- a/lib/vocabularies/code.ts
+++ b/lib/vocabularies/code.ts
@@ -98,11 +98,10 @@ export function usePattern({gen, it: {opts, errSchemaPath}}: KeywordCxt, pattern
 
   let rx: RegExpLike
   try {
-    rx = new RegExp(pattern, u)
+    rx = regExp(pattern, u)
   } catch (e) {
     throw new Error(`${(e as Error).message} | pattern ${pattern} at ${errSchemaPath}`)
   }
-  rx = regExp(pattern, u)
 
   return gen.scopeValue("pattern", {
     key: rx.toString(),

--- a/lib/vocabularies/validation/pattern.ts
+++ b/lib/vocabularies/validation/pattern.ts
@@ -24,7 +24,7 @@ const def: CodeKeywordDefinition = {
         try {
           return new RegExp(${schemaCode}, ${u})
         } catch (e) {
-          throw new Error('Invalid regular expression: ' + ${schemaCode} + ' at ' + ${it.errSchemaPath})
+          throw new Error(e.message + ' | pattern ' + ${schemaCode} + ' at ' + ${it.errSchemaPath})
         }
       })()`
       : usePattern(cxt, schema)

--- a/lib/vocabularies/validation/pattern.ts
+++ b/lib/vocabularies/validation/pattern.ts
@@ -18,9 +18,16 @@ const def: CodeKeywordDefinition = {
   error,
   code(cxt: KeywordCxt) {
     const {data, $data, schema, schemaCode, it} = cxt
-    // TODO regexp should be wrapped in try/catchs
     const u = it.opts.unicodeRegExp ? "u" : ""
-    const regExp = $data ? _`(new RegExp(${schemaCode}, ${u}))` : usePattern(cxt, schema)
+    const regExp = $data
+      ? _`(function() {
+        try {
+          return new RegExp(${schemaCode}, ${u})
+        } catch (e) {
+          throw new Error('Invalid regular expression: ' + ${schemaCode} + ' at ' + ${it.errSchemaPath})
+        }
+      })()`
+      : usePattern(cxt, schema)
     cxt.fail$data(_`!${regExp}.test(${data})`)
   },
 }

--- a/spec/issues/2477_informative_pattern_errors.spec.ts
+++ b/spec/issues/2477_informative_pattern_errors.spec.ts
@@ -1,7 +1,7 @@
 import _Ajv from "../ajv2020"
 import * as assert from "assert"
 
-describe.only("Invalid regexp patterns should throw more informative errors (issue #2477)", () => {
+describe("Invalid regexp patterns should throw more informative errors (issue #2477)", () => {
   it("throws with pattern and schema path", () => {
     const ajv = new _Ajv()
 

--- a/spec/issues/2477_informative_pattern_errors.spec.ts
+++ b/spec/issues/2477_informative_pattern_errors.spec.ts
@@ -13,7 +13,10 @@ describe("Invalid regexp patterns should throw more informative errors (issue #2
     assert.throws(
       () => ajv.compile(rootSchema),
       (thrown: unknown) => {
-        assert.equal((thrown as Error).message, "Invalid regular expression: ^[0-9]{2-4} at #")
+        assert.equal(
+          (thrown as Error).message,
+          "Invalid regular expression: /^[0-9]{2-4}/: Incomplete quantifier | pattern ^[0-9]{2-4} at #"
+        )
         return true
       }
     )
@@ -30,7 +33,7 @@ describe("Invalid regexp patterns should throw more informative errors (issue #2
       (thrown: unknown) => {
         assert.equal(
           (thrown as Error).message,
-          "Invalid regular expression: ^[0-9]{2-4} at #/properties/foo"
+          "Invalid regular expression: /^[0-9]{2-4}/: Incomplete quantifier | pattern ^[0-9]{2-4} at #/properties/foo"
         )
         return true
       }
@@ -52,7 +55,7 @@ describe("Invalid regexp patterns should throw more informative errors (issue #2
       (thrown: unknown) => {
         assert.equal(
           (thrown as Error).message,
-          "Invalid regular expression: ^[0-9]{2-4} at #/properties/string"
+          "Invalid regular expression: /^[0-9]{2-4}/: Incomplete quantifier | pattern ^[0-9]{2-4} at #/properties/string"
         )
         return true
       }

--- a/spec/issues/2477_informative_pattern_errors.spec.ts
+++ b/spec/issues/2477_informative_pattern_errors.spec.ts
@@ -1,7 +1,7 @@
 import _Ajv from "../ajv2020"
 import * as assert from "assert"
 
-describe("Invalid regexp patterns should throw more informative errors (issue #2477)", () => {
+describe.only("Invalid regexp patterns should throw more informative errors (issue #2477)", () => {
   it("throws with pattern and schema path", () => {
     const ajv = new _Ajv()
 
@@ -12,13 +12,7 @@ describe("Invalid regexp patterns should throw more informative errors (issue #2
 
     assert.throws(
       () => ajv.compile(rootSchema),
-      (thrown: unknown) => {
-        assert.equal(
-          (thrown as Error).message,
-          "Invalid regular expression: /^[0-9]{2-4}/: Incomplete quantifier | pattern ^[0-9]{2-4} at #"
-        )
-        return true
-      }
+      (thrown: Error) => thrown.message.includes("pattern ^[0-9]{2-4} at #")
     )
 
     const pathSchema = {
@@ -30,13 +24,7 @@ describe("Invalid regexp patterns should throw more informative errors (issue #2
 
     assert.throws(
       () => ajv.compile(pathSchema),
-      (thrown: unknown) => {
-        assert.equal(
-          (thrown as Error).message,
-          "Invalid regular expression: /^[0-9]{2-4}/: Incomplete quantifier | pattern ^[0-9]{2-4} at #/properties/foo"
-        )
-        return true
-      }
+      (thrown: Error) => thrown.message.includes("pattern ^[0-9]{2-4} at #/properties/foo")
     )
   })
   it("throws with pattern and schema path with $data", () => {
@@ -52,13 +40,7 @@ describe("Invalid regexp patterns should throw more informative errors (issue #2
 
     assert.throws(
       () => ajv.compile(validate({shouldMatch: "^[0-9]{2-4}", string: "123"})),
-      (thrown: unknown) => {
-        assert.equal(
-          (thrown as Error).message,
-          "Invalid regular expression: /^[0-9]{2-4}/: Incomplete quantifier | pattern ^[0-9]{2-4} at #/properties/string"
-        )
-        return true
-      }
+      (thrown: Error) => thrown.message.includes("pattern ^[0-9]{2-4} at #/properties/string")
     )
   })
 })

--- a/spec/issues/2477_informative_pattern_errors.spec.ts
+++ b/spec/issues/2477_informative_pattern_errors.spec.ts
@@ -1,0 +1,61 @@
+import _Ajv from "../ajv2020"
+import * as assert from "assert"
+
+describe("Invalid regexp patterns should throw more informative errors (issue #2477)", () => {
+  it("throws with pattern and schema path", () => {
+    const ajv = new _Ajv()
+
+    const rootSchema = {
+      type: "string",
+      pattern: "^[0-9]{2-4}",
+    }
+
+    assert.throws(
+      () => ajv.compile(rootSchema),
+      (thrown: unknown) => {
+        assert.equal((thrown as Error).message, "Invalid regular expression: ^[0-9]{2-4} at #")
+        return true
+      }
+    )
+
+    const pathSchema = {
+      type: "object",
+      properties: {
+        foo: rootSchema,
+      },
+    }
+
+    assert.throws(
+      () => ajv.compile(pathSchema),
+      (thrown: unknown) => {
+        assert.equal(
+          (thrown as Error).message,
+          "Invalid regular expression: ^[0-9]{2-4} at #/properties/foo"
+        )
+        return true
+      }
+    )
+  })
+  it("throws with pattern and schema path with $data", () => {
+    const ajv = new _Ajv({$data: true})
+
+    const schema = {
+      properties: {
+        shouldMatch: {},
+        string: {pattern: {$data: "1/shouldMatch"}},
+      },
+    }
+    const validate = ajv.compile(schema)
+
+    assert.throws(
+      () => ajv.compile(validate({shouldMatch: "^[0-9]{2-4}", string: "123"})),
+      (thrown: unknown) => {
+        assert.equal(
+          (thrown as Error).message,
+          "Invalid regular expression: ^[0-9]{2-4} at #/properties/string"
+        )
+        return true
+      }
+    )
+  })
+})


### PR DESCRIPTION
**What issue does this pull request resolve?**

#2477 - Wrap regexp instantiation in try/catch to add pattern and schema path to the error message

**What changes did you make?**

Wrapped both the regular and codegen'd versions of the pattern keyword regexp creation

**Is there anything that requires more attention while reviewing?**

Not sure if there is a better way to do the codegen, I did try using gen.try etc but couldn't figure it out.
