### PR TITLE
fix: #2482 Infinity and NaN serialise to null

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -204,6 +204,14 @@ Defines how date-time strings are parsed and validated. By default Ajv only allo
 This option makes JTD validation and parsing more permissive and non-standard. The date strings without time part will be accepted by Ajv, but will be rejected by other JTD validators.
 :::
 
+### safeNumbers <Badge text="JTD only" />
+
+Defines how special case numbers, Infinity, -Infinity and NaN are handled. Use `safeNumbers: "null"` to serialize them to `null` which is correct behavior according to the JSON spec. If you wish to handle these values, however, and not lose the data you can use `safeNumbers: "string"` which will serialize them to strings. If this option is not set the values will be included as the original literal values.
+
+::: warning The default behavior can produce invalid JSON
+If `safeNumbers` is left undefined, the serializer will produce invalid JSON when there are any special case numbers in the data. This is, however, the fastest mode and so should be used unless you expect to encounter special case numbers.
+:::
+
 ### int32range <Badge text="JTD only" />
 
 Can be used to disable range checking for `int32` and `uint32` types.

--- a/docs/options.md
+++ b/docs/options.md
@@ -206,10 +206,16 @@ This option makes JTD validation and parsing more permissive and non-standard. T
 
 ### specialNumbers <Badge text="JTD only" />
 
-Defines how special case numbers, Infinity, -Infinity and NaN are handled. Use `specialNumbers: "null"` to serialize them to `null` which is correct behavior according to the JSON spec. If you wish to handle these values, however, and not lose the data you can use `specialNumbers: "string"` which will serialize them to strings. If this option is not set the values will be included as the original literal values.
+Defines how special case numbers `Infinity`, `-Infinity` and `NaN` are handled.
+
+Option values:
+
+- `"fast"` - (default): Do not treat special numbers differently to normal numbers. This is the fastest method but also can produce invalid JSON if the data contains special numbers.
+- `"null"` - Special numbers will be serialized to `null` which is the correct behavior according to the JSON spec and is also the same behavior as `JSON.stringify`.
+- `"string"` - Special numbers will be serialized as strings, for example `"Infinity"`. This, while non-standard behavior, will allow parsing of the data without losing what the original values were.
 
 ::: warning The default behavior can produce invalid JSON
-If `specialNumbers` is left undefined, the serializer will produce invalid JSON when there are any special case numbers in the data. This is, however, the fastest mode and so should be used unless you expect to encounter special case numbers.
+Using `specialNumbers: "fast" or undefined` can produce invalid JSON when there are any special case numbers in the data.
 :::
 
 ### int32range <Badge text="JTD only" />

--- a/docs/options.md
+++ b/docs/options.md
@@ -212,7 +212,6 @@ Option values:
 
 - `"fast"` - (default): Do not treat special numbers differently to normal numbers. This is the fastest method but also can produce invalid JSON if the data contains special numbers.
 - `"null"` - Special numbers will be serialized to `null` which is the correct behavior according to the JSON spec and is also the same behavior as `JSON.stringify`.
-- `"string"` - Special numbers will be serialized as strings, for example `"Infinity"`. This, while non-standard behavior, will allow parsing of the data without losing what the original values were.
 
 ::: warning The default behavior can produce invalid JSON
 Using `specialNumbers: "fast" or undefined` can produce invalid JSON when there are any special case numbers in the data.

--- a/docs/options.md
+++ b/docs/options.md
@@ -204,12 +204,12 @@ Defines how date-time strings are parsed and validated. By default Ajv only allo
 This option makes JTD validation and parsing more permissive and non-standard. The date strings without time part will be accepted by Ajv, but will be rejected by other JTD validators.
 :::
 
-### safeNumbers <Badge text="JTD only" />
+### specialNumbers <Badge text="JTD only" />
 
-Defines how special case numbers, Infinity, -Infinity and NaN are handled. Use `safeNumbers: "null"` to serialize them to `null` which is correct behavior according to the JSON spec. If you wish to handle these values, however, and not lose the data you can use `safeNumbers: "string"` which will serialize them to strings. If this option is not set the values will be included as the original literal values.
+Defines how special case numbers, Infinity, -Infinity and NaN are handled. Use `specialNumbers: "null"` to serialize them to `null` which is correct behavior according to the JSON spec. If you wish to handle these values, however, and not lose the data you can use `specialNumbers: "string"` which will serialize them to strings. If this option is not set the values will be included as the original literal values.
 
 ::: warning The default behavior can produce invalid JSON
-If `safeNumbers` is left undefined, the serializer will produce invalid JSON when there are any special case numbers in the data. This is, however, the fastest mode and so should be used unless you expect to encounter special case numbers.
+If `specialNumbers` is left undefined, the serializer will produce invalid JSON when there are any special case numbers in the data. This is, however, the fastest mode and so should be used unless you expect to encounter special case numbers.
 :::
 
 ### int32range <Badge text="JTD only" />

--- a/lib/compile/jtd/serialize.ts
+++ b/lib/compile/jtd/serialize.ts
@@ -229,20 +229,15 @@ function serializeString({gen, data}: SerializeCxt): void {
 }
 
 function serializeNumber({gen, data, self}: SerializeCxt): void {
+  const condition = _`${data} === Infinity || ${data} === -Infinity || Number.isNaN(${data})`
+  const addNumber = (): CodeGen => gen.add(N.json, _`"" + ${data}`)
+
   if (self.opts.specialNumbers === "null") {
-    gen.if(
-      _`${data} === Infinity || ${data} === -Infinity || Number.isNaN(${data})`,
-      () => gen.add(N.json, _`null`),
-      () => gen.add(N.json, _`"" + ${data}`)
-    )
+    gen.if(condition, () => gen.add(N.json, _`null`), addNumber)
   } else if (self.opts.specialNumbers === "string") {
-    gen.if(
-      _`${data} === Infinity || ${data} === -Infinity || Number.isNaN(${data})`,
-      () => gen.add(N.json, str`"${data}"`),
-      () => gen.add(N.json, _`"" + ${data}`)
-    )
+    gen.if(condition, () => gen.add(N.json, str`"${data}"`), addNumber)
   } else {
-    gen.add(N.json, _`"" + ${data}`)
+    addNumber()
   }
 }
 

--- a/lib/compile/jtd/serialize.ts
+++ b/lib/compile/jtd/serialize.ts
@@ -233,17 +233,11 @@ function serializeNumber({gen, data, self}: SerializeCxt): void {
 
   if (self.opts.specialNumbers === undefined || self.opts.specialNumbers === "fast") {
     gen.add(N.json, _`"" + ${data}`)
-  } else if (self.opts.specialNumbers === "null") {
+  } else {
+    // specialNumbers === "null"
     gen.if(
       condition,
       () => gen.add(N.json, _`null`),
-      () => gen.add(N.json, _`"" + ${data}`)
-    )
-  } else {
-    // specialNumbers === "string"
-    gen.if(
-      condition,
-      () => gen.add(N.json, str`"${data}"`),
       () => gen.add(N.json, _`"" + ${data}`)
     )
   }

--- a/lib/compile/jtd/serialize.ts
+++ b/lib/compile/jtd/serialize.ts
@@ -229,13 +229,13 @@ function serializeString({gen, data}: SerializeCxt): void {
 }
 
 function serializeNumber({gen, data, self}: SerializeCxt): void {
-  if (self.opts.safeNumbers === "null") {
+  if (self.opts.specialNumbers === "null") {
     gen.if(
       _`${data} === Infinity || ${data} === -Infinity || Number.isNaN(${data})`,
       () => gen.add(N.json, _`null`),
       () => gen.add(N.json, _`"" + ${data}`)
     )
-  } else if (self.opts.safeNumbers === "string") {
+  } else if (self.opts.specialNumbers === "string") {
     gen.if(
       _`${data} === Infinity || ${data} === -Infinity || Number.isNaN(${data})`,
       () => gen.add(N.json, str`"${data}"`),

--- a/lib/compile/jtd/serialize.ts
+++ b/lib/compile/jtd/serialize.ts
@@ -228,12 +228,22 @@ function serializeString({gen, data}: SerializeCxt): void {
   gen.add(N.json, _`${useFunc(gen, quote)}(${data})`)
 }
 
-function serializeNumber({gen, data}: SerializeCxt): void {
-  gen.if(
-    _`${data} === Infinity || ${data} === -Infinity || Number.isNaN(${data})`,
-    () => gen.add(N.json, _`null`),
-    () => gen.add(N.json, _`"" + ${data}`)
-  )
+function serializeNumber({gen, data, self}: SerializeCxt): void {
+  if (self.opts.safeNumbers === "null") {
+    gen.if(
+      _`${data} === Infinity || ${data} === -Infinity || Number.isNaN(${data})`,
+      () => gen.add(N.json, _`null`),
+      () => gen.add(N.json, _`"" + ${data}`)
+    )
+  } else if (self.opts.safeNumbers === "string") {
+    gen.if(
+      _`${data} === Infinity || ${data} === -Infinity || Number.isNaN(${data})`,
+      () => gen.add(N.json, str`"${data}"`),
+      () => gen.add(N.json, _`"" + ${data}`)
+    )
+  } else {
+    gen.add(N.json, _`"" + ${data}`)
+  }
 }
 
 function serializeRef(cxt: SerializeCxt): void {

--- a/lib/compile/jtd/serialize.ts
+++ b/lib/compile/jtd/serialize.ts
@@ -229,15 +229,23 @@ function serializeString({gen, data}: SerializeCxt): void {
 }
 
 function serializeNumber({gen, data, self}: SerializeCxt): void {
-  const condition = _`${data} === Infinity || ${data} === -Infinity || Number.isNaN(${data})`
-  const addNumber = (): CodeGen => gen.add(N.json, _`"" + ${data}`)
+  const condition = _`${data} === Infinity || ${data} === -Infinity || ${data} !== ${data}`
 
-  if (self.opts.specialNumbers === "null") {
-    gen.if(condition, () => gen.add(N.json, _`null`), addNumber)
-  } else if (self.opts.specialNumbers === "string") {
-    gen.if(condition, () => gen.add(N.json, str`"${data}"`), addNumber)
+  if (self.opts.specialNumbers === undefined || self.opts.specialNumbers === "fast") {
+    gen.add(N.json, _`"" + ${data}`)
+  } else if (self.opts.specialNumbers === "null") {
+    gen.if(
+      condition,
+      () => gen.add(N.json, _`null`),
+      () => gen.add(N.json, _`"" + ${data}`)
+    )
   } else {
-    addNumber()
+    // specialNumbers === "string"
+    gen.if(
+      condition,
+      () => gen.add(N.json, str`"${data}"`),
+      () => gen.add(N.json, _`"" + ${data}`)
+    )
   }
 }
 

--- a/lib/compile/jtd/serialize.ts
+++ b/lib/compile/jtd/serialize.ts
@@ -229,7 +229,11 @@ function serializeString({gen, data}: SerializeCxt): void {
 }
 
 function serializeNumber({gen, data}: SerializeCxt): void {
-  gen.add(N.json, _`"" + ${data}`)
+  gen.if(
+    _`${data} === Infinity || ${data} === -Infinity || Number.isNaN(${data})`,
+    () => gen.add(N.json, _`null`),
+    () => gen.add(N.json, _`"" + ${data}`)
+  )
 }
 
 function serializeRef(cxt: SerializeCxt): void {

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -107,7 +107,7 @@ export interface CurrentOptions {
   timestamp?: "string" | "date" // JTD only
   parseDate?: boolean // JTD only
   allowDate?: boolean // JTD only
-  specialNumbers?: "string" | "null" // JTD only
+  specialNumbers?: "fast" | "string" | "null" // JTD only
   $comment?:
     | true
     | ((comment: string, schemaPath?: string, rootSchema?: AnySchemaObject) => unknown)

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -107,7 +107,7 @@ export interface CurrentOptions {
   timestamp?: "string" | "date" // JTD only
   parseDate?: boolean // JTD only
   allowDate?: boolean // JTD only
-  safeNumbers?: "string" | "null" // JTD only
+  specialNumbers?: "string" | "null" // JTD only
   $comment?:
     | true
     | ((comment: string, schemaPath?: string, rootSchema?: AnySchemaObject) => unknown)

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -107,6 +107,7 @@ export interface CurrentOptions {
   timestamp?: "string" | "date" // JTD only
   parseDate?: boolean // JTD only
   allowDate?: boolean // JTD only
+  safeNumbers?: "string" | "null" // JTD only
   $comment?:
     | true
     | ((comment: string, schemaPath?: string, rootSchema?: AnySchemaObject) => unknown)

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -107,7 +107,7 @@ export interface CurrentOptions {
   timestamp?: "string" | "date" // JTD only
   parseDate?: boolean // JTD only
   allowDate?: boolean // JTD only
-  specialNumbers?: "fast" | "string" | "null" // JTD only
+  specialNumbers?: "fast" | "null" // JTD only
   $comment?:
     | true
     | ((comment: string, schemaPath?: string, rootSchema?: AnySchemaObject) => unknown)

--- a/spec/jtd-schema.spec.ts
+++ b/spec/jtd-schema.spec.ts
@@ -146,6 +146,19 @@ describe("JSON Type Definition", () => {
     }
   })
 
+  describe("serialize special numeric values", () => {
+    const ajv = new _AjvJTD()
+
+    it(`should serialize Infinity to null`, () => {
+      const serialize = ajv.compileSerializer({type: "float64"})
+      assert.deepStrictEqual(JSON.parse(serialize(Infinity)), null)
+    })
+    it(`should serialize NaN to null`, () => {
+      const serialize = ajv.compileSerializer({type: "float64"})
+      assert.deepStrictEqual(JSON.parse(serialize(NaN)), null)
+    })
+  })
+
   describe("parse", () => {
     let ajv: AjvJTD
     before(() => (ajv = new _AjvJTD()))

--- a/spec/jtd-schema.spec.ts
+++ b/spec/jtd-schema.spec.ts
@@ -191,29 +191,6 @@ describe("JSON Type Definition", () => {
         assert.equal(JSON.parse(res), null)
       })
     })
-
-    describe("to string", () => {
-      const ajv = new _AjvJTD({specialNumbers: "string"})
-
-      it(`should serialize Infinity to string`, () => {
-        const serialize = ajv.compileSerializer({type: "float64"})
-        const res = serialize(Infinity)
-        assert.equal(res, '"Infinity"')
-        assert.equal(JSON.parse(res), "Infinity")
-      })
-      it(`should serialize -Infinity to string`, () => {
-        const serialize = ajv.compileSerializer({type: "float64"})
-        const res = serialize(-Infinity)
-        assert.equal(res, '"-Infinity"')
-        assert.equal(JSON.parse(res), "-Infinity")
-      })
-      it(`should serialize NaN to string`, () => {
-        const serialize = ajv.compileSerializer({type: "float64"})
-        const res = serialize(NaN)
-        assert.equal(res, '"NaN"')
-        assert.equal(JSON.parse(res), "NaN")
-      })
-    })
   })
 
   describe("parse", () => {

--- a/spec/jtd-schema.spec.ts
+++ b/spec/jtd-schema.spec.ts
@@ -146,21 +146,49 @@ describe("JSON Type Definition", () => {
     }
   })
 
-  describe.only("serialize special numeric values to null", () => {
+  describe("serialize special numeric values", () => {
+    describe("default", () => {
+      const ajv = new _AjvJTD()
+
+      it(`should serialize Infinity to literal`, () => {
+        const serialize = ajv.compileSerializer({type: "float64"})
+        const res = serialize(Infinity)
+        assert.equal(res, "Infinity")
+        assert.throws(() => JSON.parse(res))
+      })
+      it(`should serialize -Infinity to literal`, () => {
+        const serialize = ajv.compileSerializer({type: "float64"})
+        const res = serialize(-Infinity)
+        assert.equal(res, "-Infinity")
+        assert.throws(() => JSON.parse(res))
+      })
+      it(`should serialize NaN to literal`, () => {
+        const serialize = ajv.compileSerializer({type: "float64"})
+        const res = serialize(NaN)
+        assert.equal(res, "NaN")
+        assert.throws(() => JSON.parse(res))
+      })
+    })
     describe("to null", () => {
       const ajv = new _AjvJTD({safeNumbers: "null"})
 
       it(`should serialize Infinity to null`, () => {
         const serialize = ajv.compileSerializer({type: "float64"})
-        assert.deepStrictEqual(JSON.parse(serialize(Infinity)), null)
+        const res = serialize(Infinity)
+        assert.equal(res, "null")
+        assert.equal(JSON.parse(res), null)
       })
       it(`should serialize -Infinity to null`, () => {
         const serialize = ajv.compileSerializer({type: "float64"})
-        assert.deepStrictEqual(JSON.parse(serialize(-Infinity)), null)
+        const res = serialize(-Infinity)
+        assert.equal(res, "null")
+        assert.equal(JSON.parse(res), null)
       })
       it(`should serialize NaN to null`, () => {
         const serialize = ajv.compileSerializer({type: "float64"})
-        assert.deepStrictEqual(JSON.parse(serialize(NaN)), null)
+        const res = serialize(NaN)
+        assert.equal(res, "null")
+        assert.equal(JSON.parse(res), null)
       })
     })
 
@@ -169,16 +197,21 @@ describe("JSON Type Definition", () => {
 
       it(`should serialize Infinity to string`, () => {
         const serialize = ajv.compileSerializer({type: "float64"})
-        console.log(serialize(Infinity))
-        assert.deepStrictEqual(JSON.parse(serialize(Infinity)), "Infinity")
+        const res = serialize(Infinity)
+        assert.equal(res, '"Infinity"')
+        assert.equal(JSON.parse(res), "Infinity")
       })
       it(`should serialize -Infinity to string`, () => {
         const serialize = ajv.compileSerializer({type: "float64"})
-        assert.deepStrictEqual(JSON.parse(serialize(-Infinity)), "-Infinity")
+        const res = serialize(-Infinity)
+        assert.equal(res, '"-Infinity"')
+        assert.equal(JSON.parse(res), "-Infinity")
       })
       it(`should serialize NaN to string`, () => {
         const serialize = ajv.compileSerializer({type: "float64"})
-        assert.deepStrictEqual(JSON.parse(serialize(NaN)), "NaN")
+        const res = serialize(NaN)
+        assert.equal(res, '"NaN"')
+        assert.equal(JSON.parse(res), "NaN")
       })
     })
   })

--- a/spec/jtd-schema.spec.ts
+++ b/spec/jtd-schema.spec.ts
@@ -147,8 +147,8 @@ describe("JSON Type Definition", () => {
   })
 
   describe("serialize special numeric values", () => {
-    describe("default", () => {
-      const ajv = new _AjvJTD()
+    describe("fast", () => {
+      const ajv = new _AjvJTD({specialNumbers: "fast"})
 
       it(`should serialize Infinity to literal`, () => {
         const serialize = ajv.compileSerializer({type: "float64"})

--- a/spec/jtd-schema.spec.ts
+++ b/spec/jtd-schema.spec.ts
@@ -146,16 +146,40 @@ describe("JSON Type Definition", () => {
     }
   })
 
-  describe("serialize special numeric values", () => {
-    const ajv = new _AjvJTD()
+  describe.only("serialize special numeric values to null", () => {
+    describe("to null", () => {
+      const ajv = new _AjvJTD({safeNumbers: "null"})
 
-    it(`should serialize Infinity to null`, () => {
-      const serialize = ajv.compileSerializer({type: "float64"})
-      assert.deepStrictEqual(JSON.parse(serialize(Infinity)), null)
+      it(`should serialize Infinity to null`, () => {
+        const serialize = ajv.compileSerializer({type: "float64"})
+        assert.deepStrictEqual(JSON.parse(serialize(Infinity)), null)
+      })
+      it(`should serialize -Infinity to null`, () => {
+        const serialize = ajv.compileSerializer({type: "float64"})
+        assert.deepStrictEqual(JSON.parse(serialize(-Infinity)), null)
+      })
+      it(`should serialize NaN to null`, () => {
+        const serialize = ajv.compileSerializer({type: "float64"})
+        assert.deepStrictEqual(JSON.parse(serialize(NaN)), null)
+      })
     })
-    it(`should serialize NaN to null`, () => {
-      const serialize = ajv.compileSerializer({type: "float64"})
-      assert.deepStrictEqual(JSON.parse(serialize(NaN)), null)
+
+    describe("to string", () => {
+      const ajv = new _AjvJTD({safeNumbers: "string"})
+
+      it(`should serialize Infinity to string`, () => {
+        const serialize = ajv.compileSerializer({type: "float64"})
+        console.log(serialize(Infinity))
+        assert.deepStrictEqual(JSON.parse(serialize(Infinity)), "Infinity")
+      })
+      it(`should serialize -Infinity to string`, () => {
+        const serialize = ajv.compileSerializer({type: "float64"})
+        assert.deepStrictEqual(JSON.parse(serialize(-Infinity)), "-Infinity")
+      })
+      it(`should serialize NaN to string`, () => {
+        const serialize = ajv.compileSerializer({type: "float64"})
+        assert.deepStrictEqual(JSON.parse(serialize(NaN)), "NaN")
+      })
     })
   })
 

--- a/spec/jtd-schema.spec.ts
+++ b/spec/jtd-schema.spec.ts
@@ -170,7 +170,7 @@ describe("JSON Type Definition", () => {
       })
     })
     describe("to null", () => {
-      const ajv = new _AjvJTD({safeNumbers: "null"})
+      const ajv = new _AjvJTD({specialNumbers: "null"})
 
       it(`should serialize Infinity to null`, () => {
         const serialize = ajv.compileSerializer({type: "float64"})
@@ -193,7 +193,7 @@ describe("JSON Type Definition", () => {
     })
 
     describe("to string", () => {
-      const ajv = new _AjvJTD({safeNumbers: "string"})
+      const ajv = new _AjvJTD({specialNumbers: "string"})
 
       it(`should serialize Infinity to string`, () => {
         const serialize = ajv.compileSerializer({type: "float64"})


### PR DESCRIPTION
**What issue does this pull request resolve?**
#2482 

**What changes did you make?**
Added an option to support serializing the special case numbers`Infinity`, `-Infinity` and `NaN`. See added docs for expected behavior but basically these options help to avoid invalid JSON when dealing with these values.

**Is there anything that requires more attention while reviewing?**

The tests and the new docs explain it all.
