### PR TITLE
Fixes:  UncheckedJSONSchemaType ['type'] field does not support 'array', 'object', and 'null' in an array

### DIFF
--- a/lib/types/json-schema.ts
+++ b/lib/types/json-schema.ts
@@ -49,6 +49,12 @@ type UncheckedJSONSchemaType<T, IsPartial extends boolean> = (
         ? JSONType<"string", IsPartial>
         : T extends boolean
         ? JSONType<"boolean", IsPartial>
+        : T extends readonly any[]
+        ? JSONType<"array", IsPartial>
+        : T extends Record<string, any>
+        ? JSONType<"object", IsPartial>
+        : T extends null
+        ? JSONType<"null", IsPartial>
         : never)[]
     } & UnionToIntersection<
       T extends number


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
Fixes:  UncheckedJSONSchemaType ['type'] field does not support 'array', 'object', and 'null' in an array [#2518](https://github.com/ajv-validator/ajv/issues/2518)
**What changes did you make?**
Fixed the type UncheckedJSONSchemaType.

**Is there anything that requires more attention while reviewing?**
No, the library is working unchanged.
