### PR TITLE
ci(build): add node 10+ to test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 21.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 21.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

fast-uri, that ajv has as a dependency, [was updated to v3.0.4 yesterday](https://github.com/fastify/fast-uri/releases/tag/v3.0.4), which included a PR that added optional chaining. This was fine as fast-uri only tests on Node 16+ in its CI, because we only support Node 16+.

Unfortunately, we've had a few issues raised over at fast-uri with users stating issues with old Node versions when using ajv thanks to this change.

[ajv is not tested on anything below Node 16](https://github.com/ajv-validator/ajv/blob/82735a15826a30cc51e97a1bbfb59b3d388e4b98/.github/workflows/build.yml#L15), which is at odds with what [ajv states to support in the readme](https://github.com/ajv-validator/ajv?tab=readme-ov-file#features), so this PR adds the stated supported Node versions to the CI workflow.


**What changes did you make?**

Added node 10, 12, and 14 to CI workflow.

**Is there anything that requires more attention while reviewing?**

The alternative is to update the documentation to reflect that anything under Node 16 is untested and, as such, unsupported.
