### PR TITLE
docs(readme): update minimum supported node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Performance of different validators by [json-schema-benchmark](https://github.co
   - all keywords (see [JSON Type Definition schema forms](https://ajv.js.org/json-type-definition.html))
   - meta-schema for JTD schemas
   - "union" keyword and user-defined keywords (can be used inside "metadata" member of the schema)
-- supports [browsers](https://ajv.js.org/guide/environments.html#browsers) and Node.js 10.x - current
+- supports [browsers](https://ajv.js.org/guide/environments.html#browsers) and Node.js 16.x - current
 - [asynchronous loading](https://ajv.js.org/guide/managing-schemas.html#asynchronous-schema-loading) of referenced schemas during compilation
 - "All errors" validation mode with [option allErrors](https://ajv.js.org/options.html#allerrors)
 - [error messages with parameters](https://ajv.js.org/api.html#validation-errors) describing error reasons to allow error message generation


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

fast-uri, that ajv has as a dependency, [was updated to v3.0.4 yesterday](https://github.com/fastify/fast-uri/releases/tag/v3.0.4), which included a PR that added optional chaining. This was fine as fast-uri only tests on Node 16+ in its CI, because we only support Node 16+.

Unfortunately, we've had a few issues raised over at fast-uri with users stating issues with old Node versions when using ajv thanks to this change.

[ajv is not tested on anything below Node 16](https://github.com/ajv-validator/ajv/blob/82735a15826a30cc51e97a1bbfb59b3d388e4b98/.github/workflows/build.yml#L15), which is at odds with what [ajv states to support in the readme](https://github.com/ajv-validator/ajv?tab=readme-ov-file#features), so this PR updates the documentation to the minimum tested Node version.

**What changes did you make?**

Updated documentation.

**Is there anything that requires more attention while reviewing?**

ajv doesn't support Node 10 and 12 anyway from the looks of it: https://github.com/ajv-validator/ajv/actions/runs/12629749595/
