### PR TITLE
Update typescript.md

### DIFF
--- a/docs/guide/typescript.md
+++ b/docs/guide/typescript.md
@@ -20,7 +20,7 @@ For the same example as in [Getting started](./getting-started):
 <code-group>
 <code-block title="JSON Schema">
 ```typescript
-import Ajv, {JSONSchemaType} from "ajv"
+import {Ajv, JSONSchemaType} from "ajv"
 const ajv = new Ajv()
 
 interface MyData {
@@ -61,7 +61,7 @@ if (validate(data)) {
 
 <code-block title="JSON Type Definition">
 ```typescript
-import Ajv, {JTDSchemaType} from "ajv/dist/jtd"
+import {Ajv, JTDSchemaType} from "ajv/dist/jtd.js"
 const ajv = new Ajv()
 
 interface MyData {
@@ -110,7 +110,7 @@ You can use JTD schema to construct the type of data using utility type `JTDData
 <code-group>
 <code-block title="JSON Type Definition">
 ```typescript
-import Ajv, {JTDDataType} from "ajv/dist/jtd"
+import {Ajv, JTDDataType} from "ajv/dist/jtd.js"
 const ajv = new Ajv()
 
 const schema = {
@@ -181,7 +181,7 @@ if (validate(data)) {
 
 <code-block title="JSON Type Definition">
 ```typescript
-import {JTDErrorObject} from "ajv/dist/jtd"
+import {JTDErrorObject} from "ajv/dist/jtd.js"
 
 // ...
 
@@ -214,7 +214,7 @@ This example uses the same data and schema types as above:
 <code-group>
 <code-block title="JSON Type Definition">
 ```typescript
-import Ajv, {JTDSchemaType} from "ajv/dist/jtd"
+import {Ajv, JTDSchemaType} from "ajv/dist/jtd.js"
 const ajv = new Ajv()
 
 interface MyData {
@@ -290,7 +290,7 @@ Here's a more detailed example showing several union types:
 <code-group>
 <code-block title="JSON Schema">
 ```typescript
-import Ajv, {JSONSchemaType} from "ajv"
+import {Ajv, JSONSchemaType} from "ajv"
 const ajv = new Ajv()
 
 type MyUnion = {prop: boolean} | string | number


### PR DESCRIPTION
Change the importing of the `Ajv` object from default import to named import. This will avoid the typescript errors described in https://github.com/ajv-validator/ajv/issues/2132

<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

Using Ajv with typescript, many people are reporting the error "Ajv This expression is not constructable

**What changes did you make?**

Change from default import to named import. More details here: https://github.com/ajv-validator/ajv/issues/2132

**Is there anything that requires more attention while reviewing?**

No. Thanks for considering this change.