### PR TITLE
doc: npm downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Supports JSON Schema draft-04/06/07/2019-09/2020-12 ([draft-04 support](https://
 
 [![build](https://github.com/ajv-validator/ajv/actions/workflows/build.yml/badge.svg)](https://github.com/ajv-validator/ajv/actions?query=workflow%3Abuild)
 [![npm](https://img.shields.io/npm/v/ajv.svg)](https://www.npmjs.com/package/ajv)
-[![npm downloads](https://img.shields.io/npm/dm/ajv.svg)](https://www.npmjs.com/package/ajv)
+[![npm downloads](https://img.shields.io/npm/dm/ajv.svg)](https://npm-compare.com/ajv/#timeRange=FIVE_YEARS)
 [![Coverage Status](https://coveralls.io/repos/github/ajv-validator/ajv/badge.svg?branch=master)](https://coveralls.io/github/ajv-validator/ajv?branch=master)
 [![SimpleX](https://img.shields.io/badge/chat-on%20SimpleX-70F0F9)](https://simplex.chat/contact#/?v=1-2&smp=smp%3A%2F%2Fu2dS9sG8nMNURyZwqASV4yROM28Er0luVTx5X1CsMrU%3D%40smp4.simplex.im%2F8KvvURM6J38Gdq9dCuPswMOkMny0xCOJ%23%2F%3Fv%3D1-2%26dh%3DMCowBQYDK2VuAyEAr8rPVRuMOXv6kwF2yUAap-eoVg-9ssOFCi1fIrxTUw0%253D%26srv%3Do5vmywmrnaxalvz6wi3zicyftgio6psuvyniis6gco6bp6ekl4cqj4id.onion&data=%7B%22type%22%3A%22group%22%2C%22groupLinkId%22%3A%224pwLRgWHU9tlroMWHz0uOg%3D%3D%22%7D)
 [![Gitter](https://img.shields.io/gitter/room/ajv-validator/ajv.svg)](https://gitter.im/ajv-validator/ajv)


### PR DESCRIPTION
Hi, 
I’ve made an update to the README by replacing the second NPM download badge with one that links to npm-compare.com, where users can view the dynamic [download trends of ajv](https://npm-compare.com/ajv/#timeRange=FIVE_YEARS) over the past five years. This change allows new users to easily see the download history of the package, providing more confidence in its popularity and adoption.

The first badge in README already links to the [NPM page for ajv](https://www.npmjs.com/package/ajv). The second badge now links to npm-compare.com, gives users a better perspective on the package’s growth and popularity, instead of simply repeating the link to the NPM package page.

By the way, I'm a maintainer of npm-compare.com. I’m happy to assist with any additional features or insights from our site if needed.

Thanks for considering my suggestion!
