### PR TITLE
used "arbitrary module namespace identifier names" in esm codgen

### DIFF
--- a/lib/compile/codegen/code.ts
+++ b/lib/compile/codegen/code.ts
@@ -156,14 +156,6 @@ export function getProperty(key: Code | string | number): Code {
   return typeof key == "string" && IDENTIFIER.test(key) ? new _Code(`.${key}`) : _`[${key}]`
 }
 
-//Does best effort to format the name properly
-export function getEsmExportName(key: Code | string | number): Code {
-  if (typeof key == "string" && IDENTIFIER.test(key)) {
-    return new _Code(`${key}`)
-  }
-  throw new Error(`CodeGen: invalid export name: ${key}, use explicit $id name mapping`)
-}
-
 export function regexpCode(rx: RegExp): Code {
   return new _Code(rx.toString())
 }

--- a/lib/compile/codegen/code.ts
+++ b/lib/compile/codegen/code.ts
@@ -158,8 +158,8 @@ export function getProperty(key: Code | string | number): Code {
 
 //Does best effort to format the name properly
 export function getEsmExportName(key: Code | string | number): Code {
-  if (typeof key !== "string")  throw new Error(`CodeGen: invalid export name: ${key}, use explicit $id name mapping`)
-  return IDENTIFIER.test(key) ? new _Code(`${key}`) : _`${key}`;
+  if (typeof key !== "string") throw new Error(`CodeGen: invalid export name: ${key}, use explicit $id name mapping`)
+  return IDENTIFIER.test(key) ? new _Code(`${key}`) : _`${key}`
 }
 
 export function regexpCode(rx: RegExp): Code {

--- a/lib/compile/codegen/code.ts
+++ b/lib/compile/codegen/code.ts
@@ -158,8 +158,10 @@ export function getProperty(key: Code | string | number): Code {
 
 //Does best effort to format the name properly
 export function getEsmExportName(key: Code | string | number): Code {
-  if (typeof key !== "string") throw new Error(`CodeGen: invalid export name: ${key}, use explicit $id name mapping`)
-  return IDENTIFIER.test(key) ? new _Code(`${key}`) : _`${key}`
+  if (typeof key == "string") {
+    return IDENTIFIER.test(key) ? new _Code(`${key}`) : _`${key}`
+  }
+  throw new Error(`CodeGen: invalid export name: ${key}, use explicit $id name mapping`)
 }
 
 export function regexpCode(rx: RegExp): Code {

--- a/lib/compile/codegen/code.ts
+++ b/lib/compile/codegen/code.ts
@@ -156,6 +156,12 @@ export function getProperty(key: Code | string | number): Code {
   return typeof key == "string" && IDENTIFIER.test(key) ? new _Code(`.${key}`) : _`[${key}]`
 }
 
+//Does best effort to format the name properly
+export function getEsmExportName(key: Code | string | number): Code {
+  if (typeof key !== "string")  throw new Error(`CodeGen: invalid export name: ${key}, use explicit $id name mapping`)
+  return IDENTIFIER.test(key) ? new _Code(`${key}`) : _`${key}`;
+}
+
 export function regexpCode(rx: RegExp): Code {
   return new _Code(rx.toString())
 }

--- a/lib/standalone/index.ts
+++ b/lib/standalone/index.ts
@@ -32,7 +32,7 @@ function standaloneCode(
     const vCode = validateCode(usedValues, source)
     if (ajv.opts.code.esm) {
       // Always do named export as `validate` rather than the variable `n` which is `validateXX` for known export value
-      return `"use strict";${_n}export const validate = ${n};${_n}export default ${n};${_n}${vCode}`
+      return `"use strict";${_n}export {${n} as validate,${_n}${n} as default};${_n}${vCode}`
     }
     return `"use strict";${_n}module.exports = ${n};${_n}module.exports.default = ${n};${_n}${vCode}`
   }

--- a/lib/standalone/index.ts
+++ b/lib/standalone/index.ts
@@ -2,7 +2,7 @@ import type AjvCore from "../core"
 import type {AnyValidateFunction, SourceCode} from "../types"
 import type {SchemaEnv} from "../compile"
 import {UsedScopeValues, UsedValueState, ValueScopeName, varKinds} from "../compile/codegen/scope"
-import {_, nil, _Code, Code, getProperty} from "../compile/codegen/code"
+import {_, nil, _Code, Code, getProperty, getEsmExportName} from "../compile/codegen/code"
 
 function standaloneCode(
   ajv: AjvCore,
@@ -48,7 +48,7 @@ function standaloneCode(
       if (v) {
         const vCode = validateCode(usedValues, v.source)
         const exportSyntax = ajv.opts.code.esm
-          ? _`export { ${v.source?.validateName} as ${name} };`
+          ? _`export { ${v.source?.validateName} as ${getEsmExportName(name)} };`
           : _`exports${getProperty(name)} = ${v.source?.validateName};`
         code = _`${code}${_n}${exportSyntax}${_n}${vCode}`
       }

--- a/lib/standalone/index.ts
+++ b/lib/standalone/index.ts
@@ -2,7 +2,7 @@ import type AjvCore from "../core"
 import type {AnyValidateFunction, SourceCode} from "../types"
 import type {SchemaEnv} from "../compile"
 import {UsedScopeValues, UsedValueState, ValueScopeName, varKinds} from "../compile/codegen/scope"
-import {_, nil, _Code, Code, getProperty, getEsmExportName} from "../compile/codegen/code"
+import {_, nil, _Code, Code, getProperty} from "../compile/codegen/code"
 
 function standaloneCode(
   ajv: AjvCore,
@@ -48,9 +48,9 @@ function standaloneCode(
       if (v) {
         const vCode = validateCode(usedValues, v.source)
         const exportSyntax = ajv.opts.code.esm
-          ? _`export const ${getEsmExportName(name)}`
-          : _`exports${getProperty(name)}`
-        code = _`${code}${_n}${exportSyntax} = ${v.source?.validateName};${_n}${vCode}`
+          ? _`export { ${v.source?.validateName} as ${name} };`
+          : _`exports${getProperty(name)} = ${v.source?.validateName};`
+        code = _`${code}${_n}${exportSyntax}${_n}${vCode}`
       }
     }
     return `${code}`

--- a/spec/standalone.spec.ts
+++ b/spec/standalone.spec.ts
@@ -11,7 +11,7 @@ function testExportTypeEsm(moduleCode: string, singleExport: boolean) {
   //Must have
   assert.strictEqual(moduleCode.includes("export {"), true)
   if (singleExport) {
-    assert.strictEqual(moduleCode.includes("export default"), true)
+    assert.strictEqual(moduleCode.includes("as default"), true)
   }
   //Must not have
   assert.strictEqual(moduleCode.includes("module.exports"), false)

--- a/spec/standalone.spec.ts
+++ b/spec/standalone.spec.ts
@@ -9,7 +9,7 @@ import assert = require("assert")
 
 function testExportTypeEsm(moduleCode: string, singleExport: boolean) {
   //Must have
-  assert.strictEqual(moduleCode.includes("export const"), true)
+  assert.strictEqual(moduleCode.includes("export {"), true)
   if (singleExport) {
     assert.strictEqual(moduleCode.includes("export default"), true)
   }


### PR DESCRIPTION
**What issue does this pull request resolve?**
Allow useage of compiled to esm validation function without name mapping
as es2022 introduced [arbitrary module namespace identifier names](https://github.com/tc39/ecma262/pull/2154)

**What changes did you make?**
Updated `exportSyntax` used with `esm` option set to `true`

**Is there anything that requires more attention while reviewing?**
No, due to no breaking changes where introduced