### PR TITLE
Use cache once

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -488,7 +488,7 @@ export default class Ajv {
     }
     key = normalizeId(key || id)
     this._checkUnique(key)
-    this.schemas[key] = this._addSchema(schema, _meta, key, _validateSchema, true)
+    this.schemas[key] = this._addSchema(schema, _meta, key, _validateSchema, true, false)
     return this
   }
 
@@ -701,7 +701,8 @@ export default class Ajv {
     meta?: boolean,
     baseId?: string,
     validateSchema = this.opts.validateSchema,
-    addSchema = this.opts.addUsedSchema
+    addSchema = this.opts.addUsedSchema,
+    cacheSchema = true
   ): SchemaEnv {
     let id: string | undefined
     const {schemaId} = this.opts
@@ -711,13 +712,13 @@ export default class Ajv {
       if (this.opts.jtd) throw new Error("schema must be object")
       else if (typeof schema != "boolean") throw new Error("schema must be object or boolean")
     }
-    let sch = this._cache.get(schema)
+    let sch = this._cache.get(schema) ?? (baseId ? this.schemas[baseId] : undefined)
     if (sch !== undefined) return sch
 
     baseId = normalizeId(id || baseId)
     const localRefs = getSchemaRefs.call(this, schema, baseId)
     sch = new SchemaEnv({schema, schemaId, meta, baseId, localRefs})
-    this._cache.set(sch.schema, sch)
+    if (cacheSchema) this._cache.set(sch.schema, sch)
     if (addSchema && !baseId.startsWith("#")) {
       // TODO atm it is allowed to overwrite schemas without id (instead of not adding them)
       if (baseId) this._checkUnique(baseId)

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -488,7 +488,8 @@ export default class Ajv {
     }
     key = normalizeId(key || id)
     this._checkUnique(key)
-    this.schemas[key] = this._addSchema(schema, _meta, key, _validateSchema, true, false)
+    const keyIsUnset = !key
+    this.schemas[key] = this._addSchema(schema, _meta, key, _validateSchema, true, keyIsUnset)
     return this
   }
 

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -130,6 +130,7 @@ export interface CurrentOptions {
   defaultMeta?: string | AnySchemaObject
   validateSchema?: boolean | "log"
   addUsedSchema?: boolean
+  noCache?: boolean
   inlineRefs?: boolean | number
   passContext?: boolean
   loopRequired?: number
@@ -488,8 +489,7 @@ export default class Ajv {
     }
     key = normalizeId(key || id)
     this._checkUnique(key)
-    const keyIsUnset = !key
-    this.schemas[key] = this._addSchema(schema, _meta, key, _validateSchema, true, keyIsUnset)
+    this.schemas[key] = this._addSchema(schema, _meta, key, _validateSchema, true)
     return this
   }
 
@@ -703,7 +703,7 @@ export default class Ajv {
     baseId?: string,
     validateSchema = this.opts.validateSchema,
     addSchema = this.opts.addUsedSchema,
-    cacheSchema = true
+    noCache = this.opts.noCache
   ): SchemaEnv {
     let id: string | undefined
     const {schemaId} = this.opts
@@ -713,14 +713,14 @@ export default class Ajv {
       if (this.opts.jtd) throw new Error("schema must be object")
       else if (typeof schema != "boolean") throw new Error("schema must be object or boolean")
     }
-    let sch = this._cache.get(schema) ?? (baseId ? this.schemas[baseId] : undefined)
+    let sch = this._cache.get(schema) ?? this.schemas[normalizeId(baseId || id)]
     if (sch !== undefined) return sch
 
     baseId = normalizeId(id || baseId)
     const localRefs = getSchemaRefs.call(this, schema, baseId)
     sch = new SchemaEnv({schema, schemaId, meta, baseId, localRefs})
-    if (cacheSchema) this._cache.set(sch.schema, sch)
-    if (addSchema && !baseId.startsWith("#")) {
+    if (!noCache) this._cache.set(sch.schema, sch)
+    if (!noCache && addSchema && !baseId.startsWith("#")) {
       // TODO atm it is allowed to overwrite schemas without id (instead of not adding them)
       if (baseId) this._checkUnique(baseId)
       this.refs[baseId] = sch

--- a/spec/ajv.spec.ts
+++ b/spec/ajv.spec.ts
@@ -37,6 +37,18 @@ describe("Ajv", () => {
       v1.should.equal(v2)
     })
 
+    it("should not cache compiled functions for the same schema when opt.noCache", () => {
+      ajv = new _Ajv({keywords: ["foo"], allowUnionTypes: true, noCache: true})
+      const schema = {
+        $id: "//e.com/int.json",
+        type: "integer",
+        minimum: 1,
+      }
+      const v1 = ajv.compile(schema)
+      const v2 = ajv.compile(schema)
+      v1.should.not.equal(v2)
+    })
+
     it("should throw if different schema has the same id", () => {
       ajv.compile({$id: "//e.com/int.json", type: "integer"})
       should.throw(() => {
@@ -313,9 +325,8 @@ describe("Ajv", () => {
       const v = ajv.getSchema("int")
       assert(typeof v == "function")
       v.should.be.a("function")
-
       //@ts-expect-error
-      should.not.exist(ajv._cache.get(schema))
+      ajv._cache.get(schema).validate.should.equal(v)
 
       ajv.removeSchema("int")
       should.not.exist(ajv.getSchema("int"))
@@ -330,6 +341,8 @@ describe("Ajv", () => {
       const v = ajv.getSchema("//e.com/int.json")
       assert(typeof v == "function")
       v.should.be.a("function")
+      //@ts-expect-error
+      ajv._cache.get(schema).validate.should.equal(v)
 
       ajv.removeSchema("//e.com/int.json")
       should.not.exist(ajv.getSchema("//e.com/int.json"))
@@ -338,17 +351,20 @@ describe("Ajv", () => {
     })
 
     it("should remove schema by schema object", () => {
-      const schema = {$id: "//e.com/object_test.json", type: "integer"}
+      const schema = {type: "integer"}
       ajv.addSchema(schema)
+      //@ts-expect-error
+      ajv._cache.get(schema).should.be.an("object")
       ajv.removeSchema(schema)
       //@ts-expect-error
       should.not.exist(ajv._cache.get(schema))
-      should.not.exist(ajv.getSchema("//e.com/object_test.json"))
     })
 
     it("should remove schema with id by schema object", () => {
       const schema = {$id: "//e.com/int.json", type: "integer"}
       ajv.addSchema(schema)
+      //@ts-expect-error
+      ajv._cache.get(schema).should.be.an("object")
       ajv.removeSchema(schema)
       should.not.exist(ajv.getSchema("//e.com/int.json"))
       //@ts-expect-error
@@ -365,7 +381,8 @@ describe("Ajv", () => {
     it("should remove all schemas but meta-schemas if called without an arguments", () => {
       const schema1 = {$id: "//e.com/int.json", type: "integer"}
       ajv.addSchema(schema1)
-      ajv.getSchema("//e.com/int.json")!.should.be.an("function")
+      //@ts-expect-error
+      ajv._cache.get(schema1).should.be.an("object")
 
       const schema2 = {type: "integer"}
       ajv.addSchema(schema2)
@@ -373,7 +390,8 @@ describe("Ajv", () => {
       ajv._cache.get(schema2).should.be.an("object")
 
       ajv.removeSchema()
-      should.not.exist(ajv.getSchema("//e.com/int.json"))
+      //@ts-expect-error
+      should.not.exist(ajv._cache.get(schema1))
       //@ts-expect-error
       should.not.exist(ajv._cache.get(schema2))
     })
@@ -381,12 +399,13 @@ describe("Ajv", () => {
     it("should remove all schemas but meta-schemas with key/id matching pattern", () => {
       const schema1 = {$id: "//e.com/int.json", type: "integer"}
       ajv.addSchema(schema1)
-      ajv.getSchema("//e.com/int.json")!.should.be.an("function")
+      //@ts-expect-error
+      ajv._cache.get(schema1).should.be.an("object")
 
       const schema2 = {$id: "str.json", type: "string"}
       ajv.addSchema(schema2, "//e.com/str.json")
       //@ts-expect-error
-      ajv.getSchema("//e.com/str.json").should.be.an("function")
+      ajv._cache.get(schema2).should.be.an("object")
 
       const schema3 = {type: "integer"}
       ajv.addSchema(schema3)
@@ -394,11 +413,8 @@ describe("Ajv", () => {
       ajv._cache.get(schema3).should.be.an("object")
 
       ajv.removeSchema(/e\.com/)
-      should.not.exist(ajv.getSchema("//e.com/int.json"))
       //@ts-expect-error
       should.not.exist(ajv._cache.get(schema1))
-
-      should.not.exist(ajv.getSchema("//e.com/str.json"))
       //@ts-expect-error
       should.not.exist(ajv._cache.get(schema2))
       //@ts-expect-error

--- a/spec/ajv.spec.ts
+++ b/spec/ajv.spec.ts
@@ -313,8 +313,9 @@ describe("Ajv", () => {
       const v = ajv.getSchema("int")
       assert(typeof v == "function")
       v.should.be.a("function")
+
       //@ts-expect-error
-      ajv._cache.get(schema).validate.should.equal(v)
+      should.not.exist(ajv._cache.get(schema))
 
       ajv.removeSchema("int")
       should.not.exist(ajv.getSchema("int"))
@@ -329,8 +330,6 @@ describe("Ajv", () => {
       const v = ajv.getSchema("//e.com/int.json")
       assert(typeof v == "function")
       v.should.be.a("function")
-      //@ts-expect-error
-      ajv._cache.get(schema).validate.should.equal(v)
 
       ajv.removeSchema("//e.com/int.json")
       should.not.exist(ajv.getSchema("//e.com/int.json"))
@@ -339,20 +338,17 @@ describe("Ajv", () => {
     })
 
     it("should remove schema by schema object", () => {
-      const schema = {type: "integer"}
+      const schema = {$id: "//e.com/object_test.json", type: "integer"}
       ajv.addSchema(schema)
-      //@ts-expect-error
-      ajv._cache.get(schema).should.be.an("object")
       ajv.removeSchema(schema)
       //@ts-expect-error
       should.not.exist(ajv._cache.get(schema))
+      should.not.exist(ajv.getSchema("//e.com/object_test.json"))
     })
 
     it("should remove schema with id by schema object", () => {
       const schema = {$id: "//e.com/int.json", type: "integer"}
       ajv.addSchema(schema)
-      //@ts-expect-error
-      ajv._cache.get(schema).should.be.an("object")
       ajv.removeSchema(schema)
       should.not.exist(ajv.getSchema("//e.com/int.json"))
       //@ts-expect-error
@@ -369,8 +365,7 @@ describe("Ajv", () => {
     it("should remove all schemas but meta-schemas if called without an arguments", () => {
       const schema1 = {$id: "//e.com/int.json", type: "integer"}
       ajv.addSchema(schema1)
-      //@ts-expect-error
-      ajv._cache.get(schema1).should.be.an("object")
+      ajv.getSchema("//e.com/int.json")!.should.be.an("function")
 
       const schema2 = {type: "integer"}
       ajv.addSchema(schema2)
@@ -378,8 +373,7 @@ describe("Ajv", () => {
       ajv._cache.get(schema2).should.be.an("object")
 
       ajv.removeSchema()
-      //@ts-expect-error
-      should.not.exist(ajv._cache.get(schema1))
+      should.not.exist(ajv.getSchema("//e.com/int.json"))
       //@ts-expect-error
       should.not.exist(ajv._cache.get(schema2))
     })
@@ -387,13 +381,12 @@ describe("Ajv", () => {
     it("should remove all schemas but meta-schemas with key/id matching pattern", () => {
       const schema1 = {$id: "//e.com/int.json", type: "integer"}
       ajv.addSchema(schema1)
-      //@ts-expect-error
-      ajv._cache.get(schema1).should.be.an("object")
+      ajv.getSchema("//e.com/int.json")!.should.be.an("function")
 
       const schema2 = {$id: "str.json", type: "string"}
       ajv.addSchema(schema2, "//e.com/str.json")
       //@ts-expect-error
-      ajv._cache.get(schema2).should.be.an("object")
+      ajv.getSchema("//e.com/str.json").should.be.an("function")
 
       const schema3 = {type: "integer"}
       ajv.addSchema(schema3)
@@ -401,8 +394,11 @@ describe("Ajv", () => {
       ajv._cache.get(schema3).should.be.an("object")
 
       ajv.removeSchema(/e\.com/)
+      should.not.exist(ajv.getSchema("//e.com/int.json"))
       //@ts-expect-error
       should.not.exist(ajv._cache.get(schema1))
+
+      should.not.exist(ajv.getSchema("//e.com/str.json"))
       //@ts-expect-error
       should.not.exist(ajv._cache.get(schema2))
       //@ts-expect-error

--- a/spec/standalone.spec.ts
+++ b/spec/standalone.spec.ts
@@ -129,6 +129,16 @@ describe("standalone code generation", () => {
         assert.strictEqual(Object.keys(m).length, 2)
         testExports(m)
       })
+
+      it("should generate module code with all exports when noCache option enabled", () => {
+        ajv = new _Ajv({code: {source: true}, noCache: true})
+        ajv.addSchema(numSchema, "validateNumber")
+        ajv.addSchema(strSchema, "validateString")
+        const moduleCode = standaloneCode(ajv)
+        const m = requireFromString(moduleCode)
+        assert.strictEqual(Object.keys(m).length, 2)
+        testExports(m)
+      })
     })
 
     function testExports(m: {[n: string]: AnyValidateFunction<unknown>}) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

https://github.com/ajv-validator/ajv/issues/2554#issue-3079986159

**What changes did you make?**

Implemented `noCache` instance option, allowing users to avoid using internal cache to minimise unnecessary memory usage in applications with lots of large schemas.

The `addSchema` function allows users to cache schemas under a user-defined key or the `schemaId` value. However, if users choose to use this more efficient key system, the whole schema is still entered into the internal `_cache`, meaning:
- `SchemaEnv` object is stored twice, in `Ajv.schemas` and in `Ajv._cache`
- The schema object is stored as `Ajv._cache` key

For large schemas this is less memory efficient than using `compile` alone. By adding the `noCache` option, this allows users to re-use validation functions through  `addSchema` and `getSchema` without having to store entire schemas in `Ajv._cache` keys.
