### PR TITLE
fix: `multipleOf` validation for large integers

### DIFF
--- a/lib/vocabularies/validation/multipleOf.ts
+++ b/lib/vocabularies/validation/multipleOf.ts
@@ -26,7 +26,7 @@ const def: CodeKeywordDefinition = {
     const res = gen.let("res")
     const invalid = prec
       ? _`Math.abs(Math.round(${res}) - ${res}) > 1e-${prec}`
-      : _`${res} !== parseInt(${res})`
+      : _`${res} % 1 !== 0`
     cxt.fail$data(_`(${schemaCode} === 0 || (${res} = ${data}/${schemaCode}, ${invalid}))`)
   },
 }

--- a/spec/tests/issues/large_integer_with_multiple_of.json
+++ b/spec/tests/issues/large_integer_with_multiple_of.json
@@ -1,0 +1,13 @@
+[
+  {
+    "description": "large integer is multiple of 1",
+    "schema": {"multipleOf": 1},
+    "tests": [
+      {
+        "description": "1e21 is multiple of 1",
+        "data": 1e21,
+        "valid": true
+      }
+    ]
+  }
+]


### PR DESCRIPTION
**What issue does this pull request resolve?**

https://github.com/ajv-validator/ajv/issues/2561

**What changes did you make?**

I modified the `multipleOf` to be correct and added a test.

**Is there anything that requires more attention while reviewing?**

As far as I can tell the issue has always been there ([since this commit](https://github.com/ajv-validator/ajv/commit/26abbd96d2260b3c878fb78d662e9616ea8c79e5))

Using `res !== parseInt(res)` to check where `res` is a decimal number is not reliable because large numbers like `1e21` stringify to `"1e21"` and `parseInt("1e21")` is just `1`...