### PR TITLE
fix: resolve $dynamicRef to $dynamicAnchor in $defs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [16.x, 18.x, 20.x, 21.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 21.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
       - run: npm install
       - run: git submodule update --init
       - name: update website
-        if: ${{ github.event_name == 'push' && matrix.node-version == '16.x' }}
+        if: ${{ github.event_name == 'push' && matrix.node-version == '22.x' }}
         run: ./scripts/publish-site
         env:
           GH_TOKEN_PUBLIC: ${{ secrets.GH_TOKEN_PUBLIC }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 21.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/lib/vocabularies/dynamic/dynamicRef.ts
+++ b/lib/vocabularies/dynamic/dynamicRef.ts
@@ -51,9 +51,8 @@ export function dynamicRef(cxt: KeywordCxt, ref: string): void {
       // Pre-register if we just compiled the anchor schema
       if (anchorValidate) {
         const av = anchorValidate
-        gen.if(
-          _`!${N.dynamicAnchors}${getProperty(anchor)}`,
-          () => gen.assign(_`${N.dynamicAnchors}${getProperty(anchor)}`, av)
+        gen.if(_`!${N.dynamicAnchors}${getProperty(anchor)}`, () =>
+          gen.assign(_`${N.dynamicAnchors}${getProperty(anchor)}`, av)
         )
       }
       // Dynamic lookup at runtime

--- a/lib/vocabularies/dynamic/dynamicRef.ts
+++ b/lib/vocabularies/dynamic/dynamicRef.ts
@@ -38,7 +38,7 @@ export function dynamicRef(cxt: KeywordCxt, ref: string): void {
     // Step 2: If found in localRefs but not yet compiled, compile it
     let anchorValidate: Code | undefined
     if (anchorSchema && !it.schemaEnv.root.dynamicAnchors[anchor]) {
-      const sch = compileAnchorSchema(cxt, anchorSchema, anchor)
+      const sch = compileAnchorSchema(anchorSchema)
       if (sch) {
         anchorValidate = getValidate(cxt, sch)
         // Mark as having dynamic anchor so we use dynamic lookup
@@ -63,12 +63,7 @@ export function dynamicRef(cxt: KeywordCxt, ref: string): void {
     }
   }
 
-  function compileAnchorSchema(
-    cxt: KeywordCxt,
-    schema: AnySchema,
-    _anchor: string
-  ): SchemaEnv | undefined {
-    const {it} = cxt
+  function compileAnchorSchema(schema: AnySchema): SchemaEnv | undefined {
     const {schemaEnv, self} = it
     const {root, baseId, localRefs, meta} = schemaEnv.root
     const {schemaId} = self.opts

--- a/lib/vocabularies/dynamic/dynamicRef.ts
+++ b/lib/vocabularies/dynamic/dynamicRef.ts
@@ -1,8 +1,9 @@
-import type {CodeKeywordDefinition} from "../../types"
+import type {AnySchema, CodeKeywordDefinition} from "../../types"
 import type {KeywordCxt} from "../../compile/validate"
 import {_, getProperty, Code, Name} from "../../compile/codegen"
 import N from "../../compile/names"
-import {callRef} from "../core/ref"
+import {callRef, getValidate} from "../core/ref"
+import {SchemaEnv, compileSchema} from "../../compile"
 
 const def: CodeKeywordDefinition = {
   keyword: "$dynamicRef",
@@ -29,12 +30,53 @@ export function dynamicRef(cxt: KeywordCxt, ref: string): void {
     // Because of that 2 tests in recursiveRef.json fail.
     // This is a similar problem to #815 (`$id` doesn't alter resolution scope for `{ "$ref": "#" }`).
     // (This problem is not tested in JSON-Schema-Test-Suite)
+
+    // Step 1: Try to resolve anchor from localRefs if not already compiled
+    const anchorRef = `#${anchor}`
+    const anchorSchema = it.schemaEnv.root.localRefs?.[anchorRef]
+
+    // Step 2: If found in localRefs but not yet compiled, compile it
+    let anchorValidate: Code | undefined
+    if (anchorSchema && !it.schemaEnv.root.dynamicAnchors[anchor]) {
+      const sch = compileAnchorSchema(cxt, anchorSchema, anchor)
+      if (sch) {
+        anchorValidate = getValidate(cxt, sch)
+        // Mark as having dynamic anchor so we use dynamic lookup
+        it.schemaEnv.root.dynamicAnchors[anchor] = true
+      }
+    }
+
+    // Step 3: Generate dynamic lookup code
     if (it.schemaEnv.root.dynamicAnchors[anchor]) {
+      // Pre-register if we just compiled the anchor schema
+      if (anchorValidate) {
+        const av = anchorValidate
+        gen.if(
+          _`!${N.dynamicAnchors}${getProperty(anchor)}`,
+          () => gen.assign(_`${N.dynamicAnchors}${getProperty(anchor)}`, av)
+        )
+      }
+      // Dynamic lookup at runtime
       const v = gen.let("_v", _`${N.dynamicAnchors}${getProperty(anchor)}`)
       gen.if(v, _callRef(v, valid), _callRef(it.validateName, valid))
     } else {
       _callRef(it.validateName, valid)()
     }
+  }
+
+  function compileAnchorSchema(
+    cxt: KeywordCxt,
+    schema: AnySchema,
+    _anchor: string
+  ): SchemaEnv | undefined {
+    const {it} = cxt
+    const {schemaEnv, self} = it
+    const {root, baseId, localRefs, meta} = schemaEnv.root
+    const {schemaId} = self.opts
+
+    const sch = new SchemaEnv({schema, schemaId, root, baseId, localRefs, meta})
+    compileSchema.call(self, sch)
+    return sch
   }
 
   function _callRef(validate: Code, valid?: Name): () => void {

--- a/spec/dynamic-ref.spec.ts
+++ b/spec/dynamic-ref.spec.ts
@@ -43,6 +43,32 @@ describe("recursiveRef and dynamicRef", () => {
   })
 
   describe("dynamicRef", () => {
+    it("should resolve $dynamicRef to $dynamicAnchor in $defs", () => {
+      // This test demonstrates the bug: $dynamicAnchor in $defs is not found by $dynamicRef
+      // because schemas in $defs are only compiled when referenced by $ref
+      const schema = {
+        type: "object",
+        properties: {
+          test: {$dynamicRef: "#meta"},
+        },
+        $defs: {
+          schema: {
+            $dynamicAnchor: "meta",
+            type: ["object", "boolean"],
+          },
+        },
+      }
+
+      ajvs.forEach((ajv) => {
+        const validate = ajv.compile(schema)
+        // $dynamicRef should resolve to the $defs/schema which allows object or boolean
+        assert.strictEqual(validate({test: true}), true, "boolean should be valid")
+        assert.strictEqual(validate({test: {}}), true, "object should be valid")
+        assert.strictEqual(validate({test: "string"}), false, "string should be invalid")
+        assert.strictEqual(validate({test: 123}), false, "number should be invalid")
+      })
+    })
+
     it("should allow extending recursive schema with dynamicRef (future draft2020)", () => {
       const treeSchema = {
         $id: "https://example.com/tree",


### PR DESCRIPTION
Just testing

$dynamicRef failed to find $dynamicAnchor when it was defined in non-root locations like $defs because schemas in $defs are only compiled when referenced by $ref. This fix looks up the anchor schema in localRefs during $dynamicRef compilation and compiles it if found.
