### PR TITLE
Fix: ignore undefined values in schema properties

### DIFF
--- a/lib/vocabularies/code.ts
+++ b/lib/vocabularies/code.ts
@@ -63,7 +63,9 @@ export function noPropertyInData(
 }
 
 export function allSchemaProperties(schemaMap?: SchemaMap): string[] {
-  return schemaMap ? Object.keys(schemaMap).filter((p) => p !== "__proto__" && schemaMap[p] !== undefined) : []
+  return schemaMap
+    ? Object.keys(schemaMap).filter((p) => p !== "__proto__" && schemaMap[p] !== undefined)
+    : []
 }
 
 export function schemaProperties(it: SchemaCxt, schemaMap: SchemaMap): string[] {

--- a/lib/vocabularies/code.ts
+++ b/lib/vocabularies/code.ts
@@ -63,7 +63,7 @@ export function noPropertyInData(
 }
 
 export function allSchemaProperties(schemaMap?: SchemaMap): string[] {
-  return schemaMap ? Object.keys(schemaMap).filter((p) => p !== "__proto__") : []
+  return schemaMap ? Object.keys(schemaMap).filter((p) => p !== "__proto__" && schemaMap[p] !== undefined) : []
 }
 
 export function schemaProperties(it: SchemaCxt, schemaMap: SchemaMap): string[] {

--- a/spec/issues/2578_undefined_schema_properties.spec.ts
+++ b/spec/issues/2578_undefined_schema_properties.spec.ts
@@ -27,12 +27,12 @@ describe("issue #2578, undefined values in schemas should be ignored", () => {
         baz: {type: "number"},
       },
     }
-    
+
     // Valid data
     const data1 = {foo: "FOO", baz: 42}
     const valid1 = ajv.validate(schema, data1)
     valid1.should.equal(true)
-    
+
     // Invalid data (wrong type for foo)
     const data2: any = {foo: 123, baz: 42}
     const valid2 = ajv.validate(schema, data2)
@@ -63,7 +63,7 @@ describe("issue #2578, undefined values in schemas should be ignored", () => {
   it("should handle undefined properties from destructuring", () => {
     const ajv = new _Ajv({strictSchema: false, validateSchema: false})
     // Simulating a common scenario where properties come from destructuring
-    const optionalProp: any = (undefined as any)
+    const optionalProp: any = undefined as any
     const schema = {
       type: "object",
       properties: {

--- a/spec/issues/2578_undefined_schema_properties.spec.ts
+++ b/spec/issues/2578_undefined_schema_properties.spec.ts
@@ -1,0 +1,79 @@
+import _Ajv from "../ajv"
+import chai from "../chai"
+chai.should()
+
+describe("issue #2578, undefined values in schemas should be ignored", () => {
+  it("should ignore undefined properties in schema", () => {
+    const ajv = new _Ajv({strictSchema: false, validateSchema: false})
+    const schema = {
+      type: "object",
+      properties: {
+        foo: {type: "string"},
+        bar: undefined,
+      },
+    }
+    const data = {foo: "FOO"}
+    const valid = ajv.validate(schema, data)
+    valid.should.equal(true)
+  })
+
+  it("should still validate defined properties when undefined properties exist", () => {
+    const ajv = new _Ajv({strictSchema: false, validateSchema: false})
+    const schema = {
+      type: "object",
+      properties: {
+        foo: {type: "string"},
+        bar: undefined,
+        baz: {type: "number"},
+      },
+    }
+    
+    // Valid data
+    const data1 = {foo: "FOO", baz: 42}
+    const valid1 = ajv.validate(schema, data1)
+    valid1.should.equal(true)
+    
+    // Invalid data (wrong type for foo)
+    const data2: any = {foo: 123, baz: 42}
+    const valid2 = ajv.validate(schema, data2)
+    valid2.should.equal(false)
+    chai.should().exist(ajv.errors)
+    ajv.errors?.should.have.length(1)
+    ajv.errors?.[0].should.have.property("keyword", "type")
+    ajv.errors?.[0].should.have.property("instancePath", "/foo")
+  })
+
+  it("should handle multiple undefined properties", () => {
+    const ajv = new _Ajv({strictSchema: false, validateSchema: false})
+    const schema = {
+      type: "object",
+      properties: {
+        a: undefined,
+        b: {type: "string"},
+        c: undefined,
+        d: {type: "number"},
+        e: undefined,
+      },
+    }
+    const data = {b: "test", d: 99}
+    const valid = ajv.validate(schema, data)
+    valid.should.equal(true)
+  })
+
+  it("should handle undefined properties from destructuring", () => {
+    const ajv = new _Ajv({strictSchema: false, validateSchema: false})
+    // Simulating a common scenario where properties come from destructuring
+    const optionalProp: any = (undefined as any)
+    const schema = {
+      type: "object",
+      properties: {
+        name: {type: "string"},
+        age: {type: "number"},
+        optional: optionalProp, // undefined
+      },
+    }
+    const data = {name: "John", age: 30}
+    const valid = ajv.validate(schema, data)
+    valid.should.equal(true)
+  })
+})


### PR DESCRIPTION
## Summary

This PR fixes issue #2578 where schemas with undefined property values (commonly from destructuring) cause ajv to throw a TypeError instead of ignoring them.

**Before:**
```js
const ajv = new Ajv({strictSchema: false, validateSchema: false});
const schema = {
  type: 'object',
  properties: {
    foo: {type: 'string'},
    bar: undefined  // From destructuring or conditional logic
  }
};
ajv.validate(schema, {foo: 'test'}); // Throws: "Cannot convert undefined or null to object"
```

**After:**
```js
ajv.validate(schema, {foo: 'test'}); // Returns: true (undefined properties ignored)
```

## Changes

- Modified `allSchemaProperties()` in `lib/vocabularies/code.ts` to filter out undefined values
- Added comprehensive test coverage for various scenarios with undefined schema properties

## Test Coverage

The fix includes tests for:
- Basic undefined property handling
- Multiple undefined properties
- Validation still works correctly for defined properties
- Undefined values from destructuring scenarios

## Manual Testing

Verified the fix handles:
- Single undefined properties
- Multiple undefined properties mixed with valid ones
- Validation errors still work correctly for defined properties
- Pattern properties with undefined values

Closes #2578