### PR TITLE
fixesIssue #2579

### DIFF
--- a/lib/vocabularies/applicator/oneOf.ts
+++ b/lib/vocabularies/applicator/oneOf.ts
@@ -4,20 +4,20 @@ import type {
   KeywordErrorDefinition,
   AnySchema,
 } from "../../types"
-import type { KeywordCxt } from "../../compile/validate"
-import { _, Name } from "../../compile/codegen"
-import { alwaysValidSchema, mergeEvaluated } from "../../compile/util"
-import { SchemaCxt } from "../../compile"
+import type {KeywordCxt} from "../../compile/validate"
+import {_, Name} from "../../compile/codegen"
+import {alwaysValidSchema, mergeEvaluated} from "../../compile/util"
+import {SchemaCxt} from "../../compile"
 
 export type OneOfError = ErrorObject<
   "oneOf",
-  { passingSchemas: [number, number] | null },
+  {passingSchemas: [number, number] | null},
   AnySchema[]
 >
 
 const error: KeywordErrorDefinition = {
   message: "must match exactly one schema in oneOf",
-  params: ({ params }) => _`{passingSchemas: ${params.passing}}`,
+  params: ({params}) => _`{passingSchemas: ${params.passing}}`,
 }
 
 const def: CodeKeywordDefinition = {
@@ -26,7 +26,7 @@ const def: CodeKeywordDefinition = {
   trackErrors: true,
   error,
   code(cxt: KeywordCxt) {
-    const { gen, schema, parentSchema, it } = cxt
+    const {gen, schema, parentSchema, it} = cxt
     /* istanbul ignore if */
     if (!Array.isArray(schema)) throw new Error("ajv implementation error")
     if (it.opts.discriminator && parentSchema.discriminator) return
@@ -34,7 +34,7 @@ const def: CodeKeywordDefinition = {
     const valid = gen.let("valid", false)
     const passing = gen.let("passing", null)
     const schValid = gen.name("_valid")
-    cxt.setParams({ passing })
+    cxt.setParams({passing})
     // TODO possibly fail straight away (with warning or exception) if there are two empty always valid schemas
 
     gen.block(validateOneOf)
@@ -108,4 +108,3 @@ const def: CodeKeywordDefinition = {
 }
 
 export default def
-

--- a/lib/vocabularies/applicator/oneOf.ts
+++ b/lib/vocabularies/applicator/oneOf.ts
@@ -4,20 +4,20 @@ import type {
   KeywordErrorDefinition,
   AnySchema,
 } from "../../types"
-import type {KeywordCxt} from "../../compile/validate"
-import {_, Name} from "../../compile/codegen"
-import {alwaysValidSchema} from "../../compile/util"
-import {SchemaCxt} from "../../compile"
+import type { KeywordCxt } from "../../compile/validate"
+import { _, Name } from "../../compile/codegen"
+import { alwaysValidSchema, mergeEvaluated } from "../../compile/util"
+import { SchemaCxt } from "../../compile"
 
 export type OneOfError = ErrorObject<
   "oneOf",
-  {passingSchemas: [number, number] | null},
+  { passingSchemas: [number, number] | null },
   AnySchema[]
 >
 
 const error: KeywordErrorDefinition = {
   message: "must match exactly one schema in oneOf",
-  params: ({params}) => _`{passingSchemas: ${params.passing}}`,
+  params: ({ params }) => _`{passingSchemas: ${params.passing}}`,
 }
 
 const def: CodeKeywordDefinition = {
@@ -26,7 +26,7 @@ const def: CodeKeywordDefinition = {
   trackErrors: true,
   error,
   code(cxt: KeywordCxt) {
-    const {gen, schema, parentSchema, it} = cxt
+    const { gen, schema, parentSchema, it } = cxt
     /* istanbul ignore if */
     if (!Array.isArray(schema)) throw new Error("ajv implementation error")
     if (it.opts.discriminator && parentSchema.discriminator) return
@@ -34,7 +34,7 @@ const def: CodeKeywordDefinition = {
     const valid = gen.let("valid", false)
     const passing = gen.let("passing", null)
     const schValid = gen.name("_valid")
-    cxt.setParams({passing})
+    cxt.setParams({ passing })
     // TODO possibly fail straight away (with warning or exception) if there are two empty always valid schemas
 
     gen.block(validateOneOf)
@@ -74,9 +74,38 @@ const def: CodeKeywordDefinition = {
           gen.assign(passing, i)
           if (schCxt) cxt.mergeEvaluated(schCxt, Name)
         })
+
+        // Merge statically known evaluated properties from all branches
+        // (including failing ones) per Draft 2020-12 §6.5.3.2.2.
+        // Only static property hashes are merged unconditionally;
+        // dynamic (Name) or universal (true) props are kept gated on
+        // schValid above, as they may come from applicators like
+        // unevaluatedProperties: true that should not propagate from
+        // failing branches.
+        if (schCxt && it.opts.unevaluated) {
+          if (
+            schCxt.props !== undefined &&
+            schCxt.props !== true &&
+            !(schCxt.props instanceof Name)
+          ) {
+            if (it.props !== true) {
+              it.props = mergeEvaluated.props(gen, schCxt.props, it.props)
+            }
+          }
+          if (
+            schCxt.items !== undefined &&
+            schCxt.items !== true &&
+            !(schCxt.items instanceof Name)
+          ) {
+            if (it.items !== true) {
+              it.items = mergeEvaluated.items(gen, schCxt.items, it.items)
+            }
+          }
+        }
       })
     }
   },
 }
 
 export default def
+

--- a/spec/issues/2579_oneOf_unevaluated_properties.spec.ts
+++ b/spec/issues/2579_oneOf_unevaluated_properties.spec.ts
@@ -1,0 +1,44 @@
+import _Ajv from "../ajv2020"
+import * as assert from "assert"
+
+describe("oneOf should track evaluated properties from all branches (issue #2579)", () => {
+    const ajv = new _Ajv()
+
+    const schema = {
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        type: "object",
+        oneOf: [
+            {
+                properties: { a: { type: "string" } },
+                required: ["a", "x"],
+            },
+            {
+                properties: { b: { type: "number" } },
+                required: ["b"],
+            },
+        ],
+        unevaluatedProperties: false,
+    }
+
+    const validate = ajv.compile(schema)
+
+    it("should accept instance where all properties are evaluated across branches", () => {
+        // Subschema 0 evaluates "a" but fails (missing "x").
+        // Subschema 1 evaluates "b" and passes.
+        // Both "a" and "b" are evaluated, so unevaluatedProperties: false should pass.
+        assert.strictEqual(validate({ a: "test", b: 42 }), true)
+    })
+
+    it("should reject instance with truly unevaluated properties", () => {
+        assert.strictEqual(validate({ b: 42, c: "extra" }), false)
+    })
+
+    it("should still require exactly one subschema to pass", () => {
+        // Neither subschema passes: missing both required "x" and "b".
+        assert.strictEqual(validate({ a: "test" }), false)
+    })
+
+    it("should work when only the passing branch has properties", () => {
+        assert.strictEqual(validate({ b: 42 }), true)
+    })
+})

--- a/spec/issues/2579_oneOf_unevaluated_properties.spec.ts
+++ b/spec/issues/2579_oneOf_unevaluated_properties.spec.ts
@@ -2,43 +2,43 @@ import _Ajv from "../ajv2020"
 import * as assert from "assert"
 
 describe("oneOf should track evaluated properties from all branches (issue #2579)", () => {
-    const ajv = new _Ajv()
+  const ajv = new _Ajv()
 
-    const schema = {
-        $schema: "https://json-schema.org/draft/2020-12/schema",
-        type: "object",
-        oneOf: [
-            {
-                properties: { a: { type: "string" } },
-                required: ["a", "x"],
-            },
-            {
-                properties: { b: { type: "number" } },
-                required: ["b"],
-            },
-        ],
-        unevaluatedProperties: false,
-    }
+  const schema = {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "object",
+    oneOf: [
+      {
+        properties: {a: {type: "string"}},
+        required: ["a", "x"],
+      },
+      {
+        properties: {b: {type: "number"}},
+        required: ["b"],
+      },
+    ],
+    unevaluatedProperties: false,
+  }
 
-    const validate = ajv.compile(schema)
+  const validate = ajv.compile(schema)
 
-    it("should accept instance where all properties are evaluated across branches", () => {
-        // Subschema 0 evaluates "a" but fails (missing "x").
-        // Subschema 1 evaluates "b" and passes.
-        // Both "a" and "b" are evaluated, so unevaluatedProperties: false should pass.
-        assert.strictEqual(validate({ a: "test", b: 42 }), true)
-    })
+  it("should accept instance where all properties are evaluated across branches", () => {
+    // Subschema 0 evaluates "a" but fails (missing "x").
+    // Subschema 1 evaluates "b" and passes.
+    // Both "a" and "b" are evaluated, so unevaluatedProperties: false should pass.
+    assert.strictEqual(validate({a: "test", b: 42}), true)
+  })
 
-    it("should reject instance with truly unevaluated properties", () => {
-        assert.strictEqual(validate({ b: 42, c: "extra" }), false)
-    })
+  it("should reject instance with truly unevaluated properties", () => {
+    assert.strictEqual(validate({b: 42, c: "extra"}), false)
+  })
 
-    it("should still require exactly one subschema to pass", () => {
-        // Neither subschema passes: missing both required "x" and "b".
-        assert.strictEqual(validate({ a: "test" }), false)
-    })
+  it("should still require exactly one subschema to pass", () => {
+    // Neither subschema passes: missing both required "x" and "b".
+    assert.strictEqual(validate({a: "test"}), false)
+  })
 
-    it("should work when only the passing branch has properties", () => {
-        assert.strictEqual(validate({ b: 42 }), true)
-    })
+  it("should work when only the passing branch has properties", () => {
+    assert.strictEqual(validate({b: 42}), true)
+  })
 })


### PR DESCRIPTION
**What issue does this pull request resolve?**

Fixes #2579.

When `oneOf` is combined with `unevaluatedProperties: false`, Ajv previously merged evaluation results only from the subschema that validated.  
According to Draft 2020-12 §6.5.3.2.2, instance locations processed by an applicator should be considered evaluated regardless of whether that subschema ultimately succeeds.  
Because of this, properties handled in failing branches could later be rejected as unevaluated.



**What changes did you make?**

The `oneOf` validity rule (exactly one subschema must pass) is unchanged.

This PR updates evaluation propagation so that information from processed subschemas is not lost.  
For failing branches, only statically known evaluated properties/items are merged.  
Dynamic or universal evaluations (e.g. represented by `Name` or `true`) remain gated on `schValid`, preserving Ajv’s existing scoping expectations and preventing leakage from branches that do not contribute to the result.

I also added a regression test covering the reported scenario.



**Is there anything that requires more attention while reviewing?**

Evaluation propagation around composite keywords is subtle, especially with dynamic references.

I verified locally that:
- the reported false negative is resolved,
- the exactly-one constraint is unaffected,
- the full test suite remains green.



