### PR TITLE
fix(security): backport CVE-2025-69873 - wrap $data pattern in try/catch

### DIFF
--- a/lib/dot/pattern.jst
+++ b/lib/dot/pattern.jst
@@ -3,12 +3,24 @@
 {{# def.setupKeyword }}
 {{# def.$data }}
 
+{{? $isData }}
 {{
-  var $regexp = $isData
-                ? '(new RegExp(' + $schemaValue + '))'
-                : it.usePattern($schema);
+  var $regexp = '(new RegExp(' + $schemaValue + '))';
 }}
-
+var patternValid;
+try {
+  patternValid = {{=$regexp}}.test({{=$data}});
+} catch (e) {
+  patternValid = false;
+}
+if ({{# def.$dataNotType:'string' }} !patternValid ) {
+  {{# def.error:'pattern' }}
+} {{? $breakOnError }} else { {{?}}
+{{??}}
+{{
+  var $regexp = it.usePattern($schema);
+}}
 if ({{# def.$dataNotType:'string' }} !{{=$regexp}}.test({{=$data}}) ) {
   {{# def.error:'pattern' }}
 } {{? $breakOnError }} else { {{?}}
+{{?}}

--- a/spec/issues/cve_2025_69873_redos_attack.spec.js
+++ b/spec/issues/cve_2025_69873_redos_attack.spec.js
@@ -1,0 +1,107 @@
+'use strict';
+
+var Ajv = require('../ajv');
+require('../chai').should();
+
+describe('CVE-2025-69873: ReDoS Attack Scenario', function() {
+  it('should handle pattern injection gracefully with default engine (try/catch)', function() {
+    var ajv = new Ajv({ $data: true });
+
+    var schema = {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string' },
+        value: { type: 'string', pattern: { $data: '1/pattern' } },
+      },
+    };
+
+    var validate = ajv.compile(schema);
+
+    // CVE-2025-69873 Attack Payload:
+    // Pattern: ^(a|a)*$ - catastrophic backtracking regex
+    // Value: 20 a's + X - reduced size to avoid hanging; try/catch prevents throw
+    var maliciousPayload = {
+      pattern: '^(a|a)*$',
+      value: 'a'.repeat(20) + 'X',
+    };
+
+    var start = Date.now();
+    var result = validate(maliciousPayload);
+    var elapsed = Date.now() - start;
+
+    // Should fail validation (pattern doesn't match)
+    result.should.equal(false);
+    // Should complete without throwing (try/catch in $data pattern path)
+    elapsed.should.be.below(10000);
+  });
+
+  it('should fail gracefully on invalid regex syntax in $data pattern', function() {
+    var ajv = new Ajv({ $data: true });
+
+    var schema = {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string' },
+        value: { type: 'string', pattern: { $data: '1/pattern' } },
+      },
+    };
+
+    var validate = ajv.compile(schema);
+
+    // Invalid regex syntax - RegExp constructor throws, try/catch should catch and fail validation
+    var invalidPatterns = ['[invalid', '(?(1)a|b)'];
+
+    for (var i = 0; i < invalidPatterns.length; i++) {
+      var result = validate({
+        pattern: invalidPatterns[i],
+        value: 'test',
+      });
+      result.should.equal(false);
+    }
+  });
+
+  it('should still validate valid patterns correctly with $data', function() {
+    var ajv = new Ajv({ $data: true });
+
+    var schema = {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string' },
+        value: { type: 'string', pattern: { $data: '1/pattern' } },
+      },
+    };
+
+    var validate = ajv.compile(schema);
+
+    validate({ pattern: '^[a-z]+$', value: 'abc' }).should.equal(true);
+    validate({ pattern: '^[a-z]+$', value: 'ABC' }).should.equal(false);
+    validate({ pattern: '^\\d{3}-\\d{4}$', value: '123-4567' }).should.equal(true);
+    validate({ pattern: '^\\d{3}-\\d{4}$', value: '12-345' }).should.equal(false);
+  });
+
+  it('should process attack payload without throwing', function() {
+    var ajv = new Ajv({ $data: true });
+
+    var schema = {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string' },
+        value: { type: 'string', pattern: { $data: '1/pattern' } },
+      },
+    };
+
+    var validate = ajv.compile(schema);
+
+    var payload = {
+      pattern: '^(a|a)*$',
+      value: 'a'.repeat(18) + 'X',
+    };
+
+    var start = Date.now();
+    var result = validate(payload);
+    var elapsed = Date.now() - start;
+
+    result.should.equal(false);
+    elapsed.should.be.below(8000);
+  });
+});


### PR DESCRIPTION
**What issue does this pull request resolve?**
- CVE-2025-69873 (ReDoS in the pattern keyword when $data is enabled).
- With $data: true, the pattern value can come from validated data and is passed to new RegExp() without safeguards. That allows invalid regex syntax to throw and malicious patterns (e.g. ^(a|a)*$) to cause catastrophic backtracking (ReDoS).
- This PR backports the same class of fix already applied on the main branch (v8) in #2586 (commit 720a23fa).

**What changes did you make?**
- lib/dot/pattern.jst
   - When the pattern value comes from $data, the template now generates a try/catch around RegExp creation and .test().
   - If new RegExp(...) or .test() throws (e.g. invalid regex from user input), the catch sets the result to “invalid” so validation fails instead of throwing.
   - The non-$data path is unchanged (still uses it.usePattern($schema)).
- spec/issues/cve_2025_69873_redos_attack.spec.js
   - New spec (aligned with the approach in 720a23fa453ffae8340e92c9b0fe886c54cfe0d5) that:
      - Ensures the default engine handles the ReDoS-style payload without throwing and returns false (with a safe timeout).
      - Ensures invalid regex syntax in the $data pattern fails validation instead of throwing.
      - Ensures valid $data patterns still validate correctly.
      - Ensures the attack payload is processed without throwing and within a bounded time.
- After editing pattern.jst, npm run build was run so the compiled lib/dotjs/pattern.js is updated (if your workflow commits built output).

**Is there anything that requires more attention while reviewing?**
- Scope of the fix: The change only adds a try/catch on the $data path. It prevents throws from invalid or problematic patterns and makes validation fail safely. It does not remove ReDoS risk: a malicious pattern can still cause long runtimes via catastrophic backtracking; it just won’t throw. v8 also documents/supports a safe regex engine (e.g. RE2) for full ReDoS mitigation; v6 has no such option, so this backport is intentionally limited to the try/catch behavior.
- Tests: The new spec uses small repeat counts and generous time limits (e.g. &lt; 8–10s) so the suite doesn’t hang on slow CI while still asserting that the try/catch path is used and no throw occurs. Reviewers may want to run the new spec locally (`npx mocha spec/issues/cve_2025_69873_redos_attack.spec.js`) to confirm.