### PR TITLE
Fix: skip whitespace in empty array brackets

### DIFF
--- a/lib/compile/jtd/parse.ts
+++ b/lib/compile/jtd/parse.ts
@@ -128,6 +128,7 @@ function parseElements(cxt: ParseCxt): void {
   parseToken(cxt, "[")
   const ix = gen.let("i", 0)
   gen.assign(data, _`[]`)
+  skipWhitespace(cxt)
   parseItems(cxt, "]", () => {
     const el = gen.let("el")
     parseCode({...cxt, schema: schema.elements, data: el})


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
Fixes issue #2595 

**What changes did you make?**
Skip whitespace before parsing items within array, because the function that parses array, `parseItems`, assumes that if there is whitespace then there exists items to parse.

**Is there anything that requires more attention while reviewing?**
This fix might also be accomplished by adding the skip whitespaces call to `tryParseItems`, but `tryParseItems` is also used by `parseValues` function in the same file, and it is not clear if `parseValues` would require the same change (while testing parsing an empty `{ }` containing white space, the `parseJson` was used instead of `parseValues`, so I am not sure if this same bug appears in that path... I don't understand where `parseValues` is actually used).