### PR TITLE
fix: recursively check for validity of discriminator

### DIFF
--- a/lib/vocabularies/discriminator/index.ts
+++ b/lib/vocabularies/discriminator/index.ts
@@ -63,29 +63,86 @@ const def: CodeKeywordDefinition = {
     function getMapping(): {[T in string]?: number} {
       const oneOfMapping: {[T in string]?: number} = {}
       const topRequired = hasRequired(parentSchema)
-      let tagRequired = true
-      for (let i = 0; i < oneOf.length; i++) {
-        let sch = oneOf[i]
-        if (sch?.$ref && !schemaHasRulesButRef(sch, it.self.RULES)) {
-          const ref = sch.$ref
-          sch = resolveRef.call(it.self, it.schemaEnv.root, it.baseId, ref)
-          if (sch instanceof SchemaEnv) sch = sch.schema
-          if (sch === undefined) throw new MissingRefError(it.opts.uriResolver, it.baseId, ref)
-        }
-        const propSch = sch?.properties?.[tagName]
-        if (typeof propSch != "object") {
-          throw new Error(
-            `discriminator: oneOf subschemas (or referenced schemas) must have "properties/${tagName}"`
-          )
-        }
-        tagRequired = tagRequired && (topRequired || hasRequired(sch))
-        addMappings(propSch, i)
-      }
+      const tagRequired = addOneOfMappings(oneOf, topRequired)
       if (!tagRequired) throw new Error(`discriminator: "${tagName}" must be required`)
       return oneOfMapping
 
       function hasRequired({required}: AnySchemaObject): boolean {
         return Array.isArray(required) && required.includes(tagName)
+      }
+
+      function resolveOneOfSchema(sch: AnySchemaObject): AnySchemaObject {
+        if (sch.$ref && !schemaHasRulesButRef(sch, it.self.RULES)) {
+          const ref = sch.$ref
+          const resolved = resolveRef.call(it.self, it.schemaEnv.root, it.baseId, ref)
+          const resolvedSchema = resolved instanceof SchemaEnv ? resolved.schema : resolved
+          if (resolvedSchema === undefined) {
+            throw new MissingRefError(it.opts.uriResolver, it.baseId, ref)
+          }
+          if (typeof resolvedSchema === "object") {
+            return resolvedSchema as AnySchemaObject
+          }
+          throw new Error(
+            `discriminator: oneOf subschemas (or referenced schemas) must have "properties/${tagName}"`
+          )
+        }
+        return sch
+      }
+
+      function findTagPropSchema(sch: AnySchemaObject): AnySchemaObject | undefined {
+        const propSch = sch.properties?.[tagName]
+        if (typeof propSch === "object") return propSch as AnySchemaObject
+        const candidates = sch.allOf ?? sch.anyOf
+        if (Array.isArray(candidates)) {
+          for (const subSch of candidates) {
+            const resolved = resolveOneOfSchema(subSch)
+            const found = findTagPropSchema(resolved)
+            if (found) return found
+          }
+        }
+        return undefined
+      }
+
+      function checkRequired(sch: AnySchemaObject, parentRequired: boolean): boolean {
+        if (parentRequired || hasRequired(sch)) return true
+        const candidates = sch.allOf ?? sch.anyOf
+        if (Array.isArray(candidates)) {
+          for (const subSch of candidates) {
+            const resolved = resolveOneOfSchema(subSch)
+            if (checkRequired(resolved, false)) return true
+          }
+        }
+        return false
+      }
+
+      function addOneOfMappings(
+        oneOfSubschemas: AnySchemaObject[],
+        parentRequired: boolean,
+        topLevelIndex?: number
+      ): boolean {
+        let allRequired = true
+        for (let i = 0; i < oneOfSubschemas.length; i++) {
+          const mappingIndex = topLevelIndex ?? i
+          const sch = resolveOneOfSchema(oneOfSubschemas[i])
+          const propSch = findTagPropSchema(sch)
+          if (typeof propSch === "object") {
+            allRequired = allRequired && checkRequired(sch, parentRequired)
+            addMappings(propSch, mappingIndex)
+          } else if (sch.oneOf && sch.discriminator?.propertyName === tagName) {
+            allRequired = allRequired && checkRequired(sch, parentRequired)
+            const nestedRequired = addOneOfMappings(
+              sch.oneOf as AnySchemaObject[],
+              hasRequired(sch),
+              mappingIndex
+            )
+            allRequired = allRequired && nestedRequired
+          } else {
+            throw new Error(
+              `discriminator: oneOf subschemas (or referenced schemas) must have "properties/${tagName}"`
+            )
+          }
+        }
+        return allRequired
       }
 
       function addMappings(sch: AnySchemaObject, i: number): void {

--- a/spec/discriminator.spec.ts
+++ b/spec/discriminator.spec.ts
@@ -302,6 +302,249 @@ describe("discriminator keyword", function () {
     })
   })
 
+  describe("validation with nested discriminator (union of unions)", () => {
+    const schema = [
+      {
+        type: "object",
+        discriminator: {propertyName: "type"},
+        required: ["type"],
+        oneOf: [
+          {
+            discriminator: {propertyName: "type"},
+            required: ["type"],
+            oneOf: [
+              {
+                properties: {
+                  type: {type: "string", const: "a"},
+                  fieldA: {type: "number"},
+                },
+                required: ["type", "fieldA"],
+              },
+              {
+                properties: {
+                  type: {type: "string", const: "b"},
+                  fieldB: {type: "number"},
+                },
+                required: ["type", "fieldB"],
+              },
+            ],
+          },
+          {
+            properties: {
+              type: {type: "string", const: "c"},
+              fieldC: {type: "number"},
+            },
+            required: ["type", "fieldC"],
+          },
+        ],
+      },
+    ]
+
+    it("should validate data", () => {
+      assertValid(schema, {type: "a", fieldA: 1})
+      assertValid(schema, {type: "b", fieldB: 2})
+      assertValid(schema, {type: "c", fieldC: 3})
+      assertInvalid(schema, {})
+      assertInvalid(schema, {type: 1})
+      assertInvalid(schema, {type: "unknown"})
+      assertInvalid(schema, {type: "a", fieldB: 1})
+      assertInvalid(schema, {type: "b", fieldA: 1})
+      assertInvalid(schema, {type: "c", fieldA: 1})
+    })
+  })
+
+  describe("validation with deeply nested discriminator (3 levels)", () => {
+    const schema = [
+      {
+        type: "object",
+        discriminator: {propertyName: "type"},
+        required: ["type"],
+        oneOf: [
+          {
+            discriminator: {propertyName: "type"},
+            required: ["type"],
+            oneOf: [
+              {
+                discriminator: {propertyName: "type"},
+                required: ["type"],
+                oneOf: [
+                  {
+                    properties: {
+                      type: {type: "string", const: "a"},
+                      fieldA: {type: "number"},
+                    },
+                    required: ["type", "fieldA"],
+                  },
+                  {
+                    properties: {
+                      type: {type: "string", const: "b"},
+                      fieldB: {type: "number"},
+                    },
+                    required: ["type", "fieldB"],
+                  },
+                ],
+              },
+              {
+                properties: {
+                  type: {type: "string", const: "c"},
+                  fieldC: {type: "number"},
+                },
+                required: ["type", "fieldC"],
+              },
+            ],
+          },
+          {
+            properties: {
+              type: {type: "string", const: "d"},
+              fieldD: {type: "number"},
+            },
+            required: ["type", "fieldD"],
+          },
+        ],
+      },
+    ]
+
+    it("should validate data", () => {
+      assertValid(schema, {type: "a", fieldA: 1})
+      assertValid(schema, {type: "b", fieldB: 2})
+      assertValid(schema, {type: "c", fieldC: 3})
+      assertValid(schema, {type: "d", fieldD: 4})
+      assertInvalid(schema, {})
+      assertInvalid(schema, {type: "unknown"})
+      assertInvalid(schema, {type: "a", fieldD: 1})
+    })
+  })
+
+  describe("validation with allOf subschemas", () => {
+    const schema = [
+      {
+        type: "object",
+        discriminator: {propertyName: "type"},
+        required: ["type"],
+        oneOf: [
+          {
+            allOf: [
+              {
+                properties: {
+                  type: {type: "string", const: "a"},
+                },
+              },
+              {
+                properties: {
+                  fieldA: {type: "number"},
+                },
+                required: ["fieldA"],
+              },
+            ],
+          },
+          {
+            properties: {
+              type: {type: "string", const: "b"},
+              fieldB: {type: "number"},
+            },
+            required: ["type", "fieldB"],
+          },
+        ],
+      },
+    ]
+
+    it("should validate data", () => {
+      assertValid(schema, {type: "a", fieldA: 1})
+      assertValid(schema, {type: "b", fieldB: 2})
+      assertInvalid(schema, {})
+      assertInvalid(schema, {type: 1})
+      assertInvalid(schema, {type: "unknown"})
+      assertInvalid(schema, {type: "a", fieldB: 1})
+      assertInvalid(schema, {type: "b", fieldA: 1})
+    })
+  })
+
+  describe("validation with anyOf subschemas", () => {
+    const schema = [
+      {
+        type: "object",
+        discriminator: {propertyName: "type"},
+        required: ["type"],
+        oneOf: [
+          {
+            anyOf: [
+              {
+                properties: {
+                  type: {type: "string", const: "a"},
+                },
+              },
+              {
+                properties: {
+                  fieldA: {type: "number"},
+                },
+                required: ["fieldA"],
+              },
+            ],
+          },
+          {
+            properties: {
+              type: {type: "string", const: "b"},
+              fieldB: {type: "number"},
+            },
+            required: ["type", "fieldB"],
+          },
+        ],
+      },
+    ]
+
+    it("should validate data", () => {
+      assertValid(schema, {type: "a", fieldA: 1})
+      assertValid(schema, {type: "b", fieldB: 2})
+      assertValid(schema, {type: "a", fieldB: 1}) // anyOf: first sub-part matches (type=a)
+      assertInvalid(schema, {})
+      assertInvalid(schema, {type: 1})
+      assertInvalid(schema, {type: "unknown"})
+      assertInvalid(schema, {type: "b", fieldA: 1})
+    })
+  })
+
+  describe("validation with allOf subschemas and required in composed schema", () => {
+    const schema = [
+      {
+        type: "object",
+        discriminator: {propertyName: "type"},
+        oneOf: [
+          {
+            allOf: [
+              {
+                properties: {
+                  type: {type: "string", const: "a"},
+                },
+                required: ["type"],
+              },
+              {
+                properties: {
+                  fieldA: {type: "number"},
+                },
+                required: ["fieldA"],
+              },
+            ],
+          },
+          {
+            properties: {
+              type: {type: "string", const: "b"},
+              fieldB: {type: "number"},
+            },
+            required: ["type", "fieldB"],
+          },
+        ],
+      },
+    ]
+
+    it("should validate data", () => {
+      assertValid(schema, {type: "a", fieldA: 1})
+      assertValid(schema, {type: "b", fieldB: 2})
+      assertInvalid(schema, {})
+      assertInvalid(schema, {type: "unknown"})
+      assertInvalid(schema, {type: "a", fieldB: 1})
+    })
+  })
+
   describe("valid schemas", () => {
     it("should have oneOf", () => {
       invalidSchema(
@@ -366,6 +609,98 @@ describe("discriminator keyword", function () {
           oneOf: [
             {properties: {foo: {const: "a"}}, required: ["foo"]},
             {properties: {foo: {const: "b"}}},
+          ],
+        },
+        /discriminator: "foo" must be required/
+      )
+    })
+
+    it("nested oneOf subschemas should have tag property", () => {
+      invalidSchema(
+        {
+          type: "object",
+          discriminator: {propertyName: "foo"},
+          required: ["foo"],
+          oneOf: [
+            {
+              discriminator: {propertyName: "foo"},
+              required: ["foo"],
+              oneOf: [
+                {properties: {foo: {const: "a"}}, required: ["foo"]},
+                {properties: {}, required: ["foo"]},
+              ],
+            },
+            {properties: {foo: {const: "c"}}, required: ["foo"]},
+          ],
+        },
+        /discriminator: oneOf subschemas \(or referenced schemas\) must have "properties\/foo"/
+      )
+    })
+
+    it("nested oneOf subschemas should have required tag", () => {
+      invalidSchema(
+        {
+          type: "object",
+          discriminator: {propertyName: "foo"},
+          oneOf: [
+            {
+              discriminator: {propertyName: "foo"},
+              oneOf: [
+                {properties: {foo: {const: "a"}}},
+                {properties: {foo: {const: "b"}}, required: ["foo"]},
+              ],
+            },
+            {properties: {foo: {const: "c"}}, required: ["foo"]},
+          ],
+        },
+        /discriminator: "foo" must be required/
+      )
+    })
+
+    it("allOf subschemas should have tag property", () => {
+      invalidSchema(
+        {
+          type: "object",
+          discriminator: {propertyName: "foo"},
+          required: ["foo"],
+          oneOf: [
+            {
+              allOf: [{properties: {bar: {type: "string"}}}],
+            },
+            {properties: {foo: {const: "b"}}, required: ["foo"]},
+          ],
+        },
+        /discriminator: oneOf subschemas \(or referenced schemas\) must have "properties\/foo"/
+      )
+    })
+
+    it("allOf subschemas should have const or enum for tag", () => {
+      invalidSchema(
+        {
+          type: "object",
+          discriminator: {propertyName: "foo"},
+          required: ["foo"],
+          oneOf: [
+            {
+              allOf: [{properties: {foo: {type: "string"}}}],
+            },
+            {properties: {foo: {const: "b"}}, required: ["foo"]},
+          ],
+        },
+        /discriminator: "properties\/foo" must have "const" or "enum"/
+      )
+    })
+
+    it("allOf subschemas should have required tag", () => {
+      invalidSchema(
+        {
+          type: "object",
+          discriminator: {propertyName: "foo"},
+          oneOf: [
+            {
+              allOf: [{properties: {foo: {const: "a"}}}, {properties: {bar: {type: "string"}}}],
+            },
+            {properties: {foo: {const: "b"}}, required: ["foo"]},
           ],
         },
         /discriminator: "foo" must be required/


### PR DESCRIPTION
The old implementation was only checking for a single level of validity of a schema using the discriminator extension, without accounting for "unions of unions". So, for example:

```json
{
  "discriminator": {
    "propertyName": "field"
  }
  "required": ["field"],
  "oneOf": [
    {
      "oneOf": [
        {
          "properties": {
            "field": { "const": "a" }
          },
          "required": ["field"]
        },
        {
          "properties": {
            "field": { "const": "b" }
          },
          "required": ["field"]
        }
      ],
      "required": ["field"]
    },
    {
      "properties": {
        "field": { "const": "c" }
      },
      "required": ["field"]
    }
  ]
}
```

This schema would fail because the compiler would complain about the first schema in `oneOf` not having the `field` property, which was defined as the `discriminator`. But it *does* have that property, just in a subschema inside another `oneOf` definition!