### PR TITLE
fix: add ES2022.RegExp for RegExpIndicesArray

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["lib"],
   "compilerOptions": {
     "outDir": "dist",
-    "lib": ["ES2018", "DOM"],
+    "lib": ["ES2018", "ES2022.RegExp", "DOM"],
     "types": ["node"],
     "allowJs": true,
     "target": "ES2018",


### PR DESCRIPTION
without ES2022.RegExp, `npm install` will fail due to RegExpIndicesArray not being present in the ES2018 lib.

Specifically:

```sh
$ npm install

> ajv@8.18.0 prepublish
> npm run build

> ajv@8.18.0 build
> rm -rf dist && tsc && cp -r lib/refs dist && rm dist/refs/json-schema-2019-09/index.ts && rm dist/refs/json-schema-2020-12/index.ts && rm dist/refs/jtd-schema.ts

node_modules/re2/re2.d.ts:11:15 - error TS2304: Cannot find name 'RegExpIndicesArray'.

11     indices?: RegExpIndicesArray;
                 ~~~~~~~~~~~~~~~~~~

Found 1 error in node_modules/re2/re2.d.ts:11
```

<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

#2603 

**What changes did you make?**

Added `"ES2022.RegExp"` to tsconfig.json's `compilerOptions.lib` array.

**Is there anything that requires more attention while reviewing?**
