### PR TITLE
fix TypeError with empty discriminator variants

### DIFF
--- a/lib/compile/jtd/parse.ts
+++ b/lib/compile/jtd/parse.ts
@@ -232,11 +232,14 @@ function parseSchemaProperties(cxt: ParseCxt, discriminator?: string): void {
     gen.endIf()
   })
   if (properties) {
-    const hasProp = hasPropFunc(gen)
-    const allProps: Code = and(
-      ...Object.keys(properties).map((p): Code => _`${hasProp}.call(${data}, ${p})`)
-    )
-    gen.if(not(allProps), () => parsingError(cxt, str`missing required properties`))
+    const keys = Object.keys(properties);
+    if (keys.length) {
+      const hasProp = hasPropFunc(gen)
+      const allProps: Code = and(
+        ...keys.map((p): Code => _`${hasProp}.call(${data}, ${p})`)
+      )
+      gen.if(not(allProps), () => parsingError(cxt, str`missing required properties`))
+    }
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
https://github.com/ajv-validator/ajv/issues/2609

**What changes did you make?**
Extended the check for null/undefined properties to also check if there are any keys in the properties object

**Is there anything that requires more attention while reviewing?**
I'm unsure if this is the correct fix for the issue - but all tests pass and schema in question works too