### PR TITLE
Fix: additionalProperties + propertyNames with coerceTypes: array

### DIFF
--- a/lib/compile/codegen/index.ts
+++ b/lib/compile/codegen/index.ts
@@ -638,7 +638,7 @@ export class CodeGen {
     nameOrPrefix: Name | string,
     obj: Code,
     forBody: (item: Name) => void,
-    varKind: Code = this.opts.es5 ? varKinds.var : varKinds.const
+    varKind: Code = this.opts.es5 ? varKinds.var : varKinds.let
   ): CodeGen {
     if (this.opts.ownProperties) {
       return this.forOf(nameOrPrefix, _`Object.keys(${obj})`, forBody)

--- a/spec/codegen.spec.ts
+++ b/spec/codegen.spec.ts
@@ -288,10 +288,10 @@ describe("code generation", () => {
         assertEqual(_gen, "for(var _i0=0; _i0<xs.length; _i0++){var x0 = xs[_i0];console.log(x0);}")
       })
 
-      it("renders `for-in` statement", () => {
+      it("renders `for-in` statement with `let` because coerceTypes:array may generate a coercion assignment to the key variable", () => {
         gen.forIn("x", xs, (x: Name) => gen.code(_`console.log(${x})`))
         gen.optimize()
-        assertEqual(gen, "for(const x0 in xs){console.log(x0);}")
+        assertEqual(gen, "for(let x0 in xs){console.log(x0);}")
       })
 
       it("renders `for-in` statement as `for-of` with `ownProperties` option", () => {

--- a/spec/coercion.spec.ts
+++ b/spec/coercion.spec.ts
@@ -468,6 +468,29 @@ describe("Type coercion", () => {
     })
   })
 
+  it("should generate valid code for additionalProperties + propertyNames with coerceTypes array", () => {
+    // When coerceTypes:"array" is combined with propertyNames, AJV validates the loop
+    // key variable against the propertyNames schema and generates coercion code for it.
+    // With `const` on the for-in loop variable, that coercion assignment is invalid in
+    // strict mode and static analysis tools (e.g. esbuild) reject the output. The loop
+    // variable must use `let` so the generated assignment is syntactically valid.
+    const ajvWithSource = new _Ajv({coerceTypes: "array", code: {source: true}})
+    const validate = ajvWithSource.compile({
+      type: "object",
+      additionalProperties: {type: "string"},
+      propertyNames: {type: "string", pattern: "^[a-z]+$", maxLength: 32},
+      maxProperties: 32,
+    })
+    const src = validate.toString()
+    src.should.not.include("for(const ", "for-in loop variable must use `let` not `const`")
+    src.should.include("for(let ", "for-in loop variable must use `let`")
+
+    // Validate coercion still works correctly on the value
+    const data: Record<string, unknown> = {key: ["hello"]}
+    validate(data).should.equal(true)
+    ;(data.key as string).should.equal("hello")
+  })
+
   function testRules(rules, cb) {
     for (const toType in rules) {
       for (const fromType in rules[toType]) {


### PR DESCRIPTION
**What issue does this pull request resolve?**
When ajv is configured with `{ coerceTypes: "array" }` and the JSON Schema has additionalProperties & propertyNames
ajv generates a coercion assignment to the key variable itself (e.g. key0 = key0[0]). The key is a `const` causing an exception to be thrown during runtime (or during build via esbuild)

Happy to make a GH issue if you really need one.

**What changes did you make?**
Change the `varKind` in `forIn` from `varKind.const` to `varKind.let`.

**Is there anything that requires more attention while reviewing?**
No, very small change. Super edge case. TDD was used to resolve issue. Assisted with Claude Opus 4.7