### PR TITLE
chore: bump fast-uri to 3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "runkitExampleFilename": ".runkit_example.js",
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
-    "fast-uri": "^3.0.1",
+    "fast-uri": "^3.1.2",
     "json-schema-traverse": "^1.0.0",
     "require-from-string": "^2.0.2"
   },


### PR DESCRIPTION
**What issue does this pull request resolve?**
Fix for [CVE-2026-6321](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) and [CVE-2026-6322](https://github.com/advisories/GHSA-v39h-62p7-jpjc).

**What changes did you make?**
Minor version bump of [fast-uri](https://github.com/fastify/fast-uri/releases) dependency.

**Is there anything that requires more attention while reviewing?**
No.