### PR TITLE
add test for #2212: strict + coerceTypes=array should not allow Infinity

### DIFF
--- a/spec/issues/2212_strict_coerceTypes_Infinity.spec.ts
+++ b/spec/issues/2212_strict_coerceTypes_Infinity.spec.ts
@@ -1,0 +1,26 @@
+import _Ajv from "../ajv"
+import * as assert from "assert"
+
+describe("string Infinity/-Infinity should be invalid when `strict: true, coerceTypes: \"array\"` (issue #2212)", () => {
+  const ajv = new _Ajv({ strict: true, coerceTypes: 'array' })
+
+  const schema = {
+    type: "integer",
+  }
+
+  const validate = ajv.compile(schema)
+
+  it("typed integer valid", () => assert.strictEqual(validate(42), true))
+  it("typed NaN invalid", () => assert.strictEqual(validate(NaN), false))
+  it("typed Infinity invalid", () => assert.strictEqual(validate(Infinity), false))
+  it("typed -Infinity invalid", () => assert.strictEqual(validate(-Infinity), false))
+  it("typed 9e600 invalid", () => assert.strictEqual(validate(9e600), false))
+  it("typed -9E600 invalid", () => assert.strictEqual(validate(-9E600), false))
+
+  it("string integer valid", () => assert.strictEqual(validate("42"), true))
+  it("string NaN invalid", () => assert.strictEqual(validate("NaN"), false))
+  it("string Infinity invalid", () => assert.strictEqual(validate("Infinity"), false))
+  it("string -Infinity invalid", () => assert.strictEqual(validate("-Infinity"), false))
+  it("string 9e600 invalid", () => assert.strictEqual(validate("9e600"), false))
+  it("string -9E600 invalid", () => assert.strictEqual(validate("-9E600"), false))
+})

--- a/spec/issues/2212_strict_coerceTypes_Infinity.spec.ts
+++ b/spec/issues/2212_strict_coerceTypes_Infinity.spec.ts
@@ -1,8 +1,8 @@
 import _Ajv from "../ajv"
 import * as assert from "assert"
 
-describe("string Infinity/-Infinity should be invalid when `strict: true, coerceTypes: \"array\"` (issue #2212)", () => {
-  const ajv = new _Ajv({ strict: true, coerceTypes: 'array' })
+describe('string Infinity/-Infinity should be invalid when `strict: true, coerceTypes: "array"` (issue #2212)', () => {
+  const ajv = new _Ajv({strict: true, coerceTypes: "array"})
 
   const schema = {
     type: "integer",
@@ -14,8 +14,10 @@ describe("string Infinity/-Infinity should be invalid when `strict: true, coerce
   it("typed NaN invalid", () => assert.strictEqual(validate(NaN), false))
   it("typed Infinity invalid", () => assert.strictEqual(validate(Infinity), false))
   it("typed -Infinity invalid", () => assert.strictEqual(validate(-Infinity), false))
+  // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
   it("typed 9e600 invalid", () => assert.strictEqual(validate(9e600), false))
-  it("typed -9E600 invalid", () => assert.strictEqual(validate(-9E600), false))
+  // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
+  it("typed -9E600 invalid", () => assert.strictEqual(validate(-9e600), false))
 
   it("string integer valid", () => assert.strictEqual(validate("42"), true))
   it("string NaN invalid", () => assert.strictEqual(validate("NaN"), false))


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
Part of #2212 

**What changes did you make?**
I added the test case

**Is there anything that requires more attention while reviewing?**
I don't know how to actually fix this in the codebase. A maintainer can do it on this branch, someone can cherry-pick this commit, hell just copy-paste the testcase if that means it'll finally get (and stay) fixed.