### PR TITLE
Fix dynamicRef static target resolution

### DIFF
--- a/lib/compile/index.ts
+++ b/lib/compile/index.ts
@@ -12,7 +12,7 @@ import {CodeGen, _, nil, stringify, Name, Code, ValueScopeName} from "./codegen"
 import ValidationError from "../runtime/validation_error"
 import N from "./names"
 import {LocalRefs, getFullPath, _getFullPath, inlineRef, normalizeId, resolveUrl} from "./resolve"
-import {schemaHasRulesButRef, unescapeFragment} from "./util"
+import {schemaHasResourceDynamicAnchors, schemaHasRulesButRef, unescapeFragment} from "./util"
 import {validateFunctionCode} from "./validate"
 import {URIComponent} from "fast-uri"
 import {JSONType} from "./rules"
@@ -311,7 +311,12 @@ function getJsonPointer(
     }
   }
   let env: SchemaEnv | undefined
-  if (typeof schema != "boolean" && schema.$ref && !schemaHasRulesButRef(schema, this.RULES)) {
+  if (
+    typeof schema != "boolean" &&
+    schema.$ref &&
+    !schemaHasRulesButRef(schema, this.RULES) &&
+    !schemaHasResourceDynamicAnchors(schema, this.opts.schemaId)
+  ) {
     const $ref = resolveUrl(this.opts.uriResolver, baseId, schema.$ref)
     env = resolveSchema.call(this, root, $ref)
   }

--- a/lib/compile/util.ts
+++ b/lib/compile/util.ts
@@ -43,6 +43,35 @@ export function schemaHasRulesButRef(schema: AnySchema, RULES: ValidationRules):
   return false
 }
 
+export function schemaResourceDynamicAnchors(schema: AnySchema, schemaId: "$id" | "id"): string[] {
+  const anchors: {[Ref in string]?: true} = {}
+  findDynamicAnchors(schema, true)
+  return Object.keys(anchors)
+
+  function findDynamicAnchors(sch: unknown, isRoot: boolean): void {
+    if (!sch || typeof sch != "object") return
+    if (Array.isArray(sch)) {
+      for (const item of sch) findDynamicAnchors(item, false)
+      return
+    }
+
+    const schObj = sch as {[Key in string]?: unknown}
+    if (!isRoot && typeof schObj[schemaId] == "string") return
+    const {$dynamicAnchor, $recursiveAnchor} = schObj
+    if (typeof $dynamicAnchor == "string") anchors[$dynamicAnchor] = true
+    if ($recursiveAnchor === true) anchors[""] = true
+
+    for (const key in schObj) findDynamicAnchors(schObj[key], false)
+  }
+}
+
+export function schemaHasResourceDynamicAnchors(
+  schema: AnySchema,
+  schemaId: "$id" | "id"
+): boolean {
+  return schemaResourceDynamicAnchors(schema, schemaId).length > 0
+}
+
 export function schemaRefOrVal(
   {topSchemaRef, schemaPath}: SchemaObjCxt,
   schema: unknown,

--- a/lib/vocabularies/core/ref.ts
+++ b/lib/vocabularies/core/ref.ts
@@ -2,7 +2,7 @@ import type {CodeKeywordDefinition, AnySchema} from "../../types"
 import type {KeywordCxt} from "../../compile/validate"
 import MissingRefError from "../../compile/ref_error"
 import {callValidateCode} from "../code"
-import {_, nil, stringify, Code, Name} from "../../compile/codegen"
+import {_, getProperty, nil, stringify, Code, Name} from "../../compile/codegen"
 import N from "../../compile/names"
 import {SchemaEnv, resolveRef} from "../../compile"
 import {mergeEvaluated} from "../../compile/util"
@@ -14,6 +14,7 @@ const def: CodeKeywordDefinition = {
     const {gen, schema: $ref, it} = cxt
     const {baseId, schemaEnv: env, validateName, opts, self} = it
     const {root} = env
+    if (opts.dynamicRef) setupDynamicAnchors(cxt)
     if (($ref === "#" || $ref === "#/") && baseId === root.baseId) return callRootRef()
     const schOrEnv = resolveRef.call(self, root, baseId, $ref)
     if (schOrEnv === undefined) throw new MissingRefError(it.opts.uriResolver, baseId, $ref)
@@ -124,6 +125,45 @@ export function callRef(cxt: KeywordCxt, v: Code, sch?: SchemaEnv, $async?: bool
       }
     }
   }
+}
+
+function setupDynamicAnchors(cxt: KeywordCxt): void {
+  const {gen, it} = cxt
+  const {baseId, schemaEnv: env, self} = it
+  for (const anchor of dynamicAnchorsForBaseId(env, baseId)) {
+    const ref = anchor ? `#${anchor}` : "#"
+    const schOrEnv = resolveRef.call(self, env.root, baseId, ref)
+    if (!(schOrEnv instanceof SchemaEnv) || !schemaHasDynamicAnchor(schOrEnv, anchor)) continue
+    const v = _`${N.dynamicAnchors}${getProperty(anchor)}`
+    const validate = getValidate(cxt, schOrEnv)
+    gen.if(_`!${v}`, () => gen.assign(v, validate))
+  }
+
+  function dynamicAnchorsForBaseId(schemaEnv: SchemaEnv, refBaseId: string): string[] {
+    const anchors: {[Ref in string]?: true} = {}
+    const prefix = refBaseId ? `${refBaseId}#` : "#"
+    for (const ref in self.refs) {
+      if (ref.startsWith(prefix)) addAnchor(ref.slice(prefix.length))
+    }
+    if (!refBaseId && schemaEnv.root.localRefs) {
+      for (const ref in schemaEnv.root.localRefs) {
+        if (ref[0] === "#") addAnchor(ref.slice(1))
+      }
+    }
+    return Object.keys(anchors)
+
+    function addAnchor(anchor: string): void {
+      if (anchor[0] === "/") return
+      anchors[anchor] = true
+    }
+  }
+}
+
+function schemaHasDynamicAnchor(sch: SchemaEnv, anchor: string): boolean {
+  return (
+    typeof sch.schema == "object" &&
+    (anchor ? sch.schema.$dynamicAnchor === anchor : sch.schema.$recursiveAnchor === true)
+  )
 }
 
 export default def

--- a/lib/vocabularies/dynamic/dynamicRef.ts
+++ b/lib/vocabularies/dynamic/dynamicRef.ts
@@ -1,8 +1,10 @@
-import type {CodeKeywordDefinition} from "../../types"
+import type {AnySchema, CodeKeywordDefinition} from "../../types"
 import type {KeywordCxt} from "../../compile/validate"
-import {_, getProperty, Code, Name} from "../../compile/codegen"
+import MissingRefError from "../../compile/ref_error"
+import {_, getProperty, nil, stringify, Code, Name} from "../../compile/codegen"
 import N from "../../compile/names"
-import {callRef} from "../core/ref"
+import {SchemaEnv, resolveRef} from "../../compile"
+import {callRef, getValidate} from "../core/ref"
 
 const def: CodeKeywordDefinition = {
   keyword: "$dynamicRef",
@@ -14,6 +16,27 @@ export function dynamicRef(cxt: KeywordCxt, ref: string): void {
   const {gen, keyword, it} = cxt
   if (ref[0] !== "#") throw new Error(`"${keyword}" only supports hash fragment reference`)
   const anchor = ref.slice(1)
+  const {baseId, schemaEnv: env, self} = it
+  const {root} = env
+  const schOrEnv = resolveRef.call(self, root, baseId, ref)
+  let sch: SchemaEnv
+  let v: Code
+  if (schOrEnv === undefined) {
+    if (schemaHasDynamicAnchor(env, anchor)) {
+      sch = env
+    } else if (root.dynamicAnchors[anchor] || schemaHasDynamicAnchor(root, anchor)) {
+      sch = root
+    } else {
+      throw new MissingRefError(it.opts.uriResolver, baseId, ref)
+    }
+    v = sch === env ? it.validateName : getValidate(cxt, sch)
+  } else {
+    if (!(schOrEnv instanceof SchemaEnv)) return inlineRefSchema(schOrEnv)
+    sch = schOrEnv
+    v = getValidate(cxt, sch)
+  }
+  const refIsDynamic = schemaHasDynamicAnchor(sch, anchor)
+  const fallbackToCurrent = refIsDynamic && !schemaHasValidationRules(sch)
   if (it.allErrors) {
     _dynamicRef()
   } else {
@@ -23,29 +46,83 @@ export function dynamicRef(cxt: KeywordCxt, ref: string): void {
   }
 
   function _dynamicRef(valid?: Name): void {
-    // TODO the assumption here is that `recursiveRef: #` always points to the root
-    // of the schema object, which is not correct, because there may be $id that
-    // makes # point to it, and the target schema may not contain dynamic/recursiveAnchor.
-    // Because of that 2 tests in recursiveRef.json fail.
-    // This is a similar problem to #815 (`$id` doesn't alter resolution scope for `{ "$ref": "#" }`).
-    // (This problem is not tested in JSON-Schema-Test-Suite)
-    if (it.schemaEnv.root.dynamicAnchors[anchor]) {
-      const v = gen.let("_v", _`${N.dynamicAnchors}${getProperty(anchor)}`)
-      gen.if(v, _callRef(v, valid), _callRef(it.validateName, valid))
+    if (refIsDynamic && root.dynamicAnchors[anchor]) {
+      const dyn = gen.let("_v", _`${N.dynamicAnchors}${getProperty(anchor)}`)
+      gen.if(dyn, _callRef(dyn, valid), fallback(valid))
     } else {
-      _callRef(it.validateName, valid)()
+      fallback(valid)()
     }
   }
 
-  function _callRef(validate: Code, valid?: Name): () => void {
+  function fallback(valid?: Name): () => void {
+    return fallbackToCurrent ? _callRef(it.validateName, valid) : _callRef(v, valid, sch)
+  }
+
+  function _callRef(validate: Code, valid?: Name, refEnv?: SchemaEnv): () => void {
     return valid
       ? () =>
           gen.block(() => {
-            callRef(cxt, validate)
+            callRef(cxt, validate, refEnv, refEnv?.$async)
             gen.let(valid, true)
           })
-      : () => callRef(cxt, validate)
+      : () => callRef(cxt, validate, refEnv, refEnv?.$async)
   }
+
+  function inlineRefSchema(refSchema: AnySchema): void {
+    const schName = gen.scopeValue(
+      "schema",
+      it.opts.code.source === true ? {ref: refSchema, code: stringify(refSchema)} : {ref: refSchema}
+    )
+    const valid = gen.name("valid")
+    const schCxt = cxt.subschema(
+      {
+        schema: refSchema,
+        dataTypes: [],
+        schemaPath: nil,
+        topSchemaRef: schName,
+        errSchemaPath: ref,
+      },
+      valid
+    )
+    cxt.mergeEvaluated(schCxt)
+    cxt.ok(valid)
+  }
+}
+
+function schemaHasDynamicAnchor(sch: SchemaEnv, anchor: string): boolean {
+  return (
+    typeof sch.schema == "object" &&
+    (anchor ? sch.schema.$dynamicAnchor === anchor : sch.schema.$recursiveAnchor === true)
+  )
+}
+
+const ANNOTATION_OR_LOCATION: {[Key in string]?: true} = {
+  $comment: true,
+  $defs: true,
+  $dynamicAnchor: true,
+  $id: true,
+  $recursiveAnchor: true,
+  $schema: true,
+  $vocabulary: true,
+  contentEncoding: true,
+  contentMediaType: true,
+  contentSchema: true,
+  default: true,
+  definitions: true,
+  deprecated: true,
+  description: true,
+  examples: true,
+  readOnly: true,
+  title: true,
+  writeOnly: true,
+}
+
+function schemaHasValidationRules(sch: SchemaEnv): boolean {
+  if (typeof sch.schema != "object") return true
+  for (const key in sch.schema) {
+    if (!ANNOTATION_OR_LOCATION[key]) return true
+  }
+  return false
 }
 
 export default def

--- a/spec/dynamic-ref.spec.ts
+++ b/spec/dynamic-ref.spec.ts
@@ -93,6 +93,157 @@ describe("recursiveRef and dynamicRef", () => {
       })
     })
 
+    it("should bind dynamicRef to a dynamicAnchor in the referencing schema resource", () => {
+      const schema = {
+        $id: "https://example.com/test",
+        $defs: {
+          User: {
+            type: "object",
+            required: ["id", "email"],
+            properties: {
+              id: {type: "string"},
+              email: {type: "string"},
+            },
+          },
+          PaginatedTemplate: {
+            $id: "https://example.com/schemas/PaginatedTemplate",
+            $defs: {
+              itemType: {
+                $dynamicAnchor: "itemType",
+                not: {},
+              },
+            },
+            type: "object",
+            required: ["items", "total", "page", "pageSize"],
+            properties: {
+              items: {
+                type: "array",
+                items: {$dynamicRef: "#itemType"},
+              },
+              total: {type: "integer", minimum: 0},
+              page: {type: "integer", minimum: 1},
+              pageSize: {type: "integer", minimum: 1},
+            },
+          },
+          PaginatedUserResponse: {
+            $id: "https://example.com/schemas/PaginatedUserResponse",
+            $defs: {
+              itemType: {
+                $dynamicAnchor: "itemType",
+                $ref: "https://example.com/test#/$defs/User",
+              },
+            },
+            $ref: "https://example.com/test#/$defs/PaginatedTemplate",
+          },
+        },
+      }
+
+      getAjvInstances(_Ajv2020, options, {strict: false, validateFormats: false}).forEach((ajv) => {
+        ajv.addSchema(schema)
+        const validate = ajv.compile({
+          $ref: "https://example.com/test#/$defs/PaginatedUserResponse",
+        })
+
+        assert.strictEqual(
+          validate({
+            items: [{id: "u1", email: "user@example.com"}],
+            total: 1,
+            page: 1,
+            pageSize: 10,
+          }),
+          true
+        )
+
+        assert.strictEqual(
+          validate({
+            items: [{id: "u1"}],
+            total: 1,
+            page: 1,
+            pageSize: 10,
+          }),
+          false
+        )
+        assert.strictEqual(validate.errors?.[0].keyword, "required")
+      })
+    })
+
+    it("should bind dynamicRef from an inline referencing schema", () => {
+      const schema = {
+        $id: "https://example.com/inline-test",
+        $defs: {
+          User: {
+            type: "object",
+            required: ["id", "email"],
+            properties: {
+              id: {type: "string"},
+              email: {type: "string"},
+            },
+          },
+          PaginatedTemplate: {
+            $id: "https://example.com/schemas/InlinePaginatedTemplate",
+            $defs: {
+              itemType: {
+                $dynamicAnchor: "itemType",
+                not: {},
+              },
+            },
+            type: "object",
+            required: ["items", "total", "page", "pageSize"],
+            properties: {
+              items: {
+                type: "array",
+                items: {$dynamicRef: "#itemType"},
+              },
+              total: {type: "integer", minimum: 0},
+              page: {type: "integer", minimum: 1},
+              pageSize: {type: "integer", minimum: 1},
+            },
+          },
+        },
+        type: "object",
+        properties: {
+          response: {
+            $defs: {
+              itemType: {
+                $dynamicAnchor: "itemType",
+                $ref: "#/$defs/User",
+              },
+            },
+            $ref: "https://example.com/schemas/InlinePaginatedTemplate",
+          },
+        },
+      }
+
+      getAjvInstances(_Ajv2020, options, {strict: false, validateFormats: false}).forEach((ajv) => {
+        const validate = ajv.compile(schema)
+
+        assert.strictEqual(
+          validate({
+            response: {
+              items: [{id: "u1", email: "user@example.com"}],
+              total: 1,
+              page: 1,
+              pageSize: 10,
+            },
+          }),
+          true
+        )
+
+        assert.strictEqual(
+          validate({
+            response: {
+              items: [{id: "u1"}],
+              total: 1,
+              page: 1,
+              pageSize: 10,
+            },
+          }),
+          false
+        )
+        assert.strictEqual(validate.errors?.[0].keyword, "required")
+      })
+    })
+
     it("should allow extending recursive schema with dynamicRef (future draft2020)", () => {
       const treeSchema = {
         $id: "https://example.com/tree",

--- a/spec/dynamic-ref.spec.ts
+++ b/spec/dynamic-ref.spec.ts
@@ -1,6 +1,7 @@
 import type Ajv from "../dist/core"
 import type {SchemaObject} from ".."
 import _Ajv from "./ajv2019"
+import _Ajv2020 from "./ajv2020"
 import getAjvInstances from "./ajv_instances"
 import options from "./ajv_options"
 import * as assert from "assert"
@@ -43,6 +44,55 @@ describe("recursiveRef and dynamicRef", () => {
   })
 
   describe("dynamicRef", () => {
+    it("should resolve a non-root dynamicAnchor as the static target", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          schema: {$dynamicRef: "#meta"},
+        },
+        unevaluatedProperties: false,
+        $defs: {
+          schema: {
+            $dynamicAnchor: "meta",
+            type: ["object", "boolean"],
+          },
+        },
+      }
+
+      ajvs.forEach((ajv) => {
+        const validate = ajv.compile(schema)
+        assert.strictEqual(validate({schema: {type: "string"}}), true)
+        assert.strictEqual(validate({schema: true}), true)
+        assert.strictEqual(validate({schema: "bad"}), false)
+        assert.strictEqual(validate({other: true}), false)
+      })
+    })
+
+    it("should compile and validate an OpenAPI-style dynamic meta schema", () => {
+      const schema = {
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        type: "object",
+        properties: {
+          schema: {$dynamicRef: "#meta"},
+        },
+        unevaluatedProperties: false,
+        $defs: {
+          schema: {
+            $dynamicAnchor: "meta",
+            type: ["object", "boolean"],
+          },
+        },
+      }
+
+      getAjvInstances(_Ajv2020, options, {strict: false}).forEach((ajv) => {
+        const validate = ajv.compile(schema)
+        assert.strictEqual(validate({schema: {type: "string"}}), true)
+        assert.strictEqual(validate({schema: false}), true)
+        assert.strictEqual(validate({schema: "bad"}), false)
+        assert.strictEqual(validate({schema: {type: "string"}, extra: true}), false)
+      })
+    })
+
     it("should allow extending recursive schema with dynamicRef (future draft2020)", () => {
       const treeSchema = {
         $id: "https://example.com/tree",


### PR DESCRIPTION
Fixes #1745.

This is an alternative to #2573 against current `master`. It keeps the change scoped to `$dynamicRef` resolution and does not include workflow changes.

### Summary

- Resolve the `$dynamicRef` static target with the existing ref resolver before applying dynamic-anchor overrides.
- Use the resolved non-root `$dynamicAnchor` validator as the fallback target, instead of falling back to the current/root validator.
- Preserve the existing dynamic-scope “bookend” behavior for annotation/location-only dynamic anchors.
- Add regression coverage for the minimized issue schema and a draft-2020/OpenAPI-style schema using `unevaluatedProperties`.

### Tests

- `npm run build`
- `TS_NODE_PROJECT=spec/tsconfig.json ./node_modules/.bin/mocha -r ts-node/register spec/dynamic-ref.spec.ts -R dot`
- `TS_NODE_PROJECT=spec/tsconfig.json ./node_modules/.bin/mocha -r ts-node/register spec/json-schema.spec.ts --grep dynamicRef -R dot`
- Manual draft-2020 repro check with `./dist/2020`
- `npm run prettier:check`
- `npm run eslint`
- `git diff --check`
- `npm test` (`7614 passing`, `350 pending`)
