### PR TITLE
fix: avoid empty reduce when JTD parser schema has empty properties

### DIFF
--- a/lib/compile/jtd/parse.ts
+++ b/lib/compile/jtd/parse.ts
@@ -231,7 +231,7 @@ function parseSchemaProperties(cxt: ParseCxt, discriminator?: string): void {
     }
     gen.endIf()
   })
-  if (properties) {
+  if (properties && Object.keys(properties).length > 0) {
     const hasProp = hasPropFunc(gen)
     const allProps: Code = and(
       ...Object.keys(properties).map((p): Code => _`${hasProp}.call(${data}, ${p})`)

--- a/spec/jtd-schema.spec.ts
+++ b/spec/jtd-schema.spec.ts
@@ -220,6 +220,25 @@ describe("JSON Type Definition", () => {
     }
   })
 
+  describe("parse with empty properties", () => {
+    let ajv: AjvJTD
+    before(() => (ajv = new _AjvJTD()))
+
+    it("should compile parser for properties: {}", () => {
+      const parse = ajv.compileParser({properties: {}})
+      shouldParse(parse, "{}", {})
+    })
+
+    it("should compile parser for discriminator mapping with empty properties", () => {
+      const parse = ajv.compileParser({
+        discriminator: "t",
+        mapping: {a: {properties: {}}, b: {properties: {b: {type: "int32"}}}},
+      })
+      shouldParse(parse, '{"t":"a"}', {t: "a"})
+      shouldParse(parse, '{"t":"b","b":1}', {t: "b", b: 1})
+    })
+  })
+
   describe("parse tests nst/JSONTestSuite", () => {
     const ajv = new _AjvJTD()
     const parseJson: JTDParser = ajv.compileParser({})


### PR DESCRIPTION
**What issue does this pull request resolve?**

Closes #2609

**What changes did you make?**

`parseSchemaProperties` now skips the missing-required-properties check when `properties` is an empty object, so `compileParser` no longer throws `TypeError: Reduce of empty array with no initial value` for schemas like `{properties: {}}` or discriminator mappings with empty property sets.

**Is there anything that requires more attention while reviewing?**

No.