### PR TITLE
fix: CodeGen: Output import statements when esm mode is enabled #2598

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,8 @@ git submodule update --init
 npm test
 ```
 
+`npm run prettier:write` - to auto-format all files (test command fails if there are formatting issues)
+
 `npm run build` - compiles typescript to dist folder.
 
 `npm run watch` - automatically compiles typescript when files on lib folder changes.

--- a/docs/options.md
+++ b/docs/options.md
@@ -384,6 +384,8 @@ type CodeOptions = {
   // Code snippet created with `_` tagged template literal that contains all format definitions,
   // it can be the code of actual definitions or `require` call:
   // _`require("./my-formats")`
+  // Or an ESM import:
+  // new NamedImport("allFormats", "./my-formats", ".js")
   regExp: RegExpEngine
   // Pass non-standard RegExp engine to mitigate ReDoS, e.g. node-re2.
   // During validation of a schema, code.regExp will be 

--- a/lib/compile/codegen/code.ts
+++ b/lib/compile/codegen/code.ts
@@ -33,12 +33,14 @@ export class NamedImport extends _CodeOrName {
   private _str?: string
   readonly name: string
   readonly module: string
+  readonly extension: string
 
-  constructor(name: string, module: string) {
+  constructor(name: string, module: string, extension?: string) {
     super()
     if (!IDENTIFIER.test(name)) throw new Error("CodeGen: name must be a valid identifier")
     this.name = name
     this.module = module
+    this.extension = extension ?? ".js"
   }
 
   toString(): string {

--- a/lib/compile/codegen/code.ts
+++ b/lib/compile/codegen/code.ts
@@ -31,13 +31,13 @@ export class Name extends _CodeOrName {
 
 export class NamedImport extends _CodeOrName {
   private _str?: string
-  readonly name: string
-  readonly module: string
-  readonly extension: string
+  readonly name: string // the name of the symbol to import, can be empty for all imports (star import)
+  readonly module: string // the module (ID) to import from, without the extension
+  readonly extension: string // the extension to add to the module when importing, default is .js
 
   constructor(name: string, module: string, extension?: string) {
     super()
-    if (!IDENTIFIER.test(name)) throw new Error("CodeGen: name must be a valid identifier")
+    if (name && !IDENTIFIER.test(name)) throw new Error("CodeGen: name must be a valid identifier")
     this.name = name
     this.module = module
     this.extension = extension ?? ".js"
@@ -52,7 +52,9 @@ export class NamedImport extends _CodeOrName {
   }
 
   get str(): string {
-    return (this._str ??= `require(${safeStringify(this.module)}).${this.name}`)
+    return this.name
+      ? (this._str ??= `require(${safeStringify(this.module)}).${this.name}`)
+      : (this._str ??= `require(${safeStringify(this.module)})`)
   }
 
   get names(): UsedNames {

--- a/lib/compile/codegen/code.ts
+++ b/lib/compile/codegen/code.ts
@@ -29,6 +29,35 @@ export class Name extends _CodeOrName {
   }
 }
 
+export class NamedImport extends _CodeOrName {
+  private _str?: string
+  readonly name: string
+  readonly module: string
+
+  constructor(name: string, module: string) {
+    super()
+    if (!IDENTIFIER.test(name)) throw new Error("CodeGen: name must be a valid identifier")
+    this.name = name
+    this.module = module
+  }
+
+  toString(): string {
+    return this.str
+  }
+
+  emptyStr(): boolean {
+    return false
+  }
+
+  get str(): string {
+    return (this._str ??= `require(${safeStringify(this.module)}).${this.name}`)
+  }
+
+  get names(): UsedNames {
+    return {}
+  }
+}
+
 export class _Code extends _CodeOrName {
   readonly _items: readonly CodeItem[]
   private _str?: string
@@ -65,7 +94,7 @@ export type CodeItem = Name | string | number | boolean | null
 
 export type UsedNames = Record<string, number | undefined>
 
-export type Code = _Code | Name
+export type Code = _Code | Name | NamedImport
 
 export type SafeExpr = Code | number | boolean | null
 
@@ -100,6 +129,7 @@ export function str(strs: TemplateStringsArray, ...args: (CodeArg | string[])[])
 export function addCodeArg(code: CodeItem[], arg: CodeArg | string[]): void {
   if (arg instanceof _Code) code.push(...arg._items)
   else if (arg instanceof Name) code.push(arg)
+  else if (arg instanceof NamedImport) code.push(arg)
   else code.push(interpolate(arg))
 }
 

--- a/lib/compile/codegen/index.ts
+++ b/lib/compile/codegen/index.ts
@@ -2,7 +2,18 @@ import type {ScopeValueSets, NameValue, ValueScope, ValueScopeName} from "./scop
 import {_, nil, _Code, Code, Name, UsedNames, CodeItem, addCodeArg, _CodeOrName} from "./code"
 import {Scope, varKinds} from "./scope"
 
-export {_, str, strConcat, nil, getProperty, stringify, regexpCode, Name, Code} from "./code"
+export {
+  _,
+  str,
+  strConcat,
+  nil,
+  getProperty,
+  stringify,
+  regexpCode,
+  Name,
+  Code,
+  NamedImport,
+} from "./code"
 export {Scope, ScopeStore, ValueScope, ValueScopeName, ScopeValueSets, varKinds} from "./scope"
 
 // type for expressions that can be safely inserted in code without quotes

--- a/lib/compile/codegen/scope.ts
+++ b/lib/compile/codegen/scope.ts
@@ -1,4 +1,4 @@
-import {_, nil, Code, Name} from "./code"
+import {_, nil, Code, Name, NamedImport} from "./code"
 
 interface NameGroup {
   prefix: string
@@ -29,6 +29,7 @@ interface ScopeOptions {
 interface ValueScopeOptions extends ScopeOptions {
   scope: ScopeStore
   es5?: boolean
+  esm?: boolean
   lines?: boolean
 }
 
@@ -200,8 +201,12 @@ export class ValueScope extends Scope {
         nameSet.set(name, UsedValueState.Started)
         let c = valueCode(name)
         if (c) {
-          const def = this.opts.es5 ? varKinds.var : varKinds.const
-          code = _`${code}${def} ${name} = ${c};${this.opts._n}`
+          if (this.opts.esm && c instanceof NamedImport) {
+            code = _`${code}import { ${c.name} as ${name} } from ${c.module};${this.opts._n}`
+          } else {
+            const def = this.opts.es5 ? varKinds.var : varKinds.const
+            code = _`${code}${def} ${name} = ${c};${this.opts._n}`
+          }
         } else if ((c = getCode?.(name))) {
           code = _`${code}${c}${this.opts._n}`
         } else {

--- a/lib/compile/codegen/scope.ts
+++ b/lib/compile/codegen/scope.ts
@@ -203,7 +203,9 @@ export class ValueScope extends Scope {
         if (c) {
           if (this.opts.esm && c instanceof NamedImport) {
             const moduleId = `${c.module}${c.extension}`
-            code = _`${code}import { ${c.name} as ${name} } from ${moduleId};${this.opts._n}`
+            code = c.name
+              ? _`${code}import { ${c.name} as ${name} } from ${moduleId};${this.opts._n}`
+              : _`${code}import * as ${name} from ${moduleId};${this.opts._n}`
           } else {
             const def = this.opts.es5 ? varKinds.var : varKinds.const
             code = _`${code}${def} ${name} = ${c};${this.opts._n}`

--- a/lib/compile/codegen/scope.ts
+++ b/lib/compile/codegen/scope.ts
@@ -202,8 +202,8 @@ export class ValueScope extends Scope {
         let c = valueCode(name)
         if (c) {
           if (this.opts.esm && c instanceof NamedImport) {
-            const module = `${c.module}.js`
-            code = _`${code}import { ${c.name} as ${name} } from ${module};${this.opts._n}`
+            const moduleId = `${c.module}${c.extension}`
+            code = _`${code}import { ${c.name} as ${name} } from ${moduleId};${this.opts._n}`
           } else {
             const def = this.opts.es5 ? varKinds.var : varKinds.const
             code = _`${code}${def} ${name} = ${c};${this.opts._n}`

--- a/lib/compile/codegen/scope.ts
+++ b/lib/compile/codegen/scope.ts
@@ -202,7 +202,8 @@ export class ValueScope extends Scope {
         let c = valueCode(name)
         if (c) {
           if (this.opts.esm && c instanceof NamedImport) {
-            code = _`${code}import { ${c.name} as ${name} } from ${c.module};${this.opts._n}`
+            const module = `${c.module}.js`
+            code = _`${code}import { ${c.name} as ${name} } from ${module};${this.opts._n}`
           } else {
             const def = this.opts.es5 ? varKinds.var : varKinds.const
             code = _`${code}${def} ${name} = ${c};${this.opts._n}`

--- a/lib/compile/jtd/parse.ts
+++ b/lib/compile/jtd/parse.ts
@@ -359,7 +359,11 @@ function parseEmpty(cxt: ParseCxt): void {
   parseWith(cxt, parseJson)
 }
 
-function parseWith(cxt: ParseCxt, parseFunc: {code: string}, args?: SafeExpr): void {
+function parseWith(
+  cxt: ParseCxt,
+  parseFunc: {code: string; import: readonly [string, string]},
+  args?: SafeExpr
+): void {
   partialParse(cxt, useFunc(cxt.gen, parseFunc), args)
 }
 

--- a/lib/compile/util.ts
+++ b/lib/compile/util.ts
@@ -1,7 +1,7 @@
 import type {AnySchema, EvaluatedProperties, EvaluatedItems} from "../types"
 import type {SchemaCxt, SchemaObjCxt} from "."
 import {_, getProperty, Code, Name, CodeGen} from "./codegen"
-import {_Code} from "./codegen/code"
+import {_Code, NamedImport} from "./codegen/code"
 import type {Rule, ValidationRules} from "./rules"
 
 // TODO refactor to use Set
@@ -168,12 +168,24 @@ export function setEvaluated(gen: CodeGen, props: Name, ps: {[K in string]?: tru
   Object.keys(ps).forEach((p) => gen.assign(_`${props}${getProperty(p)}`, true))
 }
 
-const snippets: {[S in string]?: _Code} = {}
+const codeSnippets: {[S in string]?: _Code} = {}
+const importSnippets: {[S in string]?: NamedImport} = {}
 
-export function useFunc(gen: CodeGen, f: {code: string}): Name {
+export function useFunc(
+  gen: CodeGen,
+  f: {code: string; import?: readonly [name: string, module: string]}
+): Name {
+  if (f.import) {
+    const key = f.import[0] + "|" + f.import[1] // not ambiguous since bar (|) is not a valid name character
+    return gen.scopeValue("func", {
+      ref: f,
+      code:
+        importSnippets[key] || (importSnippets[key] = new NamedImport(f.import[0], f.import[1])),
+    })
+  }
   return gen.scopeValue("func", {
     ref: f,
-    code: snippets[f.code] || (snippets[f.code] = new _Code(f.code)),
+    code: codeSnippets[f.code] || (codeSnippets[f.code] = new _Code(f.code)),
   })
 }
 

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -293,9 +293,9 @@ export default class Ajv {
 
   constructor(opts: Options = {}) {
     opts = this.opts = {...opts, ...requiredOptions(opts)}
-    const {es5, lines} = this.opts.code
+    const {es5, esm, lines} = this.opts.code
 
-    this.scope = new ValueScope({scope: {}, prefixes: EXT_SCOPE_NAMES, es5, lines})
+    this.scope = new ValueScope({scope: {}, prefixes: EXT_SCOPE_NAMES, es5, esm, lines})
     this.logger = getLogger(opts.logger)
     const formatOpt = opts.validateFormats
     opts.validateFormats = false

--- a/lib/runtime/equal.ts
+++ b/lib/runtime/equal.ts
@@ -3,6 +3,6 @@ import * as equal from "fast-deep-equal"
 
 type Equal = typeof equal & {code: string; import: readonly [string, string]}
 ;(equal as Equal).code = 'require("ajv/dist/runtime/equal").default'
-;(equal as Equal).import = ["default", "ajv/dist/runtime/equal"]
+;(equal as Equal).import = ["default", "ajv/dist/runtime/equal.js"]
 
 export default equal as Equal

--- a/lib/runtime/equal.ts
+++ b/lib/runtime/equal.ts
@@ -3,6 +3,8 @@ import * as equal from "fast-deep-equal"
 
 type Equal = typeof equal & {code: string; import: readonly [string, string]}
 ;(equal as Equal).code = 'require("ajv/dist/runtime/equal").default'
-;(equal as Equal).import = ["default", "ajv/dist/runtime/equal"]
+;(equal as Equal).import = ["equal", "ajv/dist/runtime/equal"]
 
+const asEqual: Equal = equal as Equal
 export default equal as Equal
+export {asEqual as equal}

--- a/lib/runtime/equal.ts
+++ b/lib/runtime/equal.ts
@@ -3,6 +3,6 @@ import * as equal from "fast-deep-equal"
 
 type Equal = typeof equal & {code: string; import: readonly [string, string]}
 ;(equal as Equal).code = 'require("ajv/dist/runtime/equal").default'
-;(equal as Equal).import = ["default", "ajv/dist/runtime/equal.js"]
+;(equal as Equal).import = ["default", "ajv/dist/runtime/equal"]
 
 export default equal as Equal

--- a/lib/runtime/equal.ts
+++ b/lib/runtime/equal.ts
@@ -1,7 +1,8 @@
 // https://github.com/ajv-validator/ajv/issues/889
 import * as equal from "fast-deep-equal"
 
-type Equal = typeof equal & {code: string}
+type Equal = typeof equal & {code: string; import: readonly [string, string]}
 ;(equal as Equal).code = 'require("ajv/dist/runtime/equal").default'
+;(equal as Equal).import = ["default", "ajv/dist/runtime/equal"]
 
 export default equal as Equal

--- a/lib/runtime/parseJson.ts
+++ b/lib/runtime/parseJson.ts
@@ -30,6 +30,7 @@ export function parseJson(s: string, pos: number): unknown {
 parseJson.message = undefined as string | undefined
 parseJson.position = 0 as number
 parseJson.code = 'require("ajv/dist/runtime/parseJson").parseJson'
+parseJson.import = ["parseJson", "ajv/dist/runtime/parseJson"] as const
 
 export function parseJsonNumber(s: string, pos: number, maxDigits?: number): number | undefined {
   let numStr = ""
@@ -94,6 +95,7 @@ export function parseJsonNumber(s: string, pos: number, maxDigits?: number): num
 parseJsonNumber.message = undefined as string | undefined
 parseJsonNumber.position = 0 as number
 parseJsonNumber.code = 'require("ajv/dist/runtime/parseJson").parseJsonNumber'
+parseJsonNumber.import = ["parseJsonNumber", "ajv/dist/runtime/parseJson"] as const
 
 const escapedChars: {[X in string]?: string} = {
   b: "\b",
@@ -175,3 +177,4 @@ export function parseJsonString(s: string, pos: number): string | undefined {
 parseJsonString.message = undefined as string | undefined
 parseJsonString.position = 0 as number
 parseJsonString.code = 'require("ajv/dist/runtime/parseJson").parseJsonString'
+parseJsonString.import = ["parseJsonString", "ajv/dist/runtime/parseJson"] as const

--- a/lib/runtime/parseJson.ts
+++ b/lib/runtime/parseJson.ts
@@ -30,7 +30,7 @@ export function parseJson(s: string, pos: number): unknown {
 parseJson.message = undefined as string | undefined
 parseJson.position = 0 as number
 parseJson.code = 'require("ajv/dist/runtime/parseJson").parseJson'
-parseJson.import = ["parseJson", "ajv/dist/runtime/parseJson"] as const
+parseJson.import = ["parseJson", "ajv/dist/runtime/parseJson.js"] as const
 
 export function parseJsonNumber(s: string, pos: number, maxDigits?: number): number | undefined {
   let numStr = ""
@@ -95,7 +95,7 @@ export function parseJsonNumber(s: string, pos: number, maxDigits?: number): num
 parseJsonNumber.message = undefined as string | undefined
 parseJsonNumber.position = 0 as number
 parseJsonNumber.code = 'require("ajv/dist/runtime/parseJson").parseJsonNumber'
-parseJsonNumber.import = ["parseJsonNumber", "ajv/dist/runtime/parseJson"] as const
+parseJsonNumber.import = ["parseJsonNumber", "ajv/dist/runtime/parseJson.js"] as const
 
 const escapedChars: {[X in string]?: string} = {
   b: "\b",
@@ -177,4 +177,4 @@ export function parseJsonString(s: string, pos: number): string | undefined {
 parseJsonString.message = undefined as string | undefined
 parseJsonString.position = 0 as number
 parseJsonString.code = 'require("ajv/dist/runtime/parseJson").parseJsonString'
-parseJsonString.import = ["parseJsonString", "ajv/dist/runtime/parseJson"] as const
+parseJsonString.import = ["parseJsonString", "ajv/dist/runtime/parseJson.js"] as const

--- a/lib/runtime/parseJson.ts
+++ b/lib/runtime/parseJson.ts
@@ -30,7 +30,7 @@ export function parseJson(s: string, pos: number): unknown {
 parseJson.message = undefined as string | undefined
 parseJson.position = 0 as number
 parseJson.code = 'require("ajv/dist/runtime/parseJson").parseJson'
-parseJson.import = ["parseJson", "ajv/dist/runtime/parseJson.js"] as const
+parseJson.import = ["parseJson", "ajv/dist/runtime/parseJson"] as const
 
 export function parseJsonNumber(s: string, pos: number, maxDigits?: number): number | undefined {
   let numStr = ""
@@ -95,7 +95,7 @@ export function parseJsonNumber(s: string, pos: number, maxDigits?: number): num
 parseJsonNumber.message = undefined as string | undefined
 parseJsonNumber.position = 0 as number
 parseJsonNumber.code = 'require("ajv/dist/runtime/parseJson").parseJsonNumber'
-parseJsonNumber.import = ["parseJsonNumber", "ajv/dist/runtime/parseJson.js"] as const
+parseJsonNumber.import = ["parseJsonNumber", "ajv/dist/runtime/parseJson"] as const
 
 const escapedChars: {[X in string]?: string} = {
   b: "\b",
@@ -177,4 +177,4 @@ export function parseJsonString(s: string, pos: number): string | undefined {
 parseJsonString.message = undefined as string | undefined
 parseJsonString.position = 0 as number
 parseJsonString.code = 'require("ajv/dist/runtime/parseJson").parseJsonString'
-parseJsonString.import = ["parseJsonString", "ajv/dist/runtime/parseJson.js"] as const
+parseJsonString.import = ["parseJsonString", "ajv/dist/runtime/parseJson"] as const

--- a/lib/runtime/quote.ts
+++ b/lib/runtime/quote.ts
@@ -29,3 +29,4 @@ export default function quote(s: string): string {
 }
 
 quote.code = 'require("ajv/dist/runtime/quote").default'
+quote.import = ["default", "ajv/dist/runtime/quote"] as const

--- a/lib/runtime/quote.ts
+++ b/lib/runtime/quote.ts
@@ -29,4 +29,6 @@ export default function quote(s: string): string {
 }
 
 quote.code = 'require("ajv/dist/runtime/quote").default'
-quote.import = ["default", "ajv/dist/runtime/quote"] as const
+quote.import = ["quote", "ajv/dist/runtime/quote"] as const
+
+export {quote}

--- a/lib/runtime/quote.ts
+++ b/lib/runtime/quote.ts
@@ -29,4 +29,4 @@ export default function quote(s: string): string {
 }
 
 quote.code = 'require("ajv/dist/runtime/quote").default'
-quote.import = ["default", "ajv/dist/runtime/quote"] as const
+quote.import = ["default", "ajv/dist/runtime/quote.js"] as const

--- a/lib/runtime/quote.ts
+++ b/lib/runtime/quote.ts
@@ -29,4 +29,4 @@ export default function quote(s: string): string {
 }
 
 quote.code = 'require("ajv/dist/runtime/quote").default'
-quote.import = ["default", "ajv/dist/runtime/quote.js"] as const
+quote.import = ["default", "ajv/dist/runtime/quote"] as const

--- a/lib/runtime/timestamp.ts
+++ b/lib/runtime/timestamp.ts
@@ -44,4 +44,4 @@ function validTime(str: string): boolean {
 }
 
 validTimestamp.code = 'require("ajv/dist/runtime/timestamp").default'
-validTimestamp.import = ["default", "ajv/dist/runtime/timestamp.js"] as const
+validTimestamp.import = ["default", "ajv/dist/runtime/timestamp"] as const

--- a/lib/runtime/timestamp.ts
+++ b/lib/runtime/timestamp.ts
@@ -44,3 +44,4 @@ function validTime(str: string): boolean {
 }
 
 validTimestamp.code = 'require("ajv/dist/runtime/timestamp").default'
+validTimestamp.import = ["default", "ajv/dist/runtime/timestamp"] as const

--- a/lib/runtime/timestamp.ts
+++ b/lib/runtime/timestamp.ts
@@ -44,4 +44,4 @@ function validTime(str: string): boolean {
 }
 
 validTimestamp.code = 'require("ajv/dist/runtime/timestamp").default'
-validTimestamp.import = ["default", "ajv/dist/runtime/timestamp"] as const
+validTimestamp.import = ["default", "ajv/dist/runtime/timestamp.js"] as const

--- a/lib/runtime/timestamp.ts
+++ b/lib/runtime/timestamp.ts
@@ -44,4 +44,6 @@ function validTime(str: string): boolean {
 }
 
 validTimestamp.code = 'require("ajv/dist/runtime/timestamp").default'
-validTimestamp.import = ["default", "ajv/dist/runtime/timestamp"] as const
+validTimestamp.import = ["validTimestamp", "ajv/dist/runtime/timestamp"] as const
+
+export {validTimestamp}

--- a/lib/runtime/ucs2length.ts
+++ b/lib/runtime/ucs2length.ts
@@ -18,4 +18,4 @@ export default function ucs2length(str: string): number {
 }
 
 ucs2length.code = 'require("ajv/dist/runtime/ucs2length").default'
-ucs2length.import = ["default", "ajv/dist/runtime/ucs2length.js"] as const
+ucs2length.import = ["default", "ajv/dist/runtime/ucs2length"] as const

--- a/lib/runtime/ucs2length.ts
+++ b/lib/runtime/ucs2length.ts
@@ -18,4 +18,4 @@ export default function ucs2length(str: string): number {
 }
 
 ucs2length.code = 'require("ajv/dist/runtime/ucs2length").default'
-ucs2length.import = ["default", "ajv/dist/runtime/ucs2length"] as const
+ucs2length.import = ["default", "ajv/dist/runtime/ucs2length.js"] as const

--- a/lib/runtime/ucs2length.ts
+++ b/lib/runtime/ucs2length.ts
@@ -18,3 +18,4 @@ export default function ucs2length(str: string): number {
 }
 
 ucs2length.code = 'require("ajv/dist/runtime/ucs2length").default'
+ucs2length.import = ["default", "ajv/dist/runtime/ucs2length"] as const

--- a/lib/runtime/ucs2length.ts
+++ b/lib/runtime/ucs2length.ts
@@ -18,4 +18,6 @@ export default function ucs2length(str: string): number {
 }
 
 ucs2length.code = 'require("ajv/dist/runtime/ucs2length").default'
-ucs2length.import = ["default", "ajv/dist/runtime/ucs2length"] as const
+ucs2length.import = ["ucs2length", "ajv/dist/runtime/ucs2length"] as const
+
+export {ucs2length}

--- a/lib/runtime/uri.ts
+++ b/lib/runtime/uri.ts
@@ -2,6 +2,9 @@ import * as uri from "fast-uri"
 
 type URI = typeof uri & {code: string; import: readonly [string, string]}
 ;(uri as URI).code = 'require("ajv/dist/runtime/uri").default'
-;(uri as URI).import = ["default", "ajv/dist/runtime/uri"]
+;(uri as URI).import = ["uri", "ajv/dist/runtime/uri"]
+
+const asUri: URI = uri as URI
 
 export default uri as URI
+export {asUri as uri}

--- a/lib/runtime/uri.ts
+++ b/lib/runtime/uri.ts
@@ -2,6 +2,6 @@ import * as uri from "fast-uri"
 
 type URI = typeof uri & {code: string; import: readonly [string, string]}
 ;(uri as URI).code = 'require("ajv/dist/runtime/uri").default'
-;(uri as URI).import = ["default", "ajv/dist/runtime/uri"]
+;(uri as URI).import = ["default", "ajv/dist/runtime/uri.js"]
 
 export default uri as URI

--- a/lib/runtime/uri.ts
+++ b/lib/runtime/uri.ts
@@ -1,6 +1,7 @@
 import * as uri from "fast-uri"
 
-type URI = typeof uri & {code: string}
+type URI = typeof uri & {code: string; import: readonly [string, string]}
 ;(uri as URI).code = 'require("ajv/dist/runtime/uri").default'
+;(uri as URI).import = ["default", "ajv/dist/runtime/uri"]
 
 export default uri as URI

--- a/lib/runtime/uri.ts
+++ b/lib/runtime/uri.ts
@@ -2,6 +2,6 @@ import * as uri from "fast-uri"
 
 type URI = typeof uri & {code: string; import: readonly [string, string]}
 ;(uri as URI).code = 'require("ajv/dist/runtime/uri").default'
-;(uri as URI).import = ["default", "ajv/dist/runtime/uri.js"]
+;(uri as URI).import = ["default", "ajv/dist/runtime/uri"]
 
 export default uri as URI

--- a/lib/vocabularies/format/format.ts
+++ b/lib/vocabularies/format/format.ts
@@ -7,7 +7,7 @@ import type {
   ErrorObject,
 } from "../../types"
 import type {KeywordCxt} from "../../compile/validate"
-import {_, str, nil, or, Code, getProperty, regexpCode} from "../../compile/codegen"
+import {_, str, nil, or, Code, getProperty, regexpCode, NamedImport} from "../../compile/codegen"
 
 type FormatValidate =
   | FormatValidator<string>
@@ -92,12 +92,20 @@ const def: CodeKeywordDefinition = {
       }
 
       function getFormat(fmtDef: AddedFormat): [string, FormatValidate, Code] {
-        const code =
-          fmtDef instanceof RegExp
-            ? regexpCode(fmtDef)
-            : opts.code.formats
-            ? _`${opts.code.formats}${getProperty(schema)}`
-            : undefined
+        let code: Code | undefined
+        if (fmtDef instanceof RegExp) {
+          code = regexpCode(fmtDef)
+        } else if (opts.code.formats) {
+          if (opts.code.esm && opts.code.formats instanceof NamedImport) {
+            const f = opts.code.formats
+            const importName = gen.scopeValue("formats", {key: f.str, ref: f, code: f})
+            code = _`${importName}${getProperty(schema)}`
+          } else {
+            code = _`${opts.code.formats}${getProperty(schema)}`
+          }
+        } else {
+          code = undefined
+        }
         const fmt = gen.scopeValue("formats", {key: schema, ref: fmtDef, code})
         if (typeof fmtDef == "object" && !(fmtDef instanceof RegExp)) {
           return [fmtDef.type || "string", fmtDef.validate, _`${fmt}.validate`]

--- a/spec/codegen.spec.ts
+++ b/spec/codegen.spec.ts
@@ -548,7 +548,7 @@ describe("code generation", () => {
       assert.strictEqual(gen.getScopeValue("func", fn)?.str, "func0")
       assert.strictEqual(gen.getScopeValue("func", fn)?.value?.code instanceof NamedImport, true)
       assert.strictEqual(gen.getScopeValue("func", fn)?.value?.ref, fn)
-      assert.strictEqual(gen.scopeCode().str, 'import { "default" as func0 } from "foo";')
+      assert.strictEqual(gen.scopeCode().str, 'import { "default" as func0 } from "foo.js";')
     })
   })
 })

--- a/spec/codegen.spec.ts
+++ b/spec/codegen.spec.ts
@@ -9,7 +9,10 @@ import {
   not,
   Code,
   Name,
+  NamedImport,
 } from "../dist/compile/codegen"
+import {_Code} from "../dist/compile/codegen/code"
+import {useFunc} from "../dist/compile/util"
 import * as assert from "assert"
 
 describe("code generation", () => {
@@ -22,6 +25,31 @@ describe("code generation", () => {
 
     it("returns false from emptyStr", () => {
       assert.strictEqual(new Name("x").emptyStr(), false)
+    })
+  })
+
+  describe("NamedImport", () => {
+    it("throws if non-identifier is passed", () => {
+      assert.throws(() => new NamedImport("1x", "foo"), /name must be a valid identifier/)
+      assert.throws(() => new NamedImport("-x", "foo"), /name must be a valid identifier/)
+      assert.throws(() => new NamedImport("", "foo"), /name must be a valid identifier/)
+      new NamedImport("x", "foo")
+    })
+
+    it("returns false from emptyStr", () => {
+      assert.strictEqual(new NamedImport("x", "y").emptyStr(), false)
+    })
+
+    it("returns require call from str getter", () => {
+      assert.strictEqual(new NamedImport("x", "foo").str, 'require("foo").x')
+    })
+
+    it("returns require call from toString method", () => {
+      assert.strictEqual(new NamedImport("x", "foo").toString(), 'require("foo").x')
+    })
+
+    it("returns empty object from names getter", () => {
+      assert.deepStrictEqual(new NamedImport("x", "foo").names, {})
     })
   })
 
@@ -490,6 +518,37 @@ describe("code generation", () => {
       })
       assertEqual(gen.scopeRefs(new Name("scope")), "const val0 = scope.val[0];")
       assertEqual(gen.scopeCode(), "const val0 = 1;")
+    })
+  })
+
+  describe("useFunc", () => {
+    let gen: CodeGen
+    let scope: ScopeStore
+
+    beforeEach(() => {
+      scope = {}
+      gen = new CodeGen(new ValueScope({scope, esm: true}))
+    })
+
+    it("returns a new code instance referencing the function when no import is present", () => {
+      const fn = {code: 'require("foo").default'}
+      const name = useFunc(gen, fn)
+      assert.strictEqual(name.str, "func0")
+      assert.strictEqual(gen.getScopeValue("func", fn)?.str, "func0")
+      assert.strictEqual(gen.getScopeValue("func", fn)?.value?.code instanceof _Code, true)
+      assert.strictEqual(gen.getScopeValue("func", fn)?.value?.ref, fn)
+      assert.strictEqual(gen.scopeCode().str, 'const func0 = require("foo").default;')
+    })
+
+    it("returns a new named import instance referencing the function when an import is present", () => {
+      const fn = {code: 'require("foo").default', import: ["default", "foo"]} as const
+      const name = useFunc(gen, fn)
+      assert.strictEqual(name.str, "func0")
+      assert.strictEqual(gen.getScopeValue("func", fn)?.prefix, "func")
+      assert.strictEqual(gen.getScopeValue("func", fn)?.str, "func0")
+      assert.strictEqual(gen.getScopeValue("func", fn)?.value?.code instanceof NamedImport, true)
+      assert.strictEqual(gen.getScopeValue("func", fn)?.value?.ref, fn)
+      assert.strictEqual(gen.scopeCode().str, 'import { "default" as func0 } from "foo";')
     })
   })
 })

--- a/spec/codegen.spec.ts
+++ b/spec/codegen.spec.ts
@@ -32,7 +32,7 @@ describe("code generation", () => {
     it("throws if non-identifier is passed", () => {
       assert.throws(() => new NamedImport("1x", "foo"), /name must be a valid identifier/)
       assert.throws(() => new NamedImport("-x", "foo"), /name must be a valid identifier/)
-      assert.throws(() => new NamedImport("", "foo"), /name must be a valid identifier/)
+      new NamedImport("", "foo")
       new NamedImport("x", "foo")
     })
 
@@ -46,6 +46,10 @@ describe("code generation", () => {
 
     it("returns require call from toString method", () => {
       assert.strictEqual(new NamedImport("x", "foo").toString(), 'require("foo").x')
+    })
+
+    it("returns require call without property when name is empty", () => {
+      assert.strictEqual(new NamedImport("", "foo").str, 'require("foo")')
     })
 
     it("returns empty object from names getter", () => {

--- a/spec/standalone.spec.ts
+++ b/spec/standalone.spec.ts
@@ -35,7 +35,7 @@ function testImportTypeEsm(moduleCode: string) {
   assert.strictEqual(moduleCode.includes('.js";'), true)
   //Must not have
   assert.strictEqual(moduleCode.includes("require("), false)
-  assert.strictEqual(moduleCode.includes('.js.js'), false)
+  assert.strictEqual(moduleCode.includes(".js.js"), false)
 }
 function testImportTypeCjs(moduleCode: string) {
   //Must have
@@ -43,7 +43,7 @@ function testImportTypeCjs(moduleCode: string) {
   //Must not have
   assert.strictEqual(moduleCode.includes("import "), false)
   assert.strictEqual(moduleCode.includes('.js")'), false)
-  assert.strictEqual(moduleCode.includes('.js.js'), false)
+  assert.strictEqual(moduleCode.includes(".js.js"), false)
 }
 
 describe("standalone code generation", () => {

--- a/spec/standalone.spec.ts
+++ b/spec/standalone.spec.ts
@@ -6,6 +6,7 @@ import ajvFormats from "ajv-formats"
 import * as requireFromString from "require-from-string"
 import {importFromStringSync} from "module-from-string"
 import * as assert from "assert"
+import { NamedImport } from "../dist/compile/codegen"
 
 function testExportTypeEsm(moduleCode: string, singleExport: boolean) {
   //Must have
@@ -377,6 +378,17 @@ describe("standalone code generation", () => {
           required: ["email"],
           additionalProperties: false,
         },
+        ProductPage: {
+          type: "object",
+          properties: {
+            location: {
+              type: "string",
+              format: "uri",
+            },
+          },
+          required: ["uri"],
+          additionalProperties: false,
+        },
       },
     }
 
@@ -391,6 +403,32 @@ describe("standalone code generation", () => {
       assert.strictEqual(validateUser({}), false)
       assert.strictEqual(validateUser({email: "foo"}), false)
       assert.strictEqual(validateUser({email: "foo@bar.com"}), true)
+    })
+
+    it("should generate require calls when esm flag is disabled", () => {
+      const ajv = new _Ajv({code: {source: true, esm: false}})
+      ajvFormats(ajv)
+      ajv.addSchema(schema)
+      const moduleCode = standaloneCode(ajv, {validateUser: "#/definitions/ProductPage"})
+
+      assert.strictEqual(moduleCode.includes('require("ajv-formats/dist/formats").fullFormats.uri'), true)
+      assert.strictEqual(moduleCode.includes('import {'), false)
+      assert.strictEqual(moduleCode.includes('from "ajv-formats'), false)
+    })
+
+    it("should generate import statements when esm flag is enabled", () => {
+      const ajv = new _Ajv({code: {source: true, esm: true}})
+      // Can use ajvFormats(ajv) instead once ajv-format was updated to support ESM
+      // ajvFormats(ajv)
+      ajv.opts.code.formats = new NamedImport("formats", "ajv-formats/dist/formats", ".js")
+      ajv.addFormat("uri", () => true);
+
+      ajv.addSchema(schema)
+      const moduleCode = standaloneCode(ajv, {validateUser: "#/definitions/ProductPage"})
+
+      assert.strictEqual(moduleCode.includes('import { "formats"'), true)
+      assert.strictEqual(moduleCode.includes('from "ajv-formats/dist/formats.js";'), true)
+      assert.strictEqual(moduleCode.includes('require('), false)
     })
   })
 

--- a/spec/standalone.spec.ts
+++ b/spec/standalone.spec.ts
@@ -32,14 +32,18 @@ function testImportTypeEsm(moduleCode: string) {
   assert.strictEqual(moduleCode.includes("import { "), true)
   assert.strictEqual(moduleCode.includes(" as "), true)
   assert.strictEqual(moduleCode.includes(' from "'), true)
+  assert.strictEqual(moduleCode.includes('.js";'), true)
   //Must not have
   assert.strictEqual(moduleCode.includes("require("), false)
+  assert.strictEqual(moduleCode.includes('.js.js'), false)
 }
 function testImportTypeCjs(moduleCode: string) {
   //Must have
   assert.strictEqual(moduleCode.includes(' = require("'), true)
   //Must not have
   assert.strictEqual(moduleCode.includes("import "), false)
+  assert.strictEqual(moduleCode.includes('.js")'), false)
+  assert.strictEqual(moduleCode.includes('.js.js'), false)
 }
 
 describe("standalone code generation", () => {

--- a/spec/standalone.spec.ts
+++ b/spec/standalone.spec.ts
@@ -27,6 +27,21 @@ function testExportTypeCjs(moduleCode: string, singleExport: boolean) {
   assert.strictEqual(moduleCode.includes("export const"), false)
 }
 
+function testImportTypeEsm(moduleCode: string) {
+  //Must have
+  assert.strictEqual(moduleCode.includes("import { "), true)
+  assert.strictEqual(moduleCode.includes(" as "), true)
+  assert.strictEqual(moduleCode.includes(' from "'), true)
+  //Must not have
+  assert.strictEqual(moduleCode.includes("require("), false)
+}
+function testImportTypeCjs(moduleCode: string) {
+  //Must have
+  assert.strictEqual(moduleCode.includes(' = require("'), true)
+  //Must not have
+  assert.strictEqual(moduleCode.includes("import "), false)
+}
+
 describe("standalone code generation", () => {
   describe("multiple exports", () => {
     let ajv: Ajv
@@ -103,6 +118,28 @@ describe("standalone code generation", () => {
             throw err
           }
         }
+      })
+
+      it("should generate module code with require calls - CJS", () => {
+        ajv = new _Ajv({code: {source: true}})
+        ajv.addSchema(numSchema)
+        ajv.addSchema(strSchema)
+        const moduleCode = standaloneCode(ajv, {
+          validateNumber: "https://example.com/number.json",
+          validateString: "https://example.com/string.json",
+        })
+        testImportTypeCjs(moduleCode)
+      })
+
+      it("should generate module code with named imports - ESM", () => {
+        ajv = new _Ajv({code: {source: true, esm: true}})
+        ajv.addSchema(numSchema)
+        ajv.addSchema(strSchema)
+        const moduleCode = standaloneCode(ajv, {
+          validateNumber: "https://example.com/number.json",
+          validateString: "https://example.com/string.json",
+        })
+        testImportTypeEsm(moduleCode)
       })
     })
 

--- a/spec/standalone.spec.ts
+++ b/spec/standalone.spec.ts
@@ -6,7 +6,7 @@ import ajvFormats from "ajv-formats"
 import * as requireFromString from "require-from-string"
 import {importFromStringSync} from "module-from-string"
 import * as assert from "assert"
-import { NamedImport } from "../dist/compile/codegen"
+import {NamedImport} from "../dist/compile/codegen"
 
 function testExportTypeEsm(moduleCode: string, singleExport: boolean) {
   //Must have
@@ -405,30 +405,46 @@ describe("standalone code generation", () => {
       assert.strictEqual(validateUser({email: "foo@bar.com"}), true)
     })
 
-    it("should generate require calls when esm flag is disabled", () => {
+    it("should generate require call when esm flag is disabled", () => {
       const ajv = new _Ajv({code: {source: true, esm: false}})
       ajvFormats(ajv)
       ajv.addSchema(schema)
       const moduleCode = standaloneCode(ajv, {validateUser: "#/definitions/ProductPage"})
 
-      assert.strictEqual(moduleCode.includes('require("ajv-formats/dist/formats").fullFormats.uri'), true)
-      assert.strictEqual(moduleCode.includes('import {'), false)
+      assert.strictEqual(
+        moduleCode.includes('require("ajv-formats/dist/formats").fullFormats.uri'),
+        true
+      )
+      assert.strictEqual(moduleCode.includes("import {"), false)
       assert.strictEqual(moduleCode.includes('from "ajv-formats'), false)
     })
 
-    it("should generate import statements when esm flag is enabled", () => {
+    it("should generate named import statement when esm flag is enabled", () => {
       const ajv = new _Ajv({code: {source: true, esm: true}})
       // Can use ajvFormats(ajv) instead once ajv-format was updated to support ESM
       // ajvFormats(ajv)
       ajv.opts.code.formats = new NamedImport("formats", "ajv-formats/dist/formats", ".js")
-      ajv.addFormat("uri", () => true);
+      ajv.addFormat("uri", () => true)
 
       ajv.addSchema(schema)
       const moduleCode = standaloneCode(ajv, {validateUser: "#/definitions/ProductPage"})
 
       assert.strictEqual(moduleCode.includes('import { "formats"'), true)
       assert.strictEqual(moduleCode.includes('from "ajv-formats/dist/formats.js";'), true)
-      assert.strictEqual(moduleCode.includes('require('), false)
+      assert.strictEqual(moduleCode.includes("require("), false)
+    })
+
+    it("should generate star import statement when name is empty", () => {
+      const ajv = new _Ajv({code: {source: true, esm: true}})
+      ajv.opts.code.formats = new NamedImport("", "./myFormat", ".js")
+      ajv.addFormat("uri", () => true)
+
+      ajv.addSchema(schema)
+      const moduleCode = standaloneCode(ajv, {validateUser: "#/definitions/ProductPage"})
+
+      assert.strictEqual(moduleCode.includes("import * as "), true)
+      assert.strictEqual(moduleCode.includes('from "./myFormat.js";'), true)
+      assert.strictEqual(moduleCode.includes("require("), false)
     })
   })
 


### PR DESCRIPTION
**What issue does this pull request resolve?**

#2598

When `code.esm` is disabled, the generated code still is

```js
const func0 = require("ajv/dist/runtime/ucs2length").default;
export const SomeType = validate10;

const formats0 = require("ajv-formats/dist/formats").fullFormats.uri;
const formats2 = /^[a-z0-9!...?$/i;
```

When `code.esm` is enabled, the generated code now is

```js
import { "ucs2length" as func0 } from "ajv/dist/runtime/ucs2length.js";
export const SomeType = validate10;

import { "fullFormats" as formats0 } from "ajv-formats/dist/formats.js";
const formats1 = formats0.uri;
const formats4 = /^[a-z0-9!...?$/i;
```

**What changes did you make?**

CodeGen: Output import statements when esm mode is enabled

The change consists of 5 steps:

(1) Add `import` property to built-in functions that contain the module name and the name of the symbol to be imported. The ESM import contains the import extensions, required for strict ESM compatiblity (otherwise, browsers or Node.JS may fail to resolve the files). The `code` property could be removed, but I kept it for now due to compatibility (unsure if that is part of some API).

Also expose non-default exports for runtime functions.  ESM default imports from a CJS file are prone to error and do not work in some environments. E.g. Node.JS wraps the import in an additional `default` property. Avoid issues by adding an additional named export and use that in the generated code.

(2) Widen `Code` type to  `_Code | Name | NamedImport`. The `NamedImport` type describes, as the name  suggests, a named import. It consists of a module name and the name of the symbol to be imported. Default behavior  (property str, method toString) is to generate a require statement.

(3) `useFunc` from `util.ts` now creates a `NamedImport` instance instead of `_Code` instance.

(4) When generating the actual code in `ValueScope._reduceValues` and the esm flag is enabled, output import statements instead of require calls.

(5) `opts.code.formats` now also supports `NamedImport`. When set to a `NamedImport`, the generated code imports the formats from the specified import. `getFormat` from `format.ts` was adjusted accordingly.

**Is there anything that requires more attention while reviewing?**

* Do we need an additional option to opt-in into emitting `import { a as b } from "ajv/..."` instead of `const a = require("ajv/..")`? I don't think so, but in principle, we do not know what people are doing with the generated code, so it's not unconceivable somebody does something with it that might break something. Although in my opinion, mixing `require` with import` is weird and far more likely to break.
* [Somebody mentioned](https://github.com/ajv-validator/ajv/issues/2598#issuecomment-4412354896) `ajv-formats` also generates `require` statements. If this PR gets accepted, ajv-format can be adjusted to support ESM imports by [changing this line](https://github.com/ajv-validator/ajv-formats/blob/4ca86d21bd07571a30178cbb3714133db6eada9a/src/index.ts#L55) to use the new `NamedImport` subtype of `Code`. But note that `ajv-format` should first be distributed as a proper ESM module, otherwise attempting to import CJS code may fail.

```js
  // In https://github.com/ajv-validator/ajv-formats/blob/4ca86d21bd07571a30178cbb3714133db6eada9a/src/index.ts#L55
  ajv.opts.code.formats ??= new NamedImport(exportName, "ajv-formats/dist/formats", ".js")
```