### PR TITLE
Fix dynamicRef resolution for nested dynamic anchors

### DIFF
--- a/lib/vocabularies/core/ref.ts
+++ b/lib/vocabularies/core/ref.ts
@@ -2,9 +2,9 @@ import type {CodeKeywordDefinition, AnySchema} from "../../types"
 import type {KeywordCxt} from "../../compile/validate"
 import MissingRefError from "../../compile/ref_error"
 import {callValidateCode} from "../code"
-import {_, nil, stringify, Code, Name} from "../../compile/codegen"
+import {_, nil, stringify, getProperty, Code, Name} from "../../compile/codegen"
 import N from "../../compile/names"
-import {SchemaEnv, resolveRef} from "../../compile"
+import {SchemaEnv, compileSchema, resolveRef} from "../../compile"
 import {mergeEvaluated} from "../../compile/util"
 
 const def: CodeKeywordDefinition = {
@@ -64,8 +64,22 @@ export function callRef(cxt: KeywordCxt, v: Code, sch?: SchemaEnv, $async?: bool
   const {gen, it} = cxt
   const {allErrors, schemaEnv: env, opts} = it
   const passCxt = opts.passContext ? N.this : nil
+  if (opts.dynamicRef) setDynamicAnchors()
   if ($async) callAsyncRef()
   else callSyncRef()
+
+  function setDynamicAnchors(): void {
+    for (const anchor in env.root.dynamicAnchors) {
+      const ref = anchor ? `#${anchor}` : "#"
+      const anchorSchema = getDynamicAnchorSchema(cxt, ref, anchor)
+      if (anchorSchema) {
+        const dynamicAnchor = _`${N.dynamicAnchors}${getProperty(anchor)}`
+        gen.if(_`!${dynamicAnchor}`, () =>
+          gen.assign(dynamicAnchor, getValidate(cxt, anchorSchema))
+        )
+      }
+    }
+  }
 
   function callAsyncRef(): void {
     if (!env.$async) throw new Error("async schema referenced by sync schema")
@@ -124,6 +138,34 @@ export function callRef(cxt: KeywordCxt, v: Code, sch?: SchemaEnv, $async?: bool
       }
     }
   }
+}
+
+function getDynamicAnchorSchema(
+  cxt: KeywordCxt,
+  ref: string,
+  anchor: string
+): SchemaEnv | undefined {
+  const {schemaEnv: env, self, baseId} = cxt.it
+  const schOrEnv = resolveRef.call(self, env.root, baseId, ref)
+  if (schOrEnv === undefined) return
+  const sch = schOrEnv instanceof SchemaEnv ? schOrEnv : compileRef(cxt, schOrEnv)
+  if (!hasDynamicAnchor(sch.schema, anchor)) return
+  return sch
+}
+
+function compileRef(cxt: KeywordCxt, schema: AnySchema): SchemaEnv {
+  const {schemaEnv: env, self, baseId} = cxt.it
+  const {schemaId} = self.opts
+  const sch = new SchemaEnv({schema, schemaId, root: env.root, baseId})
+  compileSchema.call(self, sch)
+  return sch
+}
+
+function hasDynamicAnchor(schema: AnySchema, anchor: string): boolean {
+  return (
+    typeof schema == "object" &&
+    (anchor ? schema.$dynamicAnchor === anchor : schema.$recursiveAnchor === true)
+  )
 }
 
 export default def

--- a/lib/vocabularies/dynamic/dynamicRef.ts
+++ b/lib/vocabularies/dynamic/dynamicRef.ts
@@ -1,8 +1,10 @@
-import type {CodeKeywordDefinition} from "../../types"
+import type {AnySchema, CodeKeywordDefinition} from "../../types"
 import type {KeywordCxt} from "../../compile/validate"
 import {_, getProperty, Code, Name} from "../../compile/codegen"
 import N from "../../compile/names"
-import {callRef} from "../core/ref"
+import {SchemaEnv, compileSchema, resolveRef} from "../../compile"
+import MissingRefError from "../../compile/ref_error"
+import {callRef, getValidate} from "../core/ref"
 
 const def: CodeKeywordDefinition = {
   keyword: "$dynamicRef",
@@ -23,29 +25,54 @@ export function dynamicRef(cxt: KeywordCxt, ref: string): void {
   }
 
   function _dynamicRef(valid?: Name): void {
-    // TODO the assumption here is that `recursiveRef: #` always points to the root
-    // of the schema object, which is not correct, because there may be $id that
-    // makes # point to it, and the target schema may not contain dynamic/recursiveAnchor.
-    // Because of that 2 tests in recursiveRef.json fail.
-    // This is a similar problem to #815 (`$id` doesn't alter resolution scope for `{ "$ref": "#" }`).
-    // (This problem is not tested in JSON-Schema-Test-Suite)
-    if (it.schemaEnv.root.dynamicAnchors[anchor]) {
+    const staticRef = getStaticRef(cxt, ref, anchor)
+    if (staticRef.dynamic) {
       const v = gen.let("_v", _`${N.dynamicAnchors}${getProperty(anchor)}`)
-      gen.if(v, _callRef(v, valid), _callRef(it.validateName, valid))
+      gen.if(v, _callRef(v, valid), _callRef(staticRef.validate, valid, staticRef.schemaEnv))
     } else {
-      _callRef(it.validateName, valid)()
+      _callRef(staticRef.validate, valid, staticRef.schemaEnv)()
     }
   }
 
-  function _callRef(validate: Code, valid?: Name): () => void {
+  function _callRef(validate: Code, valid?: Name, schemaEnv?: SchemaEnv): () => void {
     return valid
       ? () =>
           gen.block(() => {
-            callRef(cxt, validate)
+            callRef(cxt, validate, schemaEnv, schemaEnv?.$async)
             gen.let(valid, true)
           })
-      : () => callRef(cxt, validate)
+      : () => callRef(cxt, validate, schemaEnv, schemaEnv?.$async)
   }
+}
+
+function getStaticRef(
+  cxt: KeywordCxt,
+  ref: string,
+  anchor: string
+): {validate: Code; schemaEnv?: SchemaEnv; dynamic: boolean} {
+  const {baseId, schemaEnv, self} = cxt.it
+  const staticRef = resolveRef.call(self, schemaEnv.root, baseId, ref)
+  if (staticRef === undefined) {
+    if (schemaEnv.root.dynamicAnchors[anchor]) {
+      return {validate: cxt.it.validateName, dynamic: true}
+    }
+    throw new MissingRefError(self.opts.uriResolver, baseId, ref)
+  }
+  const refEnv = staticRef instanceof SchemaEnv ? staticRef : compileRef(cxt, staticRef)
+  const {schema} = refEnv
+  const dynamic =
+    typeof schema == "object" &&
+    (anchor ? schema.$dynamicAnchor === anchor : schema.$recursiveAnchor === true)
+  return {validate: getValidate(cxt, refEnv), schemaEnv: refEnv, dynamic}
+}
+
+function compileRef(cxt: KeywordCxt, schema: AnySchema): SchemaEnv {
+  const {schemaEnv, self} = cxt.it
+  const {schemaId} = self.opts
+  const {root, baseId, localRefs, meta} = schemaEnv.root
+  const sch = new SchemaEnv({schema, schemaId, root, baseId, localRefs, meta})
+  compileSchema.call(self, sch)
+  return sch
 }
 
 export default def

--- a/spec/dynamic-ref.spec.ts
+++ b/spec/dynamic-ref.spec.ts
@@ -1,6 +1,7 @@
 import type Ajv from "../dist/core"
 import type {SchemaObject} from ".."
 import _Ajv from "./ajv2019"
+import _Ajv2020 from "./ajv2020"
 import getAjvInstances from "./ajv_instances"
 import options from "./ajv_options"
 import * as assert from "assert"
@@ -43,6 +44,29 @@ describe("recursiveRef and dynamicRef", () => {
   })
 
   describe("dynamicRef", () => {
+    it("should resolve dynamicRef to a nested dynamicAnchor in the same schema resource", () => {
+      const schema = {
+        $schema: "https://json-schema.org/draft/2020-12/schema",
+        type: "object",
+        properties: {
+          schema: {$dynamicRef: "#meta"},
+        },
+        unevaluatedProperties: false,
+        $defs: {
+          schema: {
+            $dynamicAnchor: "meta",
+            type: ["object", "boolean"],
+          },
+        },
+      }
+
+      const ajv = new _Ajv2020({strict: false})
+      const validate = ajv.compile(schema)
+
+      assert.strictEqual(validate({schema: {type: "string"}}), true)
+      assert.strictEqual(validate({schema: "string"}), false)
+    })
+
     it("should allow extending recursive schema with dynamicRef (future draft2020)", () => {
       const treeSchema = {
         $id: "https://example.com/tree",

--- a/spec/json-schema.spec.ts
+++ b/spec/json-schema.spec.ts
@@ -81,12 +81,6 @@ runTest({
   }),
   draft: 2019,
   tests: skipTestCases(require("./_json/draft2019"), {
-    recursiveRef: {
-      "$recursiveRef with no $recursiveAnchor in the initial target schema resource": [
-        "leaf node matches: recursion uses the inner schema",
-        "leaf node does not match: recursion uses the inner schema",
-      ],
-    },
     ref: {
       "refs with relative uris and defs": [
         "invalid on inner field",
@@ -120,14 +114,6 @@ runTest({
   draft: 2020,
   tests: skipTestCases(require("./_json/draft2020"), {
     dynamicRef: {
-      "A $dynamicRef to a $dynamicAnchor in the same schema resource should behave like a normal $ref to an $anchor":
-        ["An array of strings is valid"],
-      "A $dynamicRef to an $anchor in the same schema resource should behave like a normal $ref to an $anchor":
-        ["An array of strings is valid"],
-      "A $dynamicRef should resolve to the first $dynamicAnchor still in scope that is encountered when the schema is evaluated":
-        ["An array of strings is valid"],
-      "A $dynamicRef with intermediate scopes that don't include a matching $dynamicAnchor should not affect dynamic scope resolution":
-        ["An array of strings is valid"],
       "An $anchor with the same name as a $dynamicAnchor should not be used for dynamic scope resolution":
         ["Any array is valid"],
       "A $dynamicRef without a matching $dynamicAnchor in the same schema resource should behave like a normal $ref to $anchor":


### PR DESCRIPTION
## What

Fixes `$dynamicRef`/`$recursiveRef` resolution when the initial target is a nested `$dynamicAnchor`/`$recursiveAnchor`, rather than assuming dynamic refs always fall back to the current/root validator.

This addresses the OpenAPI 3.1-style reproduction in #1745 and enables several previously skipped JSON Schema Test Suite cases.

## Why

`$dynamicRef: "#meta"` should first resolve like a normal reference to the matching anchor in the current schema resource. If that target is a dynamic anchor, runtime dynamic scope can override it. If the initial target is only a normal `$anchor`, it should behave like `$ref`.

## Changes

- Resolve the static target for `$dynamicRef` before deciding whether dynamic dispatch applies.
- Preserve normal `$anchor` fallback behavior when the static target is not dynamic.
- Populate dynamic-anchor scope when calling referenced schemas so outer dynamic anchors can override nested bookend anchors.
- Add the #1745 minimal reproduction to `spec/dynamic-ref.spec.ts`.
- Unskip passing recursive/dynamic ref JSON Schema Test Suite cases.

## Validation

- `npm install`
- `npm run json-tests`
- `npm run build`
- `npm run eslint -- lib/vocabularies/core/ref.ts lib/vocabularies/dynamic/dynamicRef.ts spec/dynamic-ref.spec.ts spec/json-schema.spec.ts`
- `TS_NODE_PROJECT=spec/tsconfig.json npx mocha -r ts-node/register spec/dynamic-ref.spec.ts -R dot`
- `TS_NODE_TRANSPILE_ONLY=1 TS_NODE_PROJECT=spec/tsconfig.json npx mocha -r ts-node/register spec/dynamic-ref.spec.ts spec/json-schema.spec.ts -R dot --grep "dynamicRef|recursiveRef"`

The broader `spec/json-schema.spec.ts` run still hits unrelated existing local standalone/format failures such as `formats12 is not a function`; the dynamicRef/recursiveRef subset above passes.

Refs #1745