### PR TITLE
Fix evaluated properties with dependentSchemas

### DIFF
--- a/lib/vocabularies/applicator/dependencies.ts
+++ b/lib/vocabularies/applicator/dependencies.ts
@@ -6,8 +6,8 @@ import type {
   AnySchema,
 } from "../../types"
 import type {KeywordCxt} from "../../compile/validate"
-import {_, str} from "../../compile/codegen"
-import {alwaysValidSchema} from "../../compile/util"
+import {_, str, Name} from "../../compile/codegen"
+import {alwaysValidSchema, mergeEvaluated} from "../../compile/util"
 import {checkReportMissingProp, checkMissingProp, reportMissingProp, propertyInData} from "../code"
 
 export type PropertyDependencies = {[K in string]?: string[]}
@@ -95,8 +95,13 @@ export function validatePropertyDeps(
 export function validateSchemaDeps(cxt: KeywordCxt, schemaDeps: SchemaMap = cxt.schema): void {
   const {gen, data, keyword, it} = cxt
   const valid = gen.name("valid")
+  let evaluatedInitialized = false
   for (const prop in schemaDeps) {
     if (alwaysValidSchema(it, schemaDeps[prop] as AnySchema)) continue
+    if (!evaluatedInitialized) {
+      initEvaluated(cxt)
+      evaluatedInitialized = true
+    }
     gen.if(
       propertyInData(gen, data, prop, it.opts.ownProperties),
       () => {
@@ -106,6 +111,16 @@ export function validateSchemaDeps(cxt: KeywordCxt, schemaDeps: SchemaMap = cxt.
       () => gen.var(valid, true) // TODO var
     )
     cxt.ok(valid)
+  }
+}
+
+function initEvaluated({gen, it}: KeywordCxt): void {
+  if (!it.opts.unevaluated) return
+  if (it.props !== true && it.props !== undefined) {
+    it.props = mergeEvaluated.props(gen, it.props, undefined, Name)
+  }
+  if (it.items !== true && it.items !== undefined) {
+    it.items = mergeEvaluated.items(gen, it.items, undefined, Name)
   }
 }
 

--- a/spec/issues/2483_unevaluated_properties_dependent_schemas.spec.ts
+++ b/spec/issues/2483_unevaluated_properties_dependent_schemas.spec.ts
@@ -1,0 +1,41 @@
+import _Ajv from "../ajv2020"
+import * as assert from "assert"
+
+describe("unevaluatedProperties with dependentSchemas", () => {
+  it("should keep adjacent properties evaluated when dependency property is absent", () => {
+    const ajv = new _Ajv()
+
+    const schema = {
+      type: "object",
+      properties: {
+        name: {type: "string"},
+        link: {type: "boolean"},
+      },
+      required: ["name"],
+      unevaluatedProperties: false,
+      dependentSchemas: {
+        link: {
+          if: {
+            properties: {
+              link: {const: true},
+            },
+          },
+          then: {
+            properties: {
+              originalId: {type: "string"},
+            },
+            required: ["originalId"],
+          },
+        },
+      },
+    }
+
+    const validate = ajv.compile(schema)
+
+    assert.strictEqual(validate({name: "test"}), true)
+    assert.strictEqual(validate({name: "test", link: false}), true)
+    assert.strictEqual(validate({name: "test", link: true, originalId: "1"}), true)
+    assert.strictEqual(validate({name: "test", link: true}), false)
+    assert.strictEqual(validate({name: "test", extra: 1}), false)
+  })
+})


### PR DESCRIPTION
**What issue does this pull request resolve?**

Fixes #2483.

**What changes did you make?**

`dependentSchemas` now initializes any already-tracked evaluated properties before entering the dependency-property branch. This keeps adjacent `properties` marks available when the dependency property is absent, so `unevaluatedProperties: false` does not incorrectly report an adjacent property as unevaluated.

Added an issue regression test covering the absent dependency property case, false/true conditional dependency branches, and the expected failure when `then` applies without the required property.

**Is there anything that requires more attention while reviewing?**

Local verification:

- `npm run build`
- `TS_NODE_PROJECT=spec/tsconfig.json npx mocha -r ts-node/register spec/issues/2483_unevaluated_properties_dependent_schemas.spec.ts -R spec`
- `npm run json-tests`
- `npm run test-spec`
- `npm run eslint`
- `npm run prettier:check`
- `npm test`
- `npm run test-codegen`
- `git diff --check`