### PR TITLE
fix: guard equal() against non-function toString/valueOf properties

### DIFF
--- a/lib/runtime/equal.ts
+++ b/lib/runtime/equal.ts
@@ -1,7 +1,28 @@
 // https://github.com/ajv-validator/ajv/issues/889
 import * as equal from "fast-deep-equal"
 
-type Equal = typeof equal & {code: string}
-;(equal as Equal).code = 'require("ajv/dist/runtime/equal").default'
+// Guard against TypeError when objects have non-function toString/valueOf properties
+// (see https://github.com/ajv-validator/ajv/issues/2624)
+function safeEqual(a: unknown, b: unknown): boolean {
+  if (a && typeof a === "object") {
+    safeGuard(a as Record<string, unknown>)
+  }
+  if (b && typeof b === "object") {
+    safeGuard(b as Record<string, unknown>)
+  }
+  return equal(a, b)
+}
 
-export default equal as Equal
+function safeGuard(obj: Record<string, unknown>) {
+  if (typeof obj.toString !== "function") {
+    obj.toString = Object.prototype.toString as () => string
+  }
+  if (typeof obj.valueOf !== "function") {
+    obj.valueOf = Object.prototype.valueOf as () => unknown
+  }
+}
+
+type Equal = typeof equal & {code: string}
+;(safeEqual as Equal).code = 'require("ajv/dist/runtime/equal").default'
+
+export default safeEqual as Equal

--- a/lib/runtime/equal.ts
+++ b/lib/runtime/equal.ts
@@ -5,20 +5,21 @@ import * as equal from "fast-deep-equal"
 // (see https://github.com/ajv-validator/ajv/issues/2624)
 function safeEqual(a: unknown, b: unknown): boolean {
   if (a && typeof a === "object") {
-    safeGuard(a as Record<string, unknown>)
+    safeGuard(a)
   }
   if (b && typeof b === "object") {
-    safeGuard(b as Record<string, unknown>)
+    safeGuard(b)
   }
   return equal(a, b)
 }
 
-function safeGuard(obj: Record<string, unknown>) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function safeGuard(obj: any) {
   if (typeof obj.toString !== "function") {
-    obj.toString = Object.prototype.toString as () => string
+    obj.toString = Object.prototype.toString
   }
   if (typeof obj.valueOf !== "function") {
-    obj.valueOf = Object.prototype.valueOf as () => unknown
+    obj.valueOf = Object.prototype.valueOf
   }
 }
 

--- a/lib/runtime/equal.ts
+++ b/lib/runtime/equal.ts
@@ -14,12 +14,12 @@ function safeEqual(a: unknown, b: unknown): boolean {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function safeGuard(obj: any) {
+function safeGuard(obj: any): void {
   if (typeof obj.toString !== "function") {
-    obj.toString = Object.prototype.toString
+    obj.toString = (): string => Object.prototype.toString.call(obj)
   }
   if (typeof obj.valueOf !== "function") {
-    obj.valueOf = Object.prototype.valueOf
+    obj.valueOf = (): unknown => Object.prototype.valueOf.call(obj)
   }
 }
 


### PR DESCRIPTION
Fixes #2624

Why
The `uniqueItems`, `enum` and `const` keywords use `fast-deep-equal` for deep equality comparisons. When an object has `toString` or `valueOf` set to a non-function value (e.g. `{toString: ""}`), the library crashes with `TypeError: a.toString is not a function`. This allows a trivial 22-byte JSON payload `[{},{"toString":""}]` to DoS any endpoint validating inbound arrays with `uniqueItems:true`.

Changes
Wrapped the `fast-deep-equal` call in a safe wrapper (`safeEqual`) that restores `Object.prototype.toString` and `Object.prototype.valueOf` on both operands before comparing, if the properties exist but are not functions.

Updated component: `lib/runtime/equal.ts`

Testing
- `uniqueItems` no longer crashes on `[{}, {toString: ""}]`
- `uniqueItems` no longer crashes on `[{}, {valueOf: null}]`
- `uniqueItems` no longer crashes on `[{}, {toString: 0}]`
- Objects with normal `toString`/`valueOf` continue to work unchanged

Surface area
- Runtime / equal
- Bug fix
- Security (DoS via prototype property shadowing)