### PR TITLE
Fix: coercion issue with infinity

### DIFF
--- a/lib/compile/validate/dataType.ts
+++ b/lib/compile/validate/dataType.ts
@@ -108,7 +108,7 @@ function coerceData(it: SchemaObjCxt, types: JSONType[], coerceTo: JSONType[]): 
         gen
           .elseIf(
             _`${dataType} === "boolean" || ${data} === null
-              || (${dataType} === "string" && ${data} && ${data} == +${data} && !(${data} % 1))`
+        || (${dataType} === "string" && ${data} && ${data} == +${data} && isFinite(+${data}) && !(${data} % 1))`
           )
           .assign(coerced, _`+${data}`)
         return

--- a/lib/compile/validate/dataType.ts
+++ b/lib/compile/validate/dataType.ts
@@ -100,7 +100,7 @@ function coerceData(it: SchemaObjCxt, types: JSONType[], coerceTo: JSONType[]): 
         gen
           .elseIf(
             _`${dataType} == "boolean" || ${data} === null
-              || (${dataType} == "string" && ${data} && ${data} == +${data})`
+              || (${dataType} == "string" && ${data} && ${data} == +${data}) && isFinite(+${data})`
           )
           .assign(coerced, _`+${data}`)
         return

--- a/spec/coercion.spec.ts
+++ b/spec/coercion.spec.ts
@@ -467,7 +467,22 @@ describe("Type coercion", () => {
       validate.errors?.pop()?.keyword.should.equal("contains")
     })
   })
+  it("coerceTypes with non-finite values", () => {
+    const schema = {
+      type: "integer",
+    }
 
+    instances.forEach((_ajv) => {
+      console.log(_ajv.validate.toString())
+      _ajv.validate(schema, "Infinity").should.equal(false)
+      _ajv.validate(schema, "9e600").should.equal(false)
+      _ajv.validate(schema, "9E600").should.equal(false)
+
+      _ajv.validate(schema, "-Infinity").should.equal(false)
+      _ajv.validate(schema, "-9e600").should.equal(false)
+      _ajv.validate(schema, "-9E600").should.equal(false)
+    })
+  })
   function testRules(rules, cb) {
     for (const toType in rules) {
       for (const fromType in rules[toType]) {

--- a/spec/coercion.spec.ts
+++ b/spec/coercion.spec.ts
@@ -482,6 +482,22 @@ describe("Type coercion", () => {
       _ajv.validate(schema, "-9E600").should.equal(false)
     })
   })
+  it("coerceTypes with non-finite values with number", () => {
+    const schema = {
+      type: "number",
+    }
+
+    instances.forEach((_ajv) => {
+      _ajv.validate(schema, "Infinity").should.equal(false)
+      _ajv.validate(schema, "9e600").should.equal(false)
+      _ajv.validate(schema, "9E600").should.equal(false)
+
+      _ajv.validate(schema, "-Infinity").should.equal(false)
+      _ajv.validate(schema, "-9e600").should.equal(false)
+      _ajv.validate(schema, "-9E600").should.equal(false)
+    })
+  })
+
   function testRules(rules, cb) {
     for (const toType in rules) {
       for (const fromType in rules[toType]) {

--- a/spec/coercion.spec.ts
+++ b/spec/coercion.spec.ts
@@ -473,7 +473,6 @@ describe("Type coercion", () => {
     }
 
     instances.forEach((_ajv) => {
-      console.log(_ajv.validate.toString())
       _ajv.validate(schema, "Infinity").should.equal(false)
       _ajv.validate(schema, "9e600").should.equal(false)
       _ajv.validate(schema, "9E600").should.equal(false)


### PR DESCRIPTION
## **What issue does this pull request resolve?**

[found this issue form fastify library](https://github.com/fastify/fastify/issues/6718)

This PR fixes a validation issue where `ajv` incorrectly validates non-finite values (e.g., `"Infinity"`, `"9e600"`) as `integer` types when `coerceTypes` is enabled.

## **What changes did you make?**

I added an `isFinite(+${data})` check to the integer validation logic. This ensures that coerced values must be finite numbers to be considered valid integers.

## **Is there anything that requires more attention while reviewing?**

* Please ensure the `isFinite` implementation aligns with the existing coercion patterns used across the codebase.
* The added test cases cover edge cases for both positive and negative non-finite values.
