### PR TITLE
fix: preserve evaluated props in dependent schemas

### DIFF
--- a/lib/vocabularies/applicator/dependencies.ts
+++ b/lib/vocabularies/applicator/dependencies.ts
@@ -6,8 +6,8 @@ import type {
   AnySchema,
 } from "../../types"
 import type {KeywordCxt} from "../../compile/validate"
-import {_, str} from "../../compile/codegen"
-import {alwaysValidSchema} from "../../compile/util"
+import {_, str, Name} from "../../compile/codegen"
+import {alwaysValidSchema, mergeEvaluated} from "../../compile/util"
 import {checkReportMissingProp, checkMissingProp, reportMissingProp, propertyInData} from "../code"
 
 export type PropertyDependencies = {[K in string]?: string[]}
@@ -97,6 +97,14 @@ export function validateSchemaDeps(cxt: KeywordCxt, schemaDeps: SchemaMap = cxt.
   const valid = gen.name("valid")
   for (const prop in schemaDeps) {
     if (alwaysValidSchema(it, schemaDeps[prop] as AnySchema)) continue
+    if (
+      it.opts.unevaluated &&
+      it.props !== true &&
+      it.props !== undefined &&
+      !(it.props instanceof Name)
+    ) {
+      it.props = mergeEvaluated.props(gen, it.props, undefined, Name)
+    }
     gen.if(
       propertyInData(gen, data, prop, it.opts.ownProperties),
       () => {

--- a/spec/issues/2483_dependent_schemas_unevaluated_properties.spec.ts
+++ b/spec/issues/2483_dependent_schemas_unevaluated_properties.spec.ts
@@ -1,0 +1,45 @@
+import _Ajv from "../ajv2020"
+import * as assert from "assert"
+
+describe("issue #2483: dependentSchemas with unevaluatedProperties", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      name: {type: "string"},
+      link: {type: "boolean"},
+    },
+    required: ["name"],
+    unevaluatedProperties: false,
+    dependentSchemas: {
+      link: {
+        if: {
+          properties: {
+            link: {const: true},
+          },
+        },
+        then: {
+          properties: {
+            originalId: {type: "string"},
+          },
+          required: ["originalId"],
+        },
+      },
+    },
+  }
+
+  it("preserves evaluated properties when dependentSchemas is not applied", () => {
+    const ajv = new _Ajv()
+    const validate = ajv.compile(schema)
+
+    assert.strictEqual(validate({name: "test"}), true)
+  })
+
+  it("still validates dependent schemas when the dependency property is present", () => {
+    const ajv = new _Ajv()
+    const validate = ajv.compile(schema)
+
+    assert.strictEqual(validate({name: "test", link: false}), true)
+    assert.strictEqual(validate({name: "test", link: true}), false)
+    assert.strictEqual(validate({name: "test", link: true, originalId: "123"}), true)
+  })
+})


### PR DESCRIPTION
Fixes #2483.

This keeps already evaluated object properties available when `dependentSchemas` has to switch from a static evaluated property set to a generated runtime set.

Before this change, a schema with `properties`, `unevaluatedProperties: false`, and `dependentSchemas` could lose the properties evaluated before `dependentSchemas` when the dependency property was absent. That made valid data such as `{ name: "test" }` fail as if `name` were unevaluated.

The fix initializes the current evaluated properties into the generated runtime set before compiling a non-trivial dependent schema. That way the dependency branch can still merge additional evaluated properties when it runs, while the original evaluated properties remain available when the dependency property is not present.

Verification:
- Added a regression spec for #2483
- Confirmed the new spec failed before the fix
- `npm run build`
- `./node_modules/.bin/cross-env TS_NODE_PROJECT=spec/tsconfig.json ./node_modules/.bin/mocha -r ts-node/register spec/issues/2483_dependent_schemas_unevaluated_properties.spec.ts spec/issues/1625_evaluated_truthy_pattern_properties.spec.ts spec/issues/1515_evaluated_properties_nested_anyof.spec.ts -R spec`
- `npm run prettier:check`
- `npx eslint lib/vocabularies/applicator/dependencies.ts spec/issues/2483_dependent_schemas_unevaluated_properties.spec.ts`
- `git diff --check`

Note: I also tried the full `npm run test-spec` path after `npm run json-tests`, but the local environment requires the repository's `npm link` step so `node_modules/ajv` resolves to the local package. `npm link` was blocked on this machine by `/usr/local/lib/node_modules` permissions, so I kept verification to the changed behavior and adjacent evaluated-properties specs.
