### PR TITLE
fix: prevent deep-equality crash on objects shadowing toString/valueOf

### DIFF
--- a/lib/runtime/equal.ts
+++ b/lib/runtime/equal.ts
@@ -1,5 +1,65 @@
 // https://github.com/ajv-validator/ajv/issues/889
-import * as equal from "fast-deep-equal"
+// https://github.com/ajv-validator/ajv/issues/2624
+//
+// Vendored from `fast-deep-equal` (which is unmaintained) with a guard around
+// the `valueOf`/`toString` shortcuts. The upstream implementation calls
+// `a.valueOf()`/`a.toString()` after only checking that the property differs
+// from `Object.prototype`, so a plain JSON value that shadows them with a
+// non-function (e.g. `{toString: ""}`) makes the call throw a `TypeError`.
+// Such values are valid JSON input, so `uniqueItems`, `enum` and `const` must
+// not crash on them.
+
+function equalArrays(a: any[], b: any[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = a.length; i-- !== 0; ) if (!equal(a[i], b[i])) return false
+  return true
+}
+
+// Returns the result of the `valueOf`/`toString` shortcut, or `null` when
+// neither applies (so the caller falls back to comparing own keys). A shadowed
+// non-function `valueOf`/`toString` is treated as a regular property rather
+// than being invoked.
+function equalByCustomMethod(a: any, b: any): boolean | null {
+  const aValueOf = a.valueOf
+  if (typeof aValueOf === "function" && aValueOf !== Object.prototype.valueOf) {
+    const bValueOf = b.valueOf
+    if (typeof bValueOf !== "function") return false
+    return (aValueOf as () => unknown).call(a) === (bValueOf as () => unknown).call(b)
+  }
+  const aToString = a.toString
+  if (typeof aToString === "function" && aToString !== Object.prototype.toString) {
+    const bToString = b.toString
+    if (typeof bToString !== "function") return false
+    return (aToString as () => unknown).call(a) === (bToString as () => unknown).call(b)
+  }
+  return null
+}
+
+function equalKeys(a: any, b: any): boolean {
+  const keys = Object.keys(a)
+  if (keys.length !== Object.keys(b).length) return false
+  for (const key of keys) {
+    if (!Object.prototype.hasOwnProperty.call(b, key)) return false
+    if (!equal(a[key], b[key])) return false
+  }
+  return true
+}
+
+function equal(a: any, b: any): boolean {
+  if (a === b) return true
+
+  if (a && b && typeof a === "object" && typeof b === "object") {
+    if (a.constructor !== b.constructor) return false
+    if (Array.isArray(a)) return equalArrays(a, b)
+    if (a.constructor === RegExp) return a.source === b.source && a.flags === b.flags
+    const byMethod = equalByCustomMethod(a, b)
+    if (byMethod !== null) return byMethod
+    return equalKeys(a, b)
+  }
+
+  // true if both NaN, false otherwise
+  return a !== a && b !== b
+}
 
 type Equal = typeof equal & {code: string}
 ;(equal as Equal).code = 'require("ajv/dist/runtime/equal").default'

--- a/spec/issues/2624_deep_equal_shadowed_tostring.spec.ts
+++ b/spec/issues/2624_deep_equal_shadowed_tostring.spec.ts
@@ -1,0 +1,23 @@
+import _Ajv from "../ajv"
+import chai from "../chai"
+chai.should()
+
+describe("issue #2624: deep equality crashes on objects shadowing toString/valueOf", () => {
+  it("should not throw for uniqueItems when an item shadows toString with a non-function", () => {
+    const ajv: any = new _Ajv()
+    const validate = ajv.compile({type: "array", uniqueItems: true})
+    validate([{}, {toString: ""}]).should.equal(true)
+  })
+
+  it("should not throw for enum when a value shadows valueOf with a non-function", () => {
+    const ajv: any = new _Ajv()
+    const validate = ajv.compile({enum: [{}, {valueOf: 0}]})
+    validate({}).should.equal(true)
+  })
+
+  it("should still detect duplicates that shadow toString with equal values", () => {
+    const ajv: any = new _Ajv()
+    const validate = ajv.compile({type: "array", uniqueItems: true})
+    validate([{toString: "x"}, {toString: "x"}]).should.equal(false)
+  })
+})


### PR DESCRIPTION
**Fixes #2624**

### Problem
`uniqueItems`, `enum` and `const` crash with an unhandled `TypeError` when validating JSON objects that shadow `toString`/`valueOf` with a **non-function** value:

```js
const ajv = new Ajv()
ajv.compile({type: "array", uniqueItems: true})([{}, {toString: ""}])
// TypeError: a.toString is not a function
ajv.compile({enum: [{}, {valueOf: 0}]})({})
// TypeError: a.valueOf is not a function
```

These are valid JSON inputs. The crash escapes ajv's normal error-collection path, so a 22-byte payload like `[{}, {"toString": ""}]` can DoS any endpoint that validates arrays with `uniqueItems: true`.

### Root cause
`lib/runtime/equal.ts` re-exports `fast-deep-equal`, which calls `a.valueOf()` / `a.toString()` after only checking that the property differs from `Object.prototype` — without checking it's still a function. `fast-deep-equal` is unmaintained (last release 2020), so there's no practical upstream fix path.

### Fix
Vendor a guarded equality function in `runtime/equal.ts`. It uses the `valueOf`/`toString` shortcut only when **both** values expose them as functions, and otherwise falls back to comparing own properties (treating a shadowed non-function `valueOf`/`toString` as an ordinary property). Behavior is unchanged for all inputs that didn't crash; duplicate/equality detection for normal values is preserved.

### Tests
Added `spec/issues/2624_deep_equal_shadowed_tostring.spec.ts` covering the `uniqueItems` and `enum` crashes plus a positive case (equal shadowed values are still detected as duplicates). Verified failing before the fix (exact reported `TypeError`) and passing after. The full JSON-Schema-Test-Suite run shows no new failures.

### Note
`lib/compile/resolve.ts` also imports `fast-deep-equal` for compile-time schema de-duplication, which has the same latent issue against untrusted schema values. I kept this PR focused on the reported runtime-validation crash; happy to point `resolve.ts` at the guarded helper (and drop the `fast-deep-equal` dependency entirely) in a follow-up if you'd prefer.
