### PR TITLE
fix: strictSchema "log" should warn (not throw) on unknown format

### DIFF
--- a/lib/vocabularies/format/format.ts
+++ b/lib/vocabularies/format/format.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../types"
 import type {KeywordCxt} from "../../compile/validate"
 import {_, str, nil, or, Code, getProperty, regexpCode} from "../../compile/codegen"
+import {checkStrictMode} from "../../compile/util"
 
 type FormatValidate =
   | FormatValidator<string>
@@ -80,15 +81,10 @@ const def: CodeKeywordDefinition = {
       if (fmtType === ruleType) cxt.pass(validCondition())
 
       function unknownFormat(): void {
-        if (opts.strictSchema === false) {
-          self.logger.warn(unknownMsg())
-          return
-        }
-        throw new Error(unknownMsg())
-
-        function unknownMsg(): string {
-          return `unknown format "${schema as string}" ignored in schema at path "${errSchemaPath}"`
-        }
+        checkStrictMode(
+          it,
+          `unknown format "${schema as string}" ignored in schema at path "${errSchemaPath}"`
+        )
       }
 
       function getFormat(fmtDef: AddedFormat): [string, FormatValidate, Code] {

--- a/spec/issues/2538_strict_schema_log_unknown_format.spec.ts
+++ b/spec/issues/2538_strict_schema_log_unknown_format.spec.ts
@@ -1,0 +1,48 @@
+import _Ajv from "../ajv"
+import chai from "../chai"
+const should = chai.should()
+
+// https://github.com/ajv-validator/ajv/issues/2538
+describe("strictSchema with unknown format (issue #2538)", () => {
+  function getLogger(output) {
+    return {
+      log() {
+        throw new Error("log should not be called")
+      },
+      warn(msg) {
+        output.warning = msg
+      },
+      error() {
+        throw new Error("error should not be called")
+      },
+    }
+  }
+
+  describe('strictSchema = "log"', () => {
+    it("should log a warning for an unknown format, not throw", () => {
+      const output: any = {}
+      const ajv = new _Ajv({strictSchema: "log", logger: getLogger(output)})
+      should.not.throw(() => ajv.compile({type: "string", format: "unknown"}))
+      output.warning.should.match(/unknown format "unknown"/)
+    })
+  })
+
+  describe("strictSchema = false", () => {
+    it("should neither throw nor log a warning for an unknown format", () => {
+      const output: any = {}
+      const ajv = new _Ajv({strictSchema: false, logger: getLogger(output)})
+      should.not.throw(() => ajv.compile({type: "string", format: "unknown"}))
+      should.not.exist(output.warning)
+    })
+  })
+
+  describe("strictSchema = true (default)", () => {
+    it("should throw for an unknown format", () => {
+      const ajv = new _Ajv({strictSchema: true})
+      should.throw(
+        () => ajv.compile({type: "string", format: "unknown"}),
+        /unknown format "unknown"/
+      )
+    })
+  })
+})


### PR DESCRIPTION
Fixes #2538.

## What issue does this pull request resolve?

With `strictSchema: "log"`, an unknown `format` in a schema throws an exception instead of logging a warning. Per the [documented option values](https://github.com/ajv-validator/ajv/blob/master/docs/options.md), `"log"` should log a warning while only `true` should throw.

```js
const ajv = new Ajv({strictSchema: "log"})
ajv.compile({type: "string", format: "unknown"})
// Expected: logs `unknown format "unknown" ...`
// Actual:   throws `Error: unknown format "unknown" ignored in schema at path ...`
```

## Root cause

In `lib/vocabularies/format/format.ts`, `unknownFormat()` only special-cased `opts.strictSchema === false` (warn) and threw for every other value. Since `"log"` is not `=== false`, it fell through to `throw`. As a side effect, `strictSchema: false` also emitted a warning, whereas it should be silent ("ignore all strict schema violations").

## Fix

Replace the hand-rolled branch with the shared `checkStrictMode` helper (`lib/compile/util.ts`), which is already used throughout the codebase for the `true | false | "log"` tri-state:

- `true` → throw
- `"log"` → `logger.warn`
- `false` → silent (no-op)

This also makes the message consistent with every other strict-mode violation (prefixed with `strict mode:`).

## Tests

Added `spec/issues/2538_strict_schema_log_unknown_format.spec.ts` covering all three modes. The `"log"` and `false` cases fail on `master` and pass with this change; `true` still throws. Existing `spec/options/unknownFormats.spec.ts` and the strict-mode suites remain green, and the full JSON Schema conformance suite passes.