### PR TITLE
feat: add additionalProperties validation option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -264,6 +264,22 @@ Option values:
 
 Asynchronous function that will be used to load remote schemas when `compileAsync` [method](#api-compileAsync) is used and some reference is missing (option `missingRefs` should NOT be 'fail' or 'ignore'). This function should accept remote schema uri as a parameter and return a Promise that resolves to a schema. See example in [Asynchronous compilation](./guide/managing-schemas.md#asynchronous-schema-compilation).
 
+### additionalProperties
+
+Override how additional (unknown) object properties are handled across all schemas validated by the instance, regardless of the `additionalProperties` keyword in each schema. Unlike `removeAdditional`, this option never modifies the data.
+
+Option values:
+
+- `"default"` (default) - respect each schema's `additionalProperties` keyword.
+- `"alwaysAllow"` - additional properties are always allowed, regardless of the schema. The `additionalProperties` keyword is treated as `true`: additional properties are neither validated against a subschema nor rejected when the keyword is `false`.
+- `"alwaysError"` - additional properties always produce a validation error, regardless of the schema. The `additionalProperties` keyword is treated as `false`.
+
+`"alwaysError"` takes effect on object schemas that contain a `properties`, `patternProperties`, or `additionalProperties` keyword (the same trigger model as `removeAdditional: "all"`); it does not apply to a bare `type: "object"` schema that has none of these keywords.
+
+If `removeAdditional` is also set, it takes precedence (additional properties are removed rather than producing an error).
+
+This option is not used if schema is added with `addMetaSchema` method.
+
 ## Options to modify validated data
 
 ### removeAdditional

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -68,7 +68,12 @@ import DefaultUriResolver from "./runtime/uri"
 const defaultRegExp: RegExpEngine = (str, flags) => new RegExp(str, flags)
 defaultRegExp.code = "new RegExp"
 
-const META_IGNORE_OPTIONS: (keyof Options)[] = ["removeAdditional", "useDefaults", "coerceTypes"]
+const META_IGNORE_OPTIONS: (keyof Options)[] = [
+  "removeAdditional",
+  "useDefaults",
+  "coerceTypes",
+  "additionalProperties",
+]
 const EXT_SCOPE_NAMES = new Set([
   "validate",
   "serialize",
@@ -84,6 +89,15 @@ const EXT_SCOPE_NAMES = new Set([
   "obj",
   "Error",
 ])
+
+export const AdditionalProperties = {
+  Default: "default",
+  AlwaysAllow: "alwaysAllow",
+  AlwaysError: "alwaysError",
+} as const
+
+export type AdditionalPropertiesOption =
+  (typeof AdditionalProperties)[keyof typeof AdditionalProperties]
 
 export type Options = CurrentOptions & DeprecatedOptions
 
@@ -111,6 +125,7 @@ export interface CurrentOptions {
   $comment?:
     | true
     | ((comment: string, schemaPath?: string, rootSchema?: AnySchemaObject) => unknown)
+  additionalProperties?: AdditionalPropertiesOption
   formats?: {[Name in string]?: Format}
   keywords?: Vocabulary
   schemas?: AnySchema[] | {[Key in string]?: AnySchema}

--- a/lib/vocabularies/applicator/additionalProperties.ts
+++ b/lib/vocabularies/applicator/additionalProperties.ts
@@ -10,6 +10,7 @@ import {_, nil, or, not, Code, Name} from "../../compile/codegen"
 import N from "../../compile/names"
 import type {SubschemaArgs} from "../../compile/validate/subschema"
 import {alwaysValidSchema, schemaRefOrVal, Type} from "../../compile/util"
+import {AdditionalProperties} from "../../core"
 
 export type AdditionalPropertiesError = ErrorObject<
   "additionalProperties",
@@ -34,8 +35,16 @@ const def: CodeKeywordDefinition & AddedKeywordDefinition = {
     /* istanbul ignore if */
     if (!errsCount) throw new Error("ajv implementation error")
     const {allErrors, opts} = it
+    const addOpt = opts.additionalProperties
     it.props = true
-    if (opts.removeAdditional !== "all" && alwaysValidSchema(it, schema)) return
+    if (addOpt === AdditionalProperties.AlwaysAllow) return // treat as `true`: allow additional properties, no validation
+    if (
+      addOpt !== AdditionalProperties.AlwaysError &&
+      opts.removeAdditional !== "all" &&
+      alwaysValidSchema(it, schema)
+    ) {
+      return
+    }
     const props = allSchemaProperties(parentSchema.properties)
     const patProps = allSchemaProperties(parentSchema.patternProperties)
     checkAdditionalProperties()
@@ -75,7 +84,7 @@ const def: CodeKeywordDefinition & AddedKeywordDefinition = {
         return
       }
 
-      if (schema === false) {
+      if (addOpt === AdditionalProperties.AlwaysError || schema === false) {
         cxt.setParams({additionalProperty: key})
         cxt.error()
         if (!allErrors) gen.break()

--- a/lib/vocabularies/applicator/properties.ts
+++ b/lib/vocabularies/applicator/properties.ts
@@ -3,6 +3,7 @@ import {KeywordCxt} from "../../compile/validate"
 import {propertyInData, allSchemaProperties} from "../code"
 import {alwaysValidSchema, toHash, mergeEvaluated} from "../../compile/util"
 import apDef from "./additionalProperties"
+import {AdditionalProperties} from "../../core"
 
 const def: CodeKeywordDefinition = {
   keyword: "properties",
@@ -10,7 +11,11 @@ const def: CodeKeywordDefinition = {
   schemaType: "object",
   code(cxt: KeywordCxt) {
     const {gen, schema, parentSchema, data, it} = cxt
-    if (it.opts.removeAdditional === "all" && parentSchema.additionalProperties === undefined) {
+    if (
+      parentSchema.additionalProperties === undefined &&
+      (it.opts.removeAdditional === "all" ||
+        it.opts.additionalProperties === AdditionalProperties.AlwaysError)
+    ) {
       apDef.code(new KeywordCxt(it, apDef, "additionalProperties"))
     }
     const allProps = allSchemaProperties(schema)

--- a/spec/options/additionalProperties.spec.ts
+++ b/spec/options/additionalProperties.spec.ts
@@ -1,0 +1,215 @@
+import _Ajv from "../ajv"
+import chai from "../chai"
+chai.should()
+
+describe("additionalProperties option", () => {
+  const personSchema = {
+    type: "object",
+    properties: {name: {type: "string"}, email: {type: "string"}},
+  }
+
+  const matchingData = {name: "Ada", email: "ada@example.com"}
+  const extraData = {...matchingData, extra: "extra"}
+  const nonStringExtraData = {...matchingData, extra: 1000}
+
+  const noKeyword = personSchema
+  const additionalPropertiesAllowed = {...personSchema, additionalProperties: true}
+  const additionalPropertiesForbidden = {...personSchema, additionalProperties: false}
+  const additionalPropertiesString = {...personSchema, additionalProperties: {type: "string"}}
+
+  describe('"alwaysError"', () => {
+    const ajv = new _Ajv({additionalProperties: "alwaysError"})
+
+    it("should pass validation for no additionalProperties keyword and matching data", () => {
+      ajv.validate(noKeyword, matchingData).should.equal(true)
+    })
+
+    it("should fail validation for no additionalProperties keyword and extra data", () => {
+      ajv.validate(noKeyword, extraData).should.equal(false)
+    })
+
+    it("should fail validation for no additionalProperties keyword and non-string extra data", () => {
+      ajv.validate(noKeyword, nonStringExtraData).should.equal(false)
+    })
+
+    it("should pass validation for additionalProperties true and matching data", () => {
+      ajv.validate(additionalPropertiesAllowed, matchingData).should.equal(true)
+    })
+
+    it("should fail validation for additionalProperties true and extra data", () => {
+      // override schema's additionalProperties: true with alwaysError
+      ajv.validate(additionalPropertiesAllowed, extraData).should.equal(false)
+    })
+
+    it("should fail validation for additionalProperties true and non-string extra data", () => {
+      ajv.validate(additionalPropertiesAllowed, nonStringExtraData).should.equal(false)
+    })
+
+    it("should pass validation for additionalProperties false and matching data", () => {
+      ajv.validate(additionalPropertiesForbidden, matchingData).should.equal(true)
+    })
+
+    it("should fail validation for additionalProperties false and extra data", () => {
+      ajv.validate(additionalPropertiesForbidden, extraData).should.equal(false)
+    })
+
+    it("should fail validation for additionalProperties false and non-string extra data", () => {
+      ajv.validate(additionalPropertiesForbidden, nonStringExtraData).should.equal(false)
+    })
+
+    it("should pass validation for additionalProperties string and matching data", () => {
+      ajv.validate(additionalPropertiesString, matchingData).should.equal(true)
+    })
+
+    it("should fail validation for additionalProperties string and extra data", () => {
+      // even a value that matches the additionalProperties schema is rejected
+      ajv.validate(additionalPropertiesString, extraData).should.equal(false)
+    })
+
+    it("should fail validation for additionalProperties string and non-string extra data", () => {
+      ajv.validate(additionalPropertiesString, nonStringExtraData).should.equal(false)
+    })
+
+    it("should report the additionalProperties validation error object", () => {
+      const validate = ajv.compile(personSchema)
+
+      validate(extraData).should.equal(false)
+      const {errors} = validate
+      if (!errors) throw new Error("expected errors")
+      errors[0].keyword.should.equal("additionalProperties")
+      errors[0].params.should.eql({additionalProperty: "extra"})
+    })
+
+    it("should not affect meta-schema validation of user schemas", () => {
+      // schemas legitimately contain keywords beyond the meta-schema's properties;
+      // alwaysError must be ignored when validating schemas against their meta-schema
+      const compile = (): unknown => ajv.compile({...personSchema, title: "Person"})
+      compile.should.not.throw()
+    })
+  })
+
+  describe('"alwaysAllow"', () => {
+    const ajv = new _Ajv({additionalProperties: "alwaysAllow"})
+
+    it("should pass validation for no additionalProperties keyword and matching data", () => {
+      ajv.validate(noKeyword, matchingData).should.equal(true)
+    })
+
+    it("should pass validation for no additionalProperties keyword and extra data", () => {
+      ajv.validate(noKeyword, extraData).should.equal(true)
+    })
+
+    it("should pass validation for no additionalProperties keyword and non-string extra data", () => {
+      ajv.validate(noKeyword, nonStringExtraData).should.equal(true)
+    })
+
+    it("should pass validation for additionalProperties true and matching data", () => {
+      ajv.validate(additionalPropertiesAllowed, matchingData).should.equal(true)
+    })
+
+    it("should pass validation for additionalProperties true and extra data", () => {
+      ajv.validate(additionalPropertiesAllowed, extraData).should.equal(true)
+    })
+
+    it("should pass validation for additionalProperties true and non-string extra data", () => {
+      ajv.validate(additionalPropertiesAllowed, nonStringExtraData).should.equal(true)
+    })
+
+    it("should pass validation for additionalProperties false and matching data", () => {
+      ajv.validate(additionalPropertiesForbidden, matchingData).should.equal(true)
+    })
+
+    it("should pass validation for additionalProperties false and extra data", () => {
+      // override schema's additionalProperties: false with alwaysAllow; data is kept intact
+      const object = {...extraData}
+      ajv.validate(additionalPropertiesForbidden, object).should.equal(true)
+      object.should.have.property("extra")
+    })
+
+    it("should pass validation for additionalProperties false and non-string extra data", () => {
+      ajv.validate(additionalPropertiesForbidden, nonStringExtraData).should.equal(true)
+    })
+
+    it("should pass validation for additionalProperties string and matching data", () => {
+      ajv.validate(additionalPropertiesString, matchingData).should.equal(true)
+    })
+
+    it("should pass validation for additionalProperties string and extra data", () => {
+      ajv.validate(additionalPropertiesString, extraData).should.equal(true)
+    })
+
+    it("should pass validation for additionalProperties string and non-string extra data", () => {
+      // even a value that does not match the additionalProperties schema is allowed (treated as `true`)
+      ajv.validate(additionalPropertiesString, nonStringExtraData).should.equal(true)
+    })
+  })
+
+  describe('"default" / unset', () => {
+    for (const [label, ajv] of [
+      ["default", new _Ajv({additionalProperties: "default"})],
+      ["unset", new _Ajv({})],
+    ] as const) {
+      describe(label, () => {
+        it("should pass validation for no additionalProperties keyword and matching data", () => {
+          ajv.validate(noKeyword, matchingData).should.equal(true)
+        })
+
+        it("should pass validation for no additionalProperties keyword and extra data", () => {
+          ajv.validate(noKeyword, extraData).should.equal(true)
+        })
+
+        it("should pass validation for no additionalProperties keyword and non-string extra data", () => {
+          ajv.validate(noKeyword, nonStringExtraData).should.equal(true)
+        })
+
+        it("should pass validation for additionalProperties true and matching data", () => {
+          ajv.validate(additionalPropertiesAllowed, matchingData).should.equal(true)
+        })
+
+        it("should pass validation for additionalProperties true and extra data", () => {
+          ajv.validate(additionalPropertiesAllowed, extraData).should.equal(true)
+        })
+
+        it("should pass validation for additionalProperties true and non-string extra data", () => {
+          ajv.validate(additionalPropertiesAllowed, nonStringExtraData).should.equal(true)
+        })
+
+        it("should pass validation for additionalProperties false and matching data", () => {
+          ajv.validate(additionalPropertiesForbidden, matchingData).should.equal(true)
+        })
+
+        it("should fail validation for additionalProperties false and extra data", () => {
+          ajv.validate(additionalPropertiesForbidden, extraData).should.equal(false)
+        })
+
+        it("should fail validation for additionalProperties false and non-string extra data", () => {
+          ajv.validate(additionalPropertiesForbidden, nonStringExtraData).should.equal(false)
+        })
+
+        it("should pass validation for additionalProperties string and matching data", () => {
+          ajv.validate(additionalPropertiesString, matchingData).should.equal(true)
+        })
+
+        it("should pass validation for additionalProperties string and extra data", () => {
+          // extra value is a string, so it matches the additionalProperties schema
+          ajv.validate(additionalPropertiesString, extraData).should.equal(true)
+        })
+
+        it("should fail validation for additionalProperties string and non-string extra data", () => {
+          // extra value is not a string, so it fails the additionalProperties schema
+          ajv.validate(additionalPropertiesString, nonStringExtraData).should.equal(false)
+        })
+      })
+    }
+  })
+
+  describe("interaction with removeAdditional", () => {
+    it("removeAdditional should take precedence over alwaysError for extra data", () => {
+      const ajv = new _Ajv({removeAdditional: "all", additionalProperties: "alwaysError"})
+      const object = {...extraData}
+      ajv.validate(personSchema, object).should.equal(true)
+      object.should.have.property("name")
+      object.should.not.have.property("extra")
+    })
+  })
+})


### PR DESCRIPTION
**What issue does this pull request resolve?**

https://github.com/ajv-validator/ajv/issues/2638 Adds a global `additionalProperties` validation option so the behavior can be controlled via Ajv config rather than only per-schema.

**What changes did you make?**

- `lib/core.ts` — add and wire up the new `additionalProperties` option
- `lib/vocabularies/applicator/additionalProperties.ts` and `properties.ts` — honor the option during validation
- `docs/options.md` — document the new option
- `spec/options/additionalProperties.spec.ts` — add test coverage

**Is there anything that requires more attention while reviewing?**

Manual Testing Results: https://github.com/ajv-validator/ajv/pull/2637#issuecomment-4774303224
