### PR TITLE
fix(core): null-prototype objects for the schemas and refs registries

### DIFF
--- a/lib/core.ts
+++ b/lib/core.ts
@@ -279,8 +279,8 @@ export default class Ajv {
   logger: Logger
   // shared external scope values for compiled functions
   readonly scope: ValueScope
-  readonly schemas: {[Key in string]?: SchemaEnv} = {}
-  readonly refs: {[Ref in string]?: SchemaEnv | string} = {}
+  readonly schemas: {[Key in string]?: SchemaEnv} = Object.create(null)
+  readonly refs: {[Ref in string]?: SchemaEnv | string} = Object.create(null)
   readonly formats: {[Name in string]?: AddedFormat} = Object.create(null)
   readonly RULES: ValidationRules
   readonly _compilations: Set<SchemaEnv> = new Set()

--- a/spec/issues/registry_prototype_keys.spec.ts
+++ b/spec/issues/registry_prototype_keys.spec.ts
@@ -1,0 +1,41 @@
+import _Ajv from "../ajv"
+import chai from "../chai"
+chai.should()
+
+const protoProps = [
+  "hasOwnProperty",
+  "toString",
+  "valueOf",
+  "constructor",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toLocaleString",
+]
+
+describe("schema registry keys that are Object.prototype property names", () => {
+  describe("getSchema", () => {
+    // getSchema reads `this.schemas[keyRef] || this.refs[keyRef]`, so this
+    // exercises both registries: with plain {} objects either lookup returns an
+    // inherited Object.prototype member instead of undefined and throws.
+    it("should return undefined, not an inherited prototype member", () => {
+      const ajv = new _Ajv()
+      for (const key of protoProps) {
+        ;(() => ajv.getSchema(key)).should.not.throw()
+        chai.expect(ajv.getSchema(key)).to.equal(undefined)
+      }
+    })
+  })
+
+  describe("addSchema", () => {
+    it("should not report a clash with an unused key on a fresh instance", () => {
+      for (const key of protoProps) {
+        const ajv = new _Ajv()
+        ;(() => ajv.addSchema({type: "string"}, key)).should.not.throw()
+        const validate = ajv.getSchema(key)
+        chai.expect(validate).to.be.a("function")
+        validate!("ok").should.equal(true)
+        validate!(1).should.equal(false)
+      }
+    })
+  })
+})


### PR DESCRIPTION
**What issue does this pull request resolve?**

There's no separate issue. This is a direct follow-up to #2607 (and #2606), which changed `formats` to a null-prototype object so a `$data` format name that matches an `Object.prototype` member isn't resolved to an inherited function. The `schemas` and `refs` registries declared just above it still use plain `{}` and have the same problem. Happy to open an issue first if you'd prefer.

**What changes did you make?**

`schemas` and `refs` now use `Object.create(null)`, matching `formats`.

Both registries are keyed by schema id/ref, so a key that matches an `Object.prototype` member reads back an inherited value instead of `undefined`. On a fresh instance:

```js
const Ajv = require("ajv").default

new Ajv().getSchema("toString")
// throws: Cannot read properties of undefined (reading 'baseId')
// expected: undefined

new Ajv().addSchema({type: "string"}, "constructor")
// throws: schema with key or id "constructor" already exists
// the key is unused
```

`getSchema` reads `this.schemas[keyRef] || this.refs[keyRef]`, so both have to be null-prototype for it to return `undefined`; `_checkUnique` goes through the same lookup.

Added a regression test in `spec/issues/registry_prototype_keys.spec.ts`.

**Is there anything that requires more attention while reviewing?**

The keys involved are the inherited `Object.prototype` members (`constructor`, `toString`, `hasOwnProperty`, `valueOf`, `isPrototypeOf`, `propertyIsEnumerable`, `toLocaleString`). I scoped this to `schemas` and `refs` since those are reachable from the public API. `_loading` is the same kind of object but I left it out to keep the change minimal.
