### PR TITLE
Fix stack overflow compiling/validating oneOf with many variants

### DIFF
--- a/lib/vocabularies/applicator/oneOf.ts
+++ b/lib/vocabularies/applicator/oneOf.ts
@@ -46,34 +46,52 @@ const def: CodeKeywordDefinition = {
     )
 
     function validateOneOf(): void {
+      // Emit a flat sequence of `if` blocks (one per variant, all at the same
+      // nesting level) instead of nesting each variant inside the previous one's
+      // `else`. A nested else-chain grows O(N) deep, which overflows the call
+      // stack both while rendering the code and while running the generated
+      // validator for large `oneOf` arrays (#2641). `valid` tracks "exactly one
+      // matched so far" and `passing` records the matching index (or the first
+      // conflicting pair). Once a second variant matches, `oneOf` has already
+      // failed, so the remaining variants are guarded out at run time to keep
+      // the same short-circuit behaviour (and error output) as before.
       schArr.forEach((sch: AnySchema, i: number) => {
-        let schCxt: SchemaCxt | undefined
-        if (alwaysValidSchema(it, sch)) {
-          gen.var(schValid, true)
+        const evalVariant = (): void => {
+          let schCxt: SchemaCxt | undefined
+          if (alwaysValidSchema(it, sch)) {
+            gen.var(schValid, true)
+          } else {
+            schCxt = cxt.subschema(
+              {
+                keyword: "oneOf",
+                schemaProp: i,
+                compositeRule: true,
+              },
+              schValid
+            )
+          }
+          gen.if(schValid, () => {
+            // `mergeEvaluated` must only run for the first matching variant
+            // (`passing === null`). Merging on a later, conflict-causing match
+            // would mark that variant's properties/items as evaluated, which is
+            // wrong once `oneOf` has failed. This matches the stock nested-else
+            // codegen, where the conflicting branch's merge site never executes.
+            gen.if(
+              _`${passing} === null`,
+              () => {
+                gen.assign(valid, true).assign(passing, i)
+                if (schCxt) cxt.mergeEvaluated(schCxt, Name)
+              },
+              () =>
+                gen.if(valid, () => gen.assign(valid, false).assign(passing, _`[${passing}, ${i}]`))
+            )
+          })
+        }
+        if (i > 1) {
+          gen.if(_`${valid} || ${passing} === null`, evalVariant)
         } else {
-          schCxt = cxt.subschema(
-            {
-              keyword: "oneOf",
-              schemaProp: i,
-              compositeRule: true,
-            },
-            schValid
-          )
+          evalVariant()
         }
-
-        if (i > 0) {
-          gen
-            .if(_`${schValid} && ${valid}`)
-            .assign(valid, false)
-            .assign(passing, _`[${passing}, ${i}]`)
-            .else()
-        }
-
-        gen.if(schValid, () => {
-          gen.assign(valid, true)
-          gen.assign(passing, i)
-          if (schCxt) cxt.mergeEvaluated(schCxt, Name)
-        })
       })
     }
   },

--- a/spec/issues/2641_oneof_large_stack_overflow.spec.ts
+++ b/spec/issues/2641_oneof_large_stack_overflow.spec.ts
@@ -1,0 +1,115 @@
+import _Ajv from "../ajv"
+import _Ajv2020 from "../ajv2020"
+import type Ajv from "ajv"
+import * as assert from "assert"
+
+describe("large oneOf does not overflow the call stack (issue #2641)", () => {
+  const N = 3000
+
+  function makeSchema(n: number): object {
+    return {
+      oneOf: Array.from({length: n}, (_, i) => ({
+        type: "object",
+        required: ["name"],
+        properties: {name: {const: `variant_${i}`}},
+      })),
+    }
+  }
+
+  let ajv: Ajv
+  before(() => {
+    ajv = new _Ajv({strict: false})
+  })
+
+  it(`should compile a oneOf with ${N} variants without throwing`, function () {
+    this.timeout(10000)
+    assert.doesNotThrow(() => ajv.compile(makeSchema(N)))
+  })
+
+  it(`should validate against a oneOf with ${N} variants without RangeError`, function () {
+    this.timeout(10000)
+    const validate = ajv.compile(makeSchema(N))
+    // matches exactly one variant
+    assert.strictEqual(validate({name: "variant_0"}), true)
+    assert.strictEqual(validate({name: `variant_${N - 1}`}), true)
+    // matches zero variants
+    assert.strictEqual(validate({name: "missing"}), false)
+    assert.strictEqual(validate({}), false)
+  })
+
+  it("should keep oneOf semantics for a matching / failing input", () => {
+    const validate = ajv.compile({
+      oneOf: [
+        {type: "object", properties: {a: {const: 1}}, required: ["a"]},
+        {type: "object", properties: {b: {const: 2}}, required: ["b"]},
+        {type: "object", properties: {c: {const: 3}}, required: ["c"]},
+      ],
+    })
+    assert.strictEqual(validate({a: 1}), true)
+    assert.strictEqual(validate({a: 1, b: 2}), false)
+    assert.strictEqual(validate({a: 1, b: 2, c: 3}), false)
+    assert.strictEqual(validate({}), false)
+  })
+
+  it("should report the conflicting pair in passingSchemas when several match", () => {
+    const validate = ajv.compile({
+      oneOf: [
+        {type: "object", properties: {a: {const: 1}}, required: ["a"]},
+        {type: "object", properties: {b: {const: 2}}, required: ["b"]},
+        {type: "object", properties: {c: {const: 3}}, required: ["c"]},
+      ],
+    })
+    validate({a: 1, b: 2, c: 3})
+    const err = (validate.errors || []).find((e) => e.keyword === "oneOf")
+    assert.deepStrictEqual(err?.params, {passingSchemas: [0, 1]})
+  })
+})
+
+describe("flat oneOf keeps unevaluatedProperties on conflict (issue #2641)", () => {
+  // The flattened oneOf codegen must only merge evaluated properties for the
+  // first matching variant. A conflict-causing later match must not mark its
+  // properties as evaluated, otherwise a legitimate unevaluatedProperties error
+  // is swallowed. Stock ajv reports both the oneOf conflict and the
+  // unevaluatedProperties error; the fix must match that behaviour.
+  const ajv = new _Ajv2020({allErrors: true})
+
+  it("reports unevaluatedProperties for the conflicting variant (2-way)", () => {
+    const validate = ajv.compile({
+      type: "object",
+      oneOf: [
+        {required: ["a"], properties: {a: {}}},
+        {required: ["b"], properties: {b: {}}},
+      ],
+      unevaluatedProperties: false,
+    })
+    assert.strictEqual(validate({a: 1, b: 1}), false)
+    const errors = validate.errors || []
+    assert.strictEqual(errors.length, 2)
+    const oneOfErr = errors.find((e) => e.keyword === "oneOf")
+    assert.deepStrictEqual(oneOfErr?.params, {passingSchemas: [0, 1]})
+    const unevalErr = errors.find((e) => e.keyword === "unevaluatedProperties")
+    assert.deepStrictEqual(unevalErr?.params, {unevaluatedProperty: "b"})
+  })
+
+  it("reports unevaluatedProperties for every non-first match (3-way)", () => {
+    const validate = ajv.compile({
+      type: "object",
+      oneOf: [
+        {required: ["a"], properties: {a: {}}},
+        {required: ["b"], properties: {b: {}}},
+        {required: ["c"], properties: {c: {}}},
+      ],
+      unevaluatedProperties: false,
+    })
+    assert.strictEqual(validate({a: 1, b: 1, c: 1}), false)
+    const errors = validate.errors || []
+    assert.strictEqual(errors.length, 3)
+    const oneOfErr = errors.find((e) => e.keyword === "oneOf")
+    assert.deepStrictEqual(oneOfErr?.params, {passingSchemas: [0, 1]})
+    const uneval = errors
+      .filter((e) => e.keyword === "unevaluatedProperties")
+      .map((e) => (e.params as {unevaluatedProperty: string}).unevaluatedProperty)
+      .sort()
+    assert.deepStrictEqual(uneval, ["b", "c"])
+  })
+})


### PR DESCRIPTION
fixes #2641

oneOf emitted one nested if/else per variant, so both codegen rendering
(If.render) and the generated validator recursed O(N) deep. That threw
RangeError for oneOf arrays with ~2000+ variants (compile crashes past ~3000).

This flattens the emitted code to one if per variant at the same nesting level
instead of nesting each variant inside the previous one's else. valid/passing
track "exactly one matched so far" the same way as before, and mergeEvaluated
still runs only on the first match, so error output (passingSchemas,
unevaluatedProperties) and short-circuit behavior are unchanged. Ran the full
oneOf test file plus the JSON-Schema-Test-Suite, all green, with byte-identical
generated error objects vs current master across draft-07/2019-09/2020-12.

Left the generic If.render recursion (the codegen-level fix the issue also
suggests) out of scope here since it touches every keyword's codegen, not just
oneOf. Happy to look at that separately if useful.
