### PR TITLE
fix(jtd): compileParser crash on empty JTD properties schema (#2609)

### DIFF
--- a/lib/compile/jtd/parse.ts
+++ b/lib/compile/jtd/parse.ts
@@ -231,11 +231,10 @@ function parseSchemaProperties(cxt: ParseCxt, discriminator?: string): void {
     }
     gen.endIf()
   })
-  if (properties) {
+  const propKeys = properties ? Object.keys(properties) : []
+  if (propKeys.length > 0) {
     const hasProp = hasPropFunc(gen)
-    const allProps: Code = and(
-      ...Object.keys(properties).map((p): Code => _`${hasProp}.call(${data}, ${p})`)
-    )
+    const allProps: Code = and(...propKeys.map((p): Code => _`${hasProp}.call(${data}, ${p})`))
     gen.if(not(allProps), () => parsingError(cxt, str`missing required properties`))
   }
 }

--- a/spec/jtd-schema.spec.ts
+++ b/spec/jtd-schema.spec.ts
@@ -218,6 +218,21 @@ describe("JSON Type Definition", () => {
         }
       })
     }
+
+    it("compiles a parser for an empty properties schema (#2609)", () => {
+      const parse = ajv.compileParser({properties: {}})
+      shouldParse(parse, "{}", {})
+      shouldFail(parse, `{"extra":1}`)
+    })
+
+    it("compiles a parser for a discriminator mapping with empty properties (#2609)", () => {
+      const parse = ajv.compileParser({
+        discriminator: "t",
+        mapping: {a: {properties: {}}, b: {properties: {b: {type: "int32"}}}},
+      })
+      shouldParse(parse, `{"t":"a"}`, {t: "a"})
+      shouldParse(parse, `{"t":"b","b":1}`, {t: "b", b: 1})
+    })
   })
 
   describe("parse tests nst/JSONTestSuite", () => {


### PR DESCRIPTION
## What issue does this PR fix?

Fixes #2609

`compileParser` crashes at compile time when a JTD schema contains an empty `properties: {}` object:

```js
const Ajv = require("ajv/dist/jtd").default
const ajv = new Ajv()

ajv.compileParser({properties: {}})
// TypeError: Reduce of empty array with no initial value

// also (from the original report) inside a discriminator mapping:
ajv.compileParser({
  discriminator: "t",
  mapping: {a: {properties: {}}, b: {properties: {b: {type: "int32"}}}},
})
// TypeError: Reduce of empty array with no initial value
```

## Root cause

In `parseSchemaProperties` (`lib/compile/jtd/parse.ts`), the generated "all required properties present" check is built with:

```ts
if (properties) {
  const allProps: Code = and(...Object.keys(properties).map(...))
  ...
}
```

When `properties` is present but empty, `Object.keys(properties)` is `[]`, so `and()` is called with no arguments. `and(...args)` is `args.reduce(andCode)` with no initial value, and `[].reduce(fn)` throws `TypeError: Reduce of empty array with no initial value`.

## Fix

A schema with no required properties has nothing to check, so the "missing required properties" guard is vacuous and can be skipped:

```ts
const propKeys = properties ? Object.keys(properties) : []
if (propKeys.length > 0) {
  const allProps: Code = and(...propKeys.map(...))
  gen.if(not(allProps), () => parsingError(cxt, str`missing required properties`))
}
```

The generated parser is unchanged for schemas that do have required properties. The `serialize.ts` counterpart already calls `and()` with a fixed pair of arguments, so it is unaffected.

## Tests

Added two regression tests to the `parse` suite in `spec/jtd-schema.spec.ts`:
- an empty `properties: {}` schema compiles and parses `{}`, and rejects `{"extra":1}`;
- a `discriminator` mapping with an empty-properties branch compiles and parses both branches.

Verified locally on the full JTD spec: **1284 passing** (2 new), and `eslint` + `prettier --check` are clean on the changed files.
