### PR TITLE
fix(jtd): parse empty arrays/objects containing whitespace (#2595)

### DIFF
--- a/lib/compile/jtd/parse.ts
+++ b/lib/compile/jtd/parse.ts
@@ -149,6 +149,11 @@ function parseItems(cxt: ParseCxt, endToken: string, block: () => void): void {
 
 function tryParseItems(cxt: ParseCxt, endToken: string, block: () => void): void {
   const {gen} = cxt
+  // Skip whitespace before the first end-token check so an empty container
+  // written with whitespace between the brackets (e.g. `[ ]` / `{ }`) is not
+  // treated as having an item. Subsequent iterations are already whitespace-
+  // safe because the comma/end-token checks below call skipWhitespace.
+  skipWhitespace(cxt)
   gen.for(_`;${N.jsonPos}<${N.jsonLen} && ${jsonSlice(1)}!==${endToken};`, () => {
     block()
     tryParseToken(cxt, ",", () => gen.break(), hasItem)

--- a/spec/jtd-schema.spec.ts
+++ b/spec/jtd-schema.spec.ts
@@ -218,6 +218,16 @@ describe("JSON Type Definition", () => {
         }
       })
     }
+
+    it("parses empty containers written with whitespace (#2595)", () => {
+      const arr = ajv.compileParser({elements: {type: "string"}})
+      shouldParse(arr, "[ ]", [])
+      shouldParse(arr, "[\n  ]", [])
+      const values = ajv.compileParser({values: {type: "string"}})
+      shouldParse(values, "{ }", {})
+      const props = ajv.compileParser({properties: {data: {elements: {type: "string"}}}})
+      shouldParse(props, `{"data": [ ]}`, {data: []})
+    })
   })
 
   describe("parse tests nst/JSONTestSuite", () => {


### PR DESCRIPTION
## What issue does this PR fix?

Fixes #2595

The JTD parser (`compileParser`) fails to parse an empty array or object when there is whitespace between the brackets:

```js
const Ajv = require("ajv/dist/jtd").default
const ajv = new Ajv()

ajv.compileParser({elements: {type: "string"}})("[ ]")            // => undefined ("unexpected token ]")
ajv.compileParser({values: {type: "string"}})("{ }")             // => undefined ("unexpected token }")
ajv.compileParser({properties: {data: {elements: {type: "string"}}}})('{"data": [ ]}') // => undefined
```

`[]`/`{}` (no whitespace) and `[ "a" ]` (whitespace around a real item) already work — only the *empty-with-whitespace* case is broken.

## Root cause

In `tryParseItems` (`lib/compile/jtd/parse.ts`), the item loop condition tests for the closing token without skipping whitespace first:

```ts
gen.for(_`;${N.jsonPos}<${N.jsonLen} && ${jsonSlice(1)}!==${endToken};`, ...)
```

For `[ ]`, after consuming `[` the position points at the space. `json[pos]` is `" "`, which is `!== "]"`, so the loop body runs and tries to parse the space as an item, then hits `]` and errors. Every *other* position is whitespace-safe because the per-item comma/end-token checks call `skipWhitespace`; only this first condition check (right after the opening token) sees raw whitespace.

## Fix

Skip whitespace once before the loop so the first end-token check sees the actual token. This fixes arrays (`elements`), objects (`values`), and `properties`/`discriminator` objects, since they all go through `tryParseItems`.

## Tests

Added a regression test to the `parse` suite in `spec/jtd-schema.spec.ts` covering `[ ]`, a multi-line empty array, `{ }`, and an empty array nested in a `properties` object.

Verified locally on the full JTD spec: **1283 passing** (1 new), and `eslint` + `prettier --check` are clean on the changed files.
