### PR TITLE
fix: keep $ref-evaluated properties across oneOf/anyOf/dependentSchemas branches

### DIFF
--- a/lib/compile/validate/index.ts
+++ b/lib/compile/validate/index.ts
@@ -24,6 +24,7 @@ import {
   checkStrictMode,
   unescapeJsonPointer,
   mergeEvaluated,
+  evaluatedPropsToName,
 } from "../util"
 import type {JSONType, Rule, RuleGroup} from "../rules"
 import {
@@ -509,6 +510,23 @@ export class KeywordCxt implements KeywordErrorCxt {
     }
     if (it.items !== true && schemaCxt.items !== undefined) {
       it.items = mergeEvaluated.items(gen, schemaCxt.items, it.items, toName)
+    }
+  }
+
+  // Materialize statically-tracked evaluated props/items into runtime variables so that they are
+  // recorded unconditionally. Keywords with conditional branches (oneOf/anyOf/dependentSchemas)
+  // merge each branch's evaluated props into a runtime object only when that branch is taken; if
+  // evaluated props accumulated before the keyword (e.g. via a sibling `$ref`) were still a static
+  // object, they would only be emitted inside the first branch and lost when a different branch
+  // matches. Calling this before generating the branches keeps them for every branch.
+  nameEvaluated(): void {
+    const {it, gen} = this
+    if (!it.opts.unevaluated) return
+    if (it.props !== true && it.props !== undefined && !(it.props instanceof Name)) {
+      it.props = evaluatedPropsToName(gen, it.props)
+    }
+    if (it.items !== true && it.items !== undefined && !(it.items instanceof Name)) {
+      it.items = gen.var("items", it.items)
     }
   }
 

--- a/lib/vocabularies/applicator/dependencies.ts
+++ b/lib/vocabularies/applicator/dependencies.ts
@@ -95,6 +95,7 @@ export function validatePropertyDeps(
 export function validateSchemaDeps(cxt: KeywordCxt, schemaDeps: SchemaMap = cxt.schema): void {
   const {gen, data, keyword, it} = cxt
   const valid = gen.name("valid")
+  cxt.nameEvaluated()
   for (const prop in schemaDeps) {
     if (alwaysValidSchema(it, schemaDeps[prop] as AnySchema)) continue
     gen.if(

--- a/lib/vocabularies/applicator/oneOf.ts
+++ b/lib/vocabularies/applicator/oneOf.ts
@@ -37,6 +37,7 @@ const def: CodeKeywordDefinition = {
     cxt.setParams({passing})
     // TODO possibly fail straight away (with warning or exception) if there are two empty always valid schemas
 
+    cxt.nameEvaluated()
     gen.block(validateOneOf)
 
     cxt.result(

--- a/lib/vocabularies/code.ts
+++ b/lib/vocabularies/code.ts
@@ -142,6 +142,7 @@ export function validateUnion(cxt: KeywordCxt): void {
   const valid = gen.let("valid", false)
   const schValid = gen.name("_valid")
 
+  cxt.nameEvaluated()
   gen.block(() =>
     schema.forEach((_sch: AnySchema, i: number) => {
       const schCxt = cxt.subschema(

--- a/spec/issues/2559_unevaluated_props_conditional_branches.spec.ts
+++ b/spec/issues/2559_unevaluated_props_conditional_branches.spec.ts
@@ -1,0 +1,72 @@
+import _Ajv from "../ajv2020"
+import * as assert from "assert"
+
+// Properties/items evaluated by a sibling `$ref` (i.e. tracked before a keyword with conditional
+// branches runs) must stay evaluated regardless of which branch matches. Previously the statically
+// tracked evaluated props were only emitted inside the first branch and were lost when a different
+// branch matched, causing spurious `unevaluatedProperties`/`unevaluatedItems` failures.
+// https://github.com/ajv-validator/ajv/issues/2559
+describe("evaluated properties from $ref preserved across conditional branches (issue #2559)", () => {
+  const ajv = new _Ajv()
+
+  const $defs = {
+    parent: {type: "object", properties: {propFromParent: true}},
+  }
+
+  it("oneOf: $ref-evaluated property is kept for every passing branch", () => {
+    const validate = ajv.compile({
+      type: "object",
+      $ref: "#/$defs/parent",
+      oneOf: [
+        {type: "object", required: ["propFrom1stOneOf"], properties: {propFrom1stOneOf: true}},
+        {type: "object", required: ["propFrom2ndOneOf"], properties: {propFrom2ndOneOf: true}},
+      ],
+      unevaluatedProperties: false,
+      $defs,
+    })
+    assert.strictEqual(validate({propFromParent: true, propFrom1stOneOf: true}), true)
+    // The 2nd branch used to drop `propFromParent`, reporting it as unevaluated.
+    assert.strictEqual(validate({propFromParent: true, propFrom2ndOneOf: true}), true)
+  })
+
+  it("anyOf: $ref-evaluated property is kept for every passing branch", () => {
+    const validate = ajv.compile({
+      type: "object",
+      $ref: "#/$defs/parent",
+      anyOf: [
+        {required: ["a"], properties: {a: true}},
+        {required: ["b"], properties: {b: true}},
+      ],
+      unevaluatedProperties: false,
+      $defs,
+    })
+    assert.strictEqual(validate({propFromParent: true, a: true}), true)
+    assert.strictEqual(validate({propFromParent: true, b: true}), true)
+  })
+
+  it("dependentSchemas: $ref-evaluated property is kept when a later dependency triggers", () => {
+    const validate = ajv.compile({
+      type: "object",
+      $ref: "#/$defs/parent",
+      dependentSchemas: {
+        a: {properties: {aa: true}},
+        propFromParent: {properties: {depProp: true}},
+      },
+      unevaluatedProperties: false,
+      $defs,
+    })
+    assert.strictEqual(validate({propFromParent: true, depProp: true}), true)
+  })
+
+  it("oneOf: items evaluated by $ref are kept for every passing branch", () => {
+    const validate = new _Ajv({strict: false}).compile({
+      type: "array",
+      $ref: "#/$defs/tuple",
+      oneOf: [{prefixItems: [{const: 1}]}, {prefixItems: [{const: 2}]}],
+      unevaluatedItems: false,
+      $defs: {tuple: {prefixItems: [true, true]}},
+    })
+    // $ref evaluates both items; the matching branch only evaluates the first.
+    assert.strictEqual(validate([2, "x"]), true)
+  })
+})


### PR DESCRIPTION
**What issue does this pull request resolve?**

Fixes #2559.

When a property (or item) is evaluated by a sibling in-place applicator such as `$ref`, and the schema also contains a keyword with conditional branches (`oneOf`, `anyOf`, `dependentSchemas`), the evaluated property could be reported as unevaluated whenever a branch other than the first one matched. Per the JSON Schema 2019-09 / 2020-12 specification, `unevaluatedProperties` and `unevaluatedItems` must consider annotations produced by all in-place applicators, including `$ref`, regardless of which conditional branch succeeds.

**What changes did you make?**

The evaluated props/items accumulated before such a keyword were tracked as a static object. Each conditional branch merges its own evaluated props into a runtime evaluated-object, but the pre-existing static set was only emitted inside the first generated branch. When a different branch matched at runtime, that set was never recorded, producing spurious `unevaluatedProperties` / `unevaluatedItems` errors.

- Added `KeywordCxt#nameEvaluated()` in `lib/compile/validate/index.ts`, which materializes the statically-tracked evaluated props/items into a runtime variable unconditionally.
- Called it before generating the branches in `oneOf` (`lib/vocabularies/applicator/oneOf.ts`), `anyOf` / `validateUnion` (`lib/vocabularies/code.ts`), and `dependentSchemas` (`lib/vocabularies/applicator/dependencies.ts`), so the evaluated set is preserved for every branch.
- Added `spec/issues/2559_unevaluated_props_conditional_branches.spec.ts` covering the reported case.

**Is there anything that requires more attention while reviewing?**

- The change is scoped to the three keywords that generate multiple conditional branches from a shared evaluated set (`oneOf`, `anyOf`, `dependentSchemas`). `if`/`then`/`else` and `discriminator` are deliberately left out of scope, as they do not exhibit this issue.
- The full official JSON Schema test suite passes (7616 tests).
