### PR TITLE
docs: replace expired jsontypedef.com link with RFC 8927

### DIFF
--- a/docs/guide/why-ajv.md
+++ b/docs/guide/why-ajv.md
@@ -4,7 +4,7 @@
 
 **Ensure your data is valid as soon as it's received**
 
-Instead of having your data validation and sanitization logic written as lengthy code, you can declare the requirements to your data with concise, easy to read and cross-platform [JSON Schema](https://json-schema.org) or [JSON Type Definition](https://jsontypedef.com) specifications and validate the data as soon as it arrives to your application.
+Instead of having your data validation and sanitization logic written as lengthy code, you can declare the requirements to your data with concise, easy to read and cross-platform [JSON Schema](https://json-schema.org) or [JSON Type Definition](https://datatracker.ietf.org/doc/rfc8927/) specifications and validate the data as soon as it arrives to your application.
 
 TypeScript users can use validation functions as type guards, having type level guarantee that if your data is validated - it is correct.
 


### PR DESCRIPTION
**What issue does this pull request resolve?**

Fixes #2619

**What changes did you make?**

Replaced the `https://jsontypedef.com` link in `docs/guide/why-ajv.md` with `https://datatracker.ietf.org/doc/rfc8927/`. That domain no longer serves JSON Type Definition documentation, and the RFC link already matches the other JTD references in this repo.

**Is there anything that requires more attention while reviewing?**

No. Docs-only change, single link update.