### PR TITLE
fix: normalize URI hosts in schema IDs

### DIFF
--- a/lib/compile/resolve.ts
+++ b/lib/compile/resolve.ts
@@ -79,8 +79,15 @@ export function _getFullPath(resolver: UriResolver, p: URIComponent): string {
 }
 
 const TRAILING_SLASH_HASH = /#\/?$/
+const URI_HOST = /^((?:[a-z][a-z0-9+.-]*:)?\/\/(?:[^/?#@]*@)?)(\[[^\]]+\]|[^/?#:]+)/i
 export function normalizeId(id: string | undefined): string {
-  return id ? id.replace(TRAILING_SLASH_HASH, "") : ""
+  return id
+    ? id
+        .replace(URI_HOST, (_match: string, prefix: string, host: string) => {
+          return `${prefix}${host.toLowerCase()}`
+        })
+        .replace(TRAILING_SLASH_HASH, "")
+    : ""
 }
 
 export function resolveUrl(resolver: UriResolver, baseId: string, id: string): string {

--- a/lib/core.ts
+++ b/lib/core.ts
@@ -558,6 +558,7 @@ export default class Ajv {
         this._cache.clear()
         return this
       case "string": {
+        schemaKeyRef = normalizeId(schemaKeyRef)
         const sch = getSchEnv.call(this, schemaKeyRef)
         if (typeof sch == "object") this._cache.delete(sch.schema)
         delete this.schemas[schemaKeyRef]

--- a/spec/issues/1068_uri_host_case.spec.ts
+++ b/spec/issues/1068_uri_host_case.spec.ts
@@ -1,0 +1,45 @@
+import _Ajv from "../ajv"
+import chai from "../chai"
+const should = chai.should()
+
+describe("issue #1068: URI host names should be case-insensitive", () => {
+  const schema = {
+    $id: "http://Test.com/Schemas/testSchema.json",
+    type: "object",
+    properties: {
+      value: {type: "string"},
+    },
+  }
+
+  for (const ref of [
+    "http://Test.com/Schemas/testSchema.json",
+    "http://test.com/Schemas/testSchema.json",
+  ]) {
+    it(`should resolve ${ref}`, () => {
+      const ajv = new _Ajv()
+      ajv.addSchema(schema)
+      const validate = ajv.compile({$ref: ref})
+
+      validate({value: "valid"}).should.equal(true)
+      validate({value: 1}).should.equal(false)
+    })
+  }
+
+  it("should keep URI paths case-sensitive", () => {
+    const ajv = new _Ajv()
+    ajv.addSchema(schema)
+    should.throw(
+      () => ajv.compile({$ref: "http://test.com/schemas/testSchema.json"}),
+      /can't resolve reference/
+    )
+  })
+
+  it("should normalize schema lookup and removal keys", () => {
+    const ajv = new _Ajv()
+    ajv.addSchema(schema)
+
+    should.equal(typeof ajv.getSchema("http://test.com/Schemas/testSchema.json"), "function")
+    ajv.removeSchema("http://TEST.com/Schemas/testSchema.json")
+    should.equal(ajv.getSchema(schema.$id), undefined)
+  })
+})


### PR DESCRIPTION
**What issue does this pull request resolve?**

Closes #1068.

**What changes did you make?**

- Normalize only the host portion of absolute and network-path URI schema IDs to lowercase when Ajv stores or looks them up.
- Apply the same normalization when a schema is removed by string ID.
- Add regression coverage for references using either host casing, validation through the resolved schema, case-sensitive paths, and host-insensitive lookup/removal.

The normalization deliberately preserves the scheme, user information, port, path, query, fragment, relative IDs, and custom keys.

**Is there anything that requires more attention while reviewing?**

The focused and broader core/issue suites pass. A full local suite attempt reached 7,245 passing and 350 pending tests, but 370 standalone-format cases failed because the repository's Unix `npm link` setup did not complete on Windows; `ajv-formats` consequently loaded a second `ajv` installation. Those failures do not exercise this change, so CI should provide the authoritative full-suite result.

Validation:

- `.\node_modules\.bin\cross-env.cmd TS_NODE_PROJECT=spec/tsconfig.json .\node_modules\.bin\mocha.cmd -r ts-node/register spec\issues\1068_uri_host_case.spec.ts spec\resolve.spec.ts -R dot` (`40 passing`)
- `.\node_modules\.bin\cross-env.cmd TS_NODE_PROJECT=spec/tsconfig.json TS_NODE_TRANSPILE_ONLY=true .\node_modules\.bin\mocha.cmd -r ts-node/register spec\ajv.spec.ts spec\resolve.spec.ts "spec/issues/**/*.spec.ts" -R dot` (`171 passing`, `1 pending`)
- `.\node_modules\.bin\tsc.cmd --noEmit`
- `.\node_modules\.bin\eslint.cmd lib\compile\resolve.ts lib\core.ts spec\issues\1068_uri_host_case.spec.ts`
- `.\node_modules\.bin\prettier.cmd --check lib\compile\resolve.ts lib\core.ts spec\issues\1068_uri_host_case.spec.ts`
- `git diff --check`
