### PR TITLE
chore: bump fast-uri to 3.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "runkitExampleFilename": ".runkit_example.js",
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
-    "fast-uri": "^3.0.1",
+    "fast-uri": "^3.1.4",
     "json-schema-traverse": "^1.0.0",
     "require-from-string": "^2.0.2"
   },


### PR DESCRIPTION
**What issue does this pull request resolve?**
Resolves high-severity vulenrability https://github.com/advisories/GHSA-v2hh-gcrm-f6hx ([CVE-2026-16221)](https://nvd.nist.gov/vuln/detail/CVE-2026-16221))

**What changes did you make?**
Bump [fast-uri to release 3.1.4](https://github.com/fastify/fast-uri/releases/tag/v3.1.4) ([3.1.3->3.14 changelog](https://github.com/fastify/fast-uri/compare/v3.1.3...v3.1.4))

**Is there anything that requires more attention while reviewing?**
Supersedes [chore: bump fast-uri to 3.1.2](https://github.com/ajv-validator/ajv/pull/2612).

Full test suite passes locally.