### PR TITLE
fix: allow Object.prototype names as discriminator tags

### DIFF
--- a/lib/vocabularies/discriminator/index.ts
+++ b/lib/vocabularies/discriminator/index.ts
@@ -61,7 +61,8 @@ const def: CodeKeywordDefinition = {
     }
 
     function getMapping(): {[T in string]?: number} {
-      const oneOfMapping: {[T in string]?: number} = {}
+      // Prototype-free map so tag values like "toString" are not treated as duplicates
+      const oneOfMapping: {[T in string]?: number} = Object.create(null)
       const topRequired = hasRequired(parentSchema)
       let tagRequired = true
       for (let i = 0; i < oneOf.length; i++) {

--- a/spec/discriminator.spec.ts
+++ b/spec/discriminator.spec.ts
@@ -358,6 +358,21 @@ describe("discriminator keyword", function () {
       )
     })
 
+    it("should allow Object.prototype property names as tag values", () => {
+      const schema = {
+        type: "object",
+        discriminator: {propertyName: "kind"},
+        required: ["kind"],
+        oneOf: [
+          {properties: {kind: {const: "toString"}}, required: ["a"]},
+          {properties: {kind: {const: "constructor"}}, required: ["b"]},
+        ],
+      }
+      assertValid([schema], {kind: "toString", a: 1})
+      assertValid([schema], {kind: "constructor", b: 1})
+      assertInvalid([schema], {kind: "toString", b: 1})
+    })
+
     it("tag should be required", () => {
       invalidSchema(
         {


### PR DESCRIPTION
## Summary
- Fixes #2650: discriminator tag uniqueness used `in` on a plain object, so values like `toString` and `constructor` were treated as duplicates.
- Build the tag map with `Object.create(null)` and add a regression test.

## Test plan
- [x] `npx cross-env TS_NODE_PROJECT=spec/tsconfig.json mocha -r ts-node/register spec/discriminator.spec.ts`
- [x] Confirm schemas with `const: "toString"` / `const: "constructor"` compile and validate
- [x] Confirm genuine duplicate tag values still throw
