### PR TITLE
fix(discriminator): allow tag values that are Object.prototype member names (#2650)

### DIFF
--- a/lib/vocabularies/discriminator/index.ts
+++ b/lib/vocabularies/discriminator/index.ts
@@ -61,7 +61,11 @@ const def: CodeKeywordDefinition = {
     }
 
     function getMapping(): {[T in string]?: number} {
-      const oneOfMapping: {[T in string]?: number} = {}
+      // Use a prototype-less object so that tag values that happen to be
+      // Object.prototype member names (e.g. "toString", "constructor",
+      // "valueOf", "hasOwnProperty", "__proto__") are not mistaken for
+      // duplicates by the `in` check in addMapping below (see issue #2650).
+      const oneOfMapping: {[T in string]?: number} = Object.create(null)
       const topRequired = hasRequired(parentSchema)
       let tagRequired = true
       for (let i = 0; i < oneOf.length; i++) {

--- a/spec/discriminator.spec.ts
+++ b/spec/discriminator.spec.ts
@@ -373,6 +373,66 @@ describe("discriminator keyword", function () {
     })
   })
 
+  describe("tag values that are Object.prototype member names (#2650)", () => {
+    const schema = {
+      type: "object",
+      discriminator: {propertyName: "kind"},
+      required: ["kind"],
+      oneOf: [
+        {
+          properties: {kind: {const: "toString"}, a: {type: "number"}},
+          required: ["a"],
+        },
+        {
+          properties: {kind: {const: "foo"}, b: {type: "number"}},
+          required: ["b"],
+        },
+      ],
+    }
+
+    it("should compile a schema whose tag value is an inherited member name", () => {
+      ajvs.forEach((ajv) => assert.doesNotThrow(() => ajv.compile(schema)))
+    })
+
+    it("should validate data with such tag values", () => {
+      assertValid([schema], {kind: "toString", a: 1})
+      assertValid([schema], {kind: "foo", b: 1})
+      assertInvalid([schema], {kind: "toString", b: 1})
+      assertInvalid([schema], {kind: "foo", a: 1})
+      assertInvalid([schema], {kind: "bar"})
+    })
+
+    it("should accept every Object.prototype member name as a unique tag value", () => {
+      for (const name of ["toString", "constructor", "valueOf", "hasOwnProperty", "__proto__"]) {
+        const s = {
+          type: "object",
+          discriminator: {propertyName: "kind"},
+          required: ["kind"],
+          oneOf: [{properties: {kind: {const: name}}}, {properties: {kind: {const: "other"}}}],
+        }
+        ajvs.forEach((ajv) => assert.doesNotThrow(() => ajv.compile(s)))
+        assertValid([s], {kind: name})
+        assertValid([s], {kind: "other"})
+        assertInvalid([s], {kind: "missing"})
+      }
+    })
+
+    it("should still reject genuine duplicate tag values that are member names", () => {
+      invalidSchema(
+        {
+          type: "object",
+          discriminator: {propertyName: "kind"},
+          required: ["kind"],
+          oneOf: [
+            {properties: {kind: {const: "toString"}}},
+            {properties: {kind: {const: "toString"}}},
+          ],
+        },
+        /discriminator: "kind" values must be unique strings/
+      )
+    })
+  })
+
   function assertValid(schemas: SchemaObject[], data: unknown): void {
     schemas.forEach((schema) =>
       ajvs.forEach((ajv) => assert.strictEqual(ajv.validate(schema, data), true))


### PR DESCRIPTION
**What issue does this pull request resolve?**

Fixes #2650

`discriminator` throws `discriminator: "<tag>" values must be unique strings` at compile time for otherwise-valid schemas whose tag `const`/`enum` values happen to be `Object.prototype` member names — `toString`, `constructor`, `valueOf`, `hasOwnProperty`, `__proto__`, etc. Reproduction (with `{discriminator: true}`):

```json
{
  "type": "object",
  "discriminator": {"propertyName": "kind"},
  "required": ["kind"],
  "oneOf": [
    {"properties": {"kind": {"const": "toString"}}, "required": ["a"]},
    {"properties": {"kind": {"const": "foo"}}, "required": ["b"]}
  ]
}
```

This schema never compiles even though `"toString"` and `"foo"` are distinct.

**Root cause**

In `lib/vocabularies/discriminator/index.ts`, `getMapping()` accumulates the tag-value → branch-index map in a plain object literal (`const oneOfMapping = {}`) and the uniqueness guard in `addMapping` tests membership with the `in` operator:

```js
if (typeof tagValue != "string" || tagValue in oneOfMapping) {
  throw new Error(`discriminator: "${tagName}" values must be unique strings`)
}
```

`in` walks the prototype chain, so for an empty literal map `"toString" in {}`, `"constructor" in {}`, `"valueOf" in {}`, `"hasOwnProperty" in {}` and `"__proto__" in {}` are all `true`. The first branch whose tag value is such an inherited member name is therefore misreported as a duplicate.

**What changes did you make?**

Build the map with `Object.create(null)` so it has no prototype:

```diff
- const oneOfMapping: {[T in string]?: number} = {}
+ const oneOfMapping: {[T in string]?: number} = Object.create(null)
```

Now `in` reflects only values that were actually inserted. This is the minimal, backward-compatible fix; it also keeps the `for (const tagValue in mapping)` dispatch loop correct (a null-prototype object has no inherited enumerable keys, so it still iterates only the inserted tag values), and it makes `oneOfMapping["__proto__"] = i` store a normal own property instead of being swallowed by the `__proto__` setter.

Added regression tests in `spec/discriminator.spec.ts` (a new `describe` block, run across all existing Ajv instances including the standalone/2019 variants):

- a discriminated union with tag `const` values `"toString"` and `"foo"` now **compiles** and validates data correctly;
- every `Object.prototype` member name (`toString`, `constructor`, `valueOf`, `hasOwnProperty`, `__proto__`) is accepted as a unique tag value;
- **genuine** duplicates (two branches both using `const: "toString"`) are **still rejected** — the uniqueness guard is not weakened.

**Is there anything that requires more attention while reviewing?**

No behavioral change beyond the bug fix. `npm run build` (tsc) passes, `eslint` and `prettier:check` are clean on the changed files, and `spec/discriminator.spec.ts` passes (15 passing, including the pre-existing duplicate-detection test and the 4 new cases).