### PR TITLE
fix: decode JSON escapes before JTD enum membership check

### DIFF
--- a/lib/compile/jtd/parse.ts
+++ b/lib/compile/jtd/parse.ts
@@ -301,19 +301,12 @@ function parseString(cxt: ParseCxt): void {
 
 function parseEnum(cxt: ParseCxt): void {
   const {gen, data, schema} = cxt
-  const enumSch = schema.enum
-  parseToken(cxt, '"')
-  // TODO loopEnum
-  gen.if(false)
-  for (const value of enumSch) {
-    const valueStr = JSON.stringify(value).slice(1) // remove starting quote
-    gen.elseIf(_`${jsonSlice(valueStr.length)} === ${valueStr}`)
-    gen.assign(data, str`${value}`)
-    gen.add(N.jsonPos, valueStr.length)
-  }
-  gen.else()
-  jsonSyntaxError(cxt)
-  gen.endIf()
+  const enumSch = schema.enum as string[]
+  // Decode escapes first (same as parseString), then check membership on the value
+  parseString(cxt)
+  gen.if(not(or(...enumSch.map((value: string) => _`${data} === ${value}`))), () =>
+    parsingError(cxt, str`unexpected enum value`)
+  )
 }
 
 function parseNumber(cxt: ParseCxt, maxDigits?: number): void {

--- a/spec/jtd-schema.spec.ts
+++ b/spec/jtd-schema.spec.ts
@@ -218,6 +218,32 @@ describe("JSON Type Definition", () => {
         }
       })
     }
+
+    describe("enum with alternate JSON string encodings", () => {
+      it("should accept unicode escapes for enum values", () => {
+        const parse = ajv.compileParser({enum: ["Active"]})
+        shouldParse(parse, '"\\u0041ctive"', "Active")
+      })
+
+      it("should accept escaped solidus in enum values", () => {
+        const parse = ajv.compileParser({enum: ["A/B"]})
+        shouldParse(parse, '"A\\/B"', "A/B")
+      })
+
+      it("should round-trip serializer output for enum values", () => {
+        const schema = {enum: ["Active", "x\u200dy"]}
+        const parse = ajv.compileParser(schema)
+        const serialize = ajv.compileSerializer(schema)
+        for (const value of schema.enum) {
+          shouldParse(parse, serialize(value), value)
+        }
+      })
+
+      it("should reject values not in the enum", () => {
+        const parse = ajv.compileParser({enum: ["Active"]})
+        shouldFail(parse, '"Inactive"')
+      })
+    })
   })
 
   describe("parse tests nst/JSONTestSuite", () => {


### PR DESCRIPTION
## Summary
- Fixes #2651: JTD `compileParser` for `enum` compared raw JSON bytes to `JSON.stringify` form, so `\uXXXX` and `\/` encodings of allowed values were rejected.
- Route enum parsing through `parseString` (same escape decoding as other string paths), then check membership on the decoded value.
- Add regression tests for unicode escapes, escaped solidus, serializer round-trip, and invalid enum values.

## Test plan
- [x] `npx cross-env TS_NODE_PROJECT=spec/tsconfig.json mocha -r ts-node/register spec/jtd-schema.spec.ts` (1286 passing)
