### PR TITLE
ci: publish with npm provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for npm provenance
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -18,12 +21,12 @@ jobs:
       - run: npm run test-ci
       - name: Publish beta version to npm
         if: ${{ github.event.release.prerelease }}
-        run: npm publish --tag beta
+        run: npm publish --provenance --tag beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish to npm
         if: ${{ !github.event.release.prerelease }}
-        run: npm publish
+        run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Commit bundles to ajv-dist


### PR DESCRIPTION
Hi, and thanks for Ajv.

Ajv publishes from GitHub Actions already, so npm provenance is available for the cost of a flag — but the published tarballs currently carry none. On the npm page there is no "Provenance" panel, and the registry metadata has no `attestations` block:

```
$ curl -s https://registry.npmjs.org/ajv | jq '.versions[."dist-tags".latest].dist.attestations'
null
```

With ~350M downloads a week, Ajv is a dependency almost nobody installs deliberately — it arrives transitively, underneath schema validation in tooling people already trust. Provenance is what lets a consumer check that the tarball on the registry was built by this workflow, from this repo, at this commit, rather than uploaded by someone holding an npm token.

This PR is three lines:

```yaml
  publish-npm:
    runs-on: ubuntu-latest
    permissions:
      contents: read
      id-token: write # required for npm provenance
    ...
        run: npm publish --provenance --tag beta
    ...
        run: npm publish --provenance
```

`id-token: write` lets the runner get the OIDC token npm exchanges for a Sigstore signature; `--provenance` tells npm to publish it. Nothing else changes — same registry, same `NODE_AUTH_TOKEN`, same two conditional publish paths. After the next release the npm page gets a "Built and signed on GitHub Actions" panel linking back to the run.

Two things I could not verify from outside and would rather flag than assume:

1. **The `permissions:` block is new.** The job had none, so it was inheriting the repository default. I set `contents: read` alongside `id-token: write` because that is what the steps here appear to need — checkout, and a `publish-bundles` script that uses its own `GH_TOKEN_PUSH_DIST` rather than the workflow token. If that script does rely on the default `GITHUB_TOKEN` having write access, this block would need `contents: write` instead. Worth a glance before merging.
2. `--provenance` needs npm 9.5 or later. `node-version: 18` currently resolves to 18.20.x, which ships npm 10, so this should be fine as-is — but it is the one thing that would make the publish step fail if the pin ever moved backwards.

Happy to adjust either, or to split the permissions change out if you'd rather take it separately.

Disclosure: I used AI assistance to help spot this and prepare the change, and I checked the registry metadata and the workflow myself.
