### PR TITLE
fix: apply strictNumbers when coercing strings to numbers

### DIFF
--- a/lib/compile/validate/dataType.ts
+++ b/lib/compile/validate/dataType.ts
@@ -87,6 +87,14 @@ function coerceData(it: SchemaObjCxt, types: JSONType[], coerceTo: JSONType[]): 
     assignParentData(it, coerced)
   })
 
+  // `strictNumbers` is applied by `checkDataType` when a value is already a number, but string
+  // coercion assigned its result without repeating the check. "Infinity" satisfies
+  // `data == +data`, and `!(data % 1)` is also true for it because `Infinity % 1` is NaN, so a
+  // non-finite value could be coerced in and then pass validation as a number or an integer.
+  function finiteCoercion(): Code {
+    return opts.strictNumbers ? _` && isFinite(+${data})` : nil
+  }
+
   function coerceSpecificType(t: string): void {
     switch (t) {
       case "string":
@@ -100,7 +108,7 @@ function coerceData(it: SchemaObjCxt, types: JSONType[], coerceTo: JSONType[]): 
         gen
           .elseIf(
             _`${dataType} == "boolean" || ${data} === null
-              || (${dataType} == "string" && ${data} && ${data} == +${data})`
+              || (${dataType} == "string" && ${data} && ${data} == +${data}${finiteCoercion()})`
           )
           .assign(coerced, _`+${data}`)
         return
@@ -108,7 +116,7 @@ function coerceData(it: SchemaObjCxt, types: JSONType[], coerceTo: JSONType[]): 
         gen
           .elseIf(
             _`${dataType} === "boolean" || ${data} === null
-              || (${dataType} === "string" && ${data} && ${data} == +${data} && !(${data} % 1))`
+              || (${dataType} === "string" && ${data} && ${data} == +${data} && !(${data} % 1)${finiteCoercion()})`
           )
           .assign(coerced, _`+${data}`)
         return

--- a/spec/coercion.spec.ts
+++ b/spec/coercion.spec.ts
@@ -468,6 +468,45 @@ describe("Type coercion", () => {
     })
   })
 
+  describe("non-finite numbers", () => {
+    const nonFinite = ["Infinity", "-Infinity", "1e999", "-1e999"]
+
+    it("should not coerce strings to Infinity by default", () => {
+      const ajvInstance = new _Ajv({coerceTypes: true})
+      for (const type of ["number", "integer"]) {
+        const validate = ajvInstance.compile({type})
+        for (const from of nonFinite) {
+          validate(from).should.equal(false, `${JSON.stringify(from)} coerced to ${type}`)
+          validate.errors?.[0].keyword.should.equal("type")
+        }
+      }
+    })
+
+    it("should still coerce finite strings", () => {
+      const ajvInstance = new _Ajv({coerceTypes: true})
+      const data = {n: "1e300", i: "42"}
+      const validate = ajvInstance.compile({
+        type: "object",
+        properties: {n: {type: "number"}, i: {type: "integer"}},
+      })
+      validate(data).should.equal(true)
+      data.n.should.equal(1e300)
+      data.i.should.equal(42)
+    })
+
+    it("should coerce strings to Infinity with strictNumbers: false", () => {
+      const ajvInstance = new _Ajv({coerceTypes: true, strictNumbers: false})
+      for (const type of ["number", "integer"]) {
+        const validate = ajvInstance.compile({type: "object", properties: {v: {type}}})
+        for (const from of nonFinite) {
+          const data = {v: from}
+          validate(data).should.equal(true)
+          Number.isFinite(data.v).should.equal(false)
+        }
+      }
+    })
+  })
+
   function testRules(rules, cb) {
     for (const toType in rules) {
       for (const fromType in rules[toType]) {


### PR DESCRIPTION
## What

With `coerceTypes` enabled, the string `"Infinity"` validates as both `number` and `integer` under the default `strictNumbers: true`.

`coerceData` assigns the result of `+data` without repeating the finiteness check that `checkDataType` applies, so `strictNumbers` is only enforced on the branch for values that are already numbers.

For `integer` the value also slips past the fractional-part test, because `Infinity % 1` is `NaN` and `!(NaN)` is `true`.

`"NaN"` was rejected only incidentally — `data == +data` is false for it — which is why the two behave differently today.

The same applies to any string that overflows, so `1e999` is accepted as an integer and reaches the caller as a non-finite number. That's the realistic trigger: it's an ordinary-looking number to a client.

## How

Gate the string coercion on `isFinite` when `strictNumbers` is set, matching `checkDataType`. With `strictNumbers: false`, previous behaviour is unchanged.

## Tests

Three cases in `spec/coercion.spec.ts`: non-finite strings rejected by default for both `number` and `integer`, finite strings (including `1e300`) still coercing, and `strictNumbers: false` still coercing to Infinity. Full suite: 7615 passing, 0 failing.

## Context

This was traced from fastify/fastify#6718, where `?num=Infinity` and `?num=1e999` pass `type: integer` validation and reach the handler as non-finite numbers. The Fastify maintainers closed that issue as belonging here.
