### PR TITLE
chore: upgrade fast-uri from v3 to v4

### DIFF
--- a/lib/compile/index.ts
+++ b/lib/compile/index.ts
@@ -14,7 +14,7 @@ import N from "./names"
 import {LocalRefs, getFullPath, _getFullPath, inlineRef, normalizeId, resolveUrl} from "./resolve"
 import {schemaHasRulesButRef, unescapeFragment} from "./util"
 import {validateFunctionCode} from "./validate"
-import {URIComponent} from "fast-uri"
+import type {URIComponent} from "fast-uri"
 import {JSONType} from "./rules"
 
 export type SchemaRefs = {

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,4 +1,4 @@
-import {URIComponent} from "fast-uri"
+import type {URIComponent} from "fast-uri"
 import type {CodeGen, Code, Name, ScopeValueSets, ValueScopeName} from "../compile/codegen"
 import type {SchemaEnv, SchemaCxt, SchemaObjCxt} from "../compile"
 import type {JSONType} from "../compile/rules"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "runkitExampleFilename": ".runkit_example.js",
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
-    "fast-uri": "^3.0.1",
+    "fast-uri": "^4.1.4",
     "json-schema-traverse": "^1.0.0",
     "require-from-string": "^2.0.2"
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Ajv.

Before continuing, please read the guidelines:
https://github.com/ajv-validator/ajv/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

- Fixes: #2601 
- Fixes: #2602 
- Fixes: #2612 
- Fixes: #2654 
- Fixes: #2658 
- Fixes: #2660 

**What changes did you make?**

- Bumped the `fast-uri` dependency from `^3.0.1` to ~`^4.1.3`~ `^4.1.4`.
- Changed the `URIComponent` import to `import type` in `lib/compile/index.ts` and `lib/types/index.ts`, since it's used only as a type, matching the existing pattern already used in `lib/compile/resolve.ts`.

**Is there anything that requires more attention while reviewing?**

fast-uri v4 removed the previously deprecated `options`/`URIComponents` type aliases, but ajv doesn't use them, so there's no impact. The public API (`parse`/`serialize`/`normalize`/`resolve`/`equal`) is unchanged.
